### PR TITLE
Bug 1032379 - Must install flanneld on the kubernetes master node

### DIFF
--- a/pillar/params.sls
+++ b/pillar/params.sls
@@ -43,7 +43,7 @@ etcd:
 
 # the flannel backend ('udp', 'vxlan', 'host-gw', etc)
 flannel:
-  backend:        'host-gw'
+  backend:        'udp'
   etcd_key:       '/flannel/network'
   iface:          'eth0'
 

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -23,6 +23,8 @@ base:
   'roles:kube-master':
     - match: grain
     - kubernetes-master
+    - flannel
+    - docker
     - reboot
   'roles:kube-minion':
     - match: grain


### PR DESCRIPTION
For `kubectl proxy` to properly proxy to the Kubernetes dashboard, you
must run flanneld and docker on the master node. This will set up the
appropriate host routes.

Additionally, nodes cannot communicate with each other in host-gw mode
in flannel without modifying iptables rules to allow the traffic.
host-gw doesn't scale very well, due to needing to add a route to every
node for every node in the cluster. The iptables rules already allow the
flannel udp encapsulation port through (udp port 8285).