### PR TITLE
reboot: added configuration for the lock holders

### DIFF
--- a/pillar/params.sls
+++ b/pillar/params.sls
@@ -43,3 +43,13 @@ flannel:
   backend:        'host-gw'
   etcd_key:       '/flannel/network'
   iface:          'eth0'
+
+# Configuration for the reboot manager (https://github.com/SUSE/rebootmgr).
+# notes:
+# - The default group for rebootmgr is "default", so we are simply taking
+#   rebootmgr's default here.
+# - `directory` contains the base directory of the configuration. In order to
+#   use it we have to append the name of the group as another directory.
+reboot:
+  group:          'default'
+  directory:      'opensuse.org/rebootmgr/locks'

--- a/salt/etcd-discovery/init.sls
+++ b/salt/etcd-discovery/init.sls
@@ -24,5 +24,3 @@ set_size:
       - cmd: cleanup
 
 {% endif %}
-
-

--- a/salt/orch/kubernetes.sls
+++ b/salt/orch/kubernetes.sls
@@ -71,3 +71,12 @@ kube_nfs_setup:
     - tgt: 'roles:nfs'
     - tgt_type: grain
     - highstate: True
+
+reboot_setup:
+  salt.state:
+    - tgt: 'roles:kube-master'
+    - tgt_type: grain
+    - highstate: True
+    - concurrent: True
+    - require:
+      - salt: etcd_proxy_setup

--- a/salt/reboot/init.sls
+++ b/salt/reboot/init.sls
@@ -1,0 +1,46 @@
+##################################################
+# Configuration for the reboot manager
+##################################################
+
+# `max_holders` contains the maximum number of lock holders for the cluster. It
+# must comply with the optimal cluster size as defined here:
+#   https://coreos.com/etcd/docs/latest/v2/admin_guide.html
+{% set max_holders = pillar['etcd']['masters']|int %}
+{% if max_holders > 1 %}
+  # Note that for odd numbers, in python (2 or 3): 7 // 2 = 3. So we comply with
+  # the optimal size.
+  {% set max_holders = max_holders // 2 %}
+{% endif %}
+
+# Cleanup any previous cluster information on /opensuse.org
+opensuseorg_cleanup:
+  pkg.installed:
+    - name: etcdctl
+  cmd.run:
+    - name: etcdctl
+            rm -r /opensuse.org
+    # ignore failures for this
+    - check_cmd:
+      - /bin/true
+
+# Initialize the `mutex` key as expected by the reboot manager.
+set_max_holders_mutex:
+  pkg.installed:
+    - name: curl
+  cmd.run:
+    - name: curl -L -X PUT
+            http://127.0.0.1:2379/v2/keys/{{ pillar['reboot']['directory'] }}/{{ pillar['reboot']['group'] }}/mutex?prevExist=false
+            -d value="0"
+    - require:
+      - cmd: opensuseorg_cleanup
+
+# Initialize the `data` key, which is JSON data with: the maximum number of
+# holders, and a list of current holders.
+set_max_holders_data:
+  pkg.installed:
+    - name: curl
+  cmd.run:
+    - name: >-
+        curl -L -X PUT http://127.0.0.1:2379/v2/keys/{{ pillar['reboot']['directory'] }}/{{ pillar['reboot']['group'] }}/data?prevExist=false -d value='{ "max":"{{ max_holders }}", "holders":[] }'
+    - require:
+      - cmd: set_max_holders_mutex

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -23,6 +23,7 @@ base:
   'roles:kube-master':
     - match: grain
     - kubernetes-master
+    - reboot
   'roles:kube-minion':
     - match: grain
     - flannel


### PR DESCRIPTION
This is needed by rebootmgr in order to check the maximum amount on lock
holders.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>