### PR TITLE
fix etcd proxy instance failure on restart

### DIFF
--- a/salt/etcd-proxy/etcd.conf
+++ b/salt/etcd-proxy/etcd.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecStartPre=/bin/bash -c "if [[ -d /var/lib/etcd/proxy ]] && [[ -d /var/lib/etcd/member ]]; then rm -rf /var/lib/etcd/member; fi"

--- a/salt/etcd-proxy/init.sls
+++ b/salt/etcd-proxy/init.sls
@@ -1,6 +1,11 @@
 include:
   - etcd
 
+/etc/systemd/system/etcd.service.d/etcd.conf:
+  file.managed:
+    - source: salt://etcd-proxy/etcd.conf
+    - makedirs: True
+
 extend:
   /etc/sysconfig/etcd:
     file.managed:


### PR DESCRIPTION
~~* adds a custom systemd unit file for etcd with a one line if statement that~~
~~checks to see if both member and proxy folders exist in /var/lib/etcd/ and~~
~~removes the member folder so that etcd members in proxy mode can start on next~~
~~reboot.~~
* adds a drop-in systemd unit file for etcd that adds an `ExecStartPre` clause removing the `member` directory if both `proxy` and `member` directories exist so that it can allow etcd to restart.
This does not affect etcd full members. It's also not possible to automatically
promote a proxy to member https://github.com/coreos/etcd/issues/2869#issuecomment-105607322
so this fix doesn't break any functionality.

~~* removes the extra parameters sent to etcd from the default systemd unit file,~~
~~since etcd picks up all the settings from the salt provisioned~~
~~/etc/sysconfig/etcd file.~~
* overriding `ExecStart` would only be possible by updating `Type=OneShot`. So extra parameters will stay for now.  

This should be considered a temporary fix.

@inercia @ereslibre 