### PR TITLE
React to IP addresses changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .idea/
 Makefile
 *.tgz
+
+# you can set a debug log level with "log_level: debug" in this file
+config/master.d/debug.conf

--- a/config/master.d/reactor.conf
+++ b/config/master.d/reactor.conf
@@ -1,3 +1,8 @@
 reactor:
   - 'salt/presence/change':
     - /usr/share/salt/kubernetes/reactor/presence.sls
+    - /usr/share/salt/kubernetes/reactor/etc-hosts.sls
+  - 'salt/beacon/*/network_settings/eth*':
+    - /usr/share/salt/kubernetes/reactor/etc-hosts.sls
+  - 'salt/minion/*/start':
+    - /usr/share/salt/kubernetes/reactor/etc-hosts.sls

--- a/pillar/beacons.sls
+++ b/pillar/beacons.sls
@@ -1,0 +1,7 @@
+beacons:
+  network_settings:
+    interval: 5
+    # monitorize any change in IP addresses in eth0
+    eth0:
+      ipaddr:
+

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -6,7 +6,12 @@ base:
     - certificates
     - ip_addrs
     - fqdn
-  'G@roles:kube-master':
+  'roles:kube-(master|minion)':
+    - match: grain_pcre
+    - beacons
+  'roles:kube-master':
+    - match: grain
     - kube-master
-  'G@roles:kube-minion':
+  'roles:kube-minion':
+    - match: grain
     - kube-minion

--- a/reactor/README.md
+++ b/reactor/README.md
@@ -1,0 +1,16 @@
+# Description
+
+Code executed by the [Salt reactor system](https://docs.saltstack.com/en/latest/topics/reactor/).
+Read the official documentation for more details on how it works.
+
+See the [reactor configuration](../config/master.d/reactor.conf) for the list
+of events that trigger actions here.
+
+## Debugging
+
+You can listen for events in the Salt master with:
+
+```
+salt-run state.event pretty=true
+```
+

--- a/reactor/etc-hosts.sls
+++ b/reactor/etc-hosts.sls
@@ -1,0 +1,7 @@
+# actions to run when a host changes/gets/losses connectivity
+
+# update all the /etc/hosts in the cluster
+update_etc_hosts:
+  runner.state.orchestrate:
+    - mods: orch.update-etc-hosts
+

--- a/reactor/presence.sls
+++ b/reactor/presence.sls
@@ -1,6 +1,8 @@
+# actions to run when a minion disappears or appears in the master
+
 # remove unused keys for minions that are not present anymore
-{% for minion_id in data['lost'] %}
-remove_unused_keys_for_{{ minion_id }}:
-   wheel.key.delete:
-     - match: {{ minion_id }}
-{% endfor %}
+# TODO: we should evaluate what to do here:
+# - we don't want to remove the key for minions that are suffering
+#   some transient connectivity error
+# - but we should remove keys for old minions that will not
+#   connect anymore

--- a/salt/etcd-proxy/etcd-proxy.conf.jinja
+++ b/salt/etcd-proxy/etcd-proxy.conf.jinja
@@ -6,8 +6,7 @@ ETCD_NAME="{{ grains['id'] }}"
 
 ETCD_LISTEN_CLIENT_URLS="http://0.0.0.0:2379"
 ETCD_LISTEN_PEER_URLS="https://0.0.0.0:2380"
-
-ETCD_ADVERTISE_CLIENT_URLS="http://{{ grains['caasp_fqdn'] }}:2379,http://{{ grains['ip4_interfaces']['eth0'][0] }}:2379"
+ETCD_ADVERTISE_CLIENT_URLS="http://{{ grains['caasp_fqdn'] }}:2379"
 
 ETCD_CA_FILE={{ pillar['paths']['ca_dir'] }}/{{ pillar['paths']['ca_filename'] }}
 ETCD_CERT_FILE=/etc/pki/minion.crt

--- a/salt/etcd/etcd.conf.jinja
+++ b/salt/etcd/etcd.conf.jinja
@@ -8,8 +8,7 @@ ETCD_NAME="{{ grains['id'] }}"
 
 ETCD_LISTEN_CLIENT_URLS="https://0.0.0.0:2379"
 ETCD_LISTEN_PEER_URLS="https://0.0.0.0:2380"
-
-ETCD_ADVERTISE_CLIENT_URLS="https://{{ grains['caasp_fqdn'] }}:2379,https://{{ grains['ip4_interfaces']['eth0'][0] }}:2379"
+ETCD_ADVERTISE_CLIENT_URLS="https://{{ grains['caasp_fqdn'] }}:2379"
 
 ETCD_CA_FILE={{ pillar['paths']['ca_dir'] }}/{{ pillar['paths']['ca_filename'] }}
 ETCD_CERT_FILE=/etc/pki/minion.crt

--- a/salt/orch/kubernetes.sls
+++ b/salt/orch/kubernetes.sls
@@ -29,7 +29,7 @@ update_mine:
 update_modules:
   salt.function:
     - tgt: '*'
-    - name: saltutil.sync_modules
+    - name: saltutil.sync_all
     - kwarg:
         refresh: True
 

--- a/salt/orch/update-etc-hosts.sls
+++ b/salt/orch/update-etc-hosts.sls
@@ -1,0 +1,33 @@
+update_grains:
+  salt.function:
+    - tgt: 'roles:kube-(master|minion)'
+    - tgt_type: grain_pcre
+    - name: saltutil.sync_all
+
+update_mine:
+  salt.function:
+    - tgt: 'roles:kube-(master|minion)'
+    - tgt_type: grain_pcre
+    - name: mine.update
+    - require:
+      - salt: update_grains
+
+etc_hosts_setup:
+  salt.state:
+    - tgt: 'roles:kube-(master|minion)'
+    - tgt_type: grain_pcre
+    - queue: True
+    - sls:
+      - etc-hosts
+    - require:
+      - salt: update_mine
+
+kube_master_setup:
+  salt.state:
+    - tgt: 'roles:kube-master'
+    - tgt_type: grain
+    - queue: True
+    - sls:
+      - kubernetes-master
+    - require:
+      - salt: etc_hosts_setup


### PR DESCRIPTION
React to changes in IP addresses in minions by running an orchestration in the cluster for updating `/etc/hosts`.

It seems the Salt minion loses connectivity to the master when the IP address changes (as reported in saltstack/salt#41578), so the effect of this PR seems to be limited to the _change-IP-after-a-reboot_ case...

### TODO:

- [x] testing

### How to test it

* start the cluster with TF  and run the orchestration
* identify the `dnsmasq` instance that is serving the network with "ps ax | grep dnsmasq" (for example, if your TF file uses the `caasp` prefix then you will see the `caaspnet` somewhere)
    ```
    $ ps ax | grep dnsmasq
    30038 ?        S      0:00 /usr/sbin/dnsmasq --conf-file=/var/lib/libvirt/dnsmasq/caaspnet.conf --leasefile-ro --dhcp-script=/usr/lib64/libvirt/libvirt_leaseshelper
    30039 ?        S      0:00 /usr/sbin/dnsmasq --conf-file=/var/lib/libvirt/dnsmasq/caaspnet.conf --leasefile-ro --dhcp-script=/usr/lib64/libvirt/libvirt_leaseshelper
    ```
* check the config file used by that `dnsmasq` and look for the DHCP file
    ```
    $ sudo cat /var/lib/libvirt/dnsmasq/caaspnet.conf
    ...
    dhcp-hostsfile=/var/lib/libvirt/dnsmasq/caaspnet.hostsfile
    ```
* edit that file (`/var/lib/libvirt/dnsmasq/caaspnet.hostsfile`) and change one of the minion's IP
* `kill -HUP <dnsmasq>`
* reboot that minion
* check that **all** the `/etc/hosts` in the cluster are being updated with the new IP