### PR TITLE
Do not set certificate `CN` if domain was not specified by a grain

### DIFF
--- a/salt/ca/init.sls
+++ b/salt/ca/init.sls
@@ -54,7 +54,9 @@ salt-minion:
 /etc/pki/ca.crt:
   x509.certificate_managed:
     - signing_private_key: /etc/pki/ca.key
+{% if salt['grains.get']('domain', None) is not none %}
     - CN: {{ grains['domain'] }}
+{% endif %}
     - C: {{ pillar['certificate_information']['subject_properties']['C'] }}
     - Email: {{ pillar['certificate_information']['subject_properties']['Email'] }}
     - GN: {{ pillar['certificate_information']['subject_properties']['GN'] }}


### PR DESCRIPTION
With the YaST installation it's really straightforward to install the dashboard without a domain name. This makes the CA not to fail when there is not a domain name specified, we will just create the CA certificate anyway.