### PR TITLE
Allow the kubelet to run on Kubernetes 1.6

### DIFF
--- a/salt/kubernetes-minion/kubelet.jinja
+++ b/salt/kubernetes-minion/kubelet.jinja
@@ -25,8 +25,8 @@ KUBELET_ARGS="\
     --cluster-domain={{ pillar['dns']['domain'] }} \
 {% endif -%}
     --node-ip={{ grains['ip4_interfaces']['eth0'][0] }} \
-    --config=/etc/kubernetes/manifests \
 {% if grains['lsb_distrib_id'] == "CAASP" -%}
+    --pod-manifest-path=/etc/kubernetes/manifests \
     --pod-infra-container-image={{ pillar['pod_infra_container_image'] }} \
 {% endif -%}
 {% if salt['pillar.get']('infrastructure', 'libvirt') == 'aws' -%}


### PR DESCRIPTION
Removes no longer valid --config flag, matches
kubic-project/terraform#32