### PR TITLE
fix infra container image (=pause image) for opensuse

### DIFF
--- a/pillar/kube-minion.sls
+++ b/pillar/kube-minion.sls
@@ -1,4 +1,6 @@
 mine_functions:
   network.ip_addrs: [eth0]
+{% if grains['lsb_distrib_id'] == "CAASP" -%}
 # infra container to use instead of downloading gcr.io/google_containers/pause
 pod_infra_container_image: sles12/pause:1.0.0
+{% endif -%}

--- a/salt/kubernetes-minion/kubelet.jinja
+++ b/salt/kubernetes-minion/kubelet.jinja
@@ -26,7 +26,9 @@ KUBELET_ARGS="\
 {% endif -%}
     --node-ip={{ grains['ip4_interfaces']['eth0'][0] }} \
     --config=/etc/kubernetes/manifests \
+{% if salt['pillar.get']('pod_infra_container_image') -%}
     --pod-infra-container-image={{ pillar['pod_infra_container_image'] }} \
+{% endif -%}
 {% if salt['pillar.get']('infrastructure', 'libvirt') == 'aws' -%}
     --cloud-provider=aws \
 {% endif -%}


### PR DESCRIPTION
sles12/pause image only exists in caasp context.

This commit fixes it so that it works on opensuse