### PR TITLE
Always set `CN`

### DIFF
--- a/salt/ca/init.sls
+++ b/salt/ca/init.sls
@@ -54,7 +54,9 @@ salt-minion:
 /etc/pki/ca.crt:
   x509.certificate_managed:
     - signing_private_key: /etc/pki/ca.key
-{% if salt['grains.get']('domain', None) is not none %}
+{% if salt['grains.get']('domain', None) is none %}
+    - CN: {{ pillar['dns']['domain'] }}
+{% else %}
     - CN: {{ grains['domain'] }}
 {% endif %}
     - C: {{ pillar['certificate_information']['subject_properties']['C'] }}


### PR DESCRIPTION
Even if no grains are set (because the domain could not be inferred), set the default dns domain from the pillar.

This ensures we also have a value for the `Common Name` value on the
certificate that will be generated for the Certificate Authority.