### PR TITLE
Include missing dependencies for state files

### DIFF
--- a/salt/docker/init.sls
+++ b/salt/docker/init.sls
@@ -1,3 +1,6 @@
+include:
+  - repositories
+  - flannel
 
 docker:
   pkg.installed:

--- a/salt/etcd/init.sls
+++ b/salt/etcd/init.sls
@@ -1,4 +1,5 @@
 include:
+  - repositories
   - cert
 
 etcd:

--- a/salt/flannel/init.sls
+++ b/salt/flannel/init.sls
@@ -1,3 +1,6 @@
+include:
+  - repositories
+
 flannel:
   pkg.latest:
     - pkgs:

--- a/salt/kubernetes-master/init.sls
+++ b/salt/kubernetes-master/init.sls
@@ -1,4 +1,5 @@
 include:
+  - repositories
   - cert
 
 {% from 'cert/init.sls' import ip_addresses %}

--- a/salt/kubernetes-minion/init.sls
+++ b/salt/kubernetes-minion/init.sls
@@ -1,6 +1,8 @@
 #######################
 # k8s components
 #######################
+include:
+  - repositories
 
 conntrack-tools:
   pkg.installed


### PR DESCRIPTION
We have to include missing dependencies for state files
for docker
```
include:
  - repositories
  - flannel
```
for etcd, flannel, kube-master and kube-minion
```
 include:
  - repositories
```