### PR TITLE
Use a constant name for the API server

### DIFF
--- a/salt/kubernetes-master/init.sls
+++ b/salt/kubernetes-master/init.sls
@@ -16,7 +16,9 @@ include:
 {% endfor %}
 
 # add some extra names the API server could have
-{% set extra_names = ["DNS: " + grains['fqdn']] %}
+{% set extra_names = ["DNS: " + grains['fqdn'],
+                      "DNS: api",
+                      "DNS: api." + pillar['internal_infra_domain']] %}
 {% for extra_name in pillar['api']['server']['extra_names'] %}
   {% do extra_names.append("DNS: " + extra_name) %}
 {% endfor %}

--- a/salt/kubernetes-minion/kubeconfig.jinja
+++ b/salt/kubernetes-minion/kubeconfig.jinja
@@ -1,13 +1,12 @@
-{% set kube_servers = [] -%}
-{% for fqdn in salt['mine.get']('roles:kube-master', 'fqdn', expr_form='grain').values() -%}
-  {% do kube_servers.append(fqdn) -%}
-{% endfor -%}
+{% set api_server = "api." + pillar['internal_infra_domain']  -%}
+{% set api_ssl_port = salt['pillar.get']('api:ssl_port', '6443') -%}
+{% set api_server_url = 'https://' + api_server + ':' + api_ssl_port) -%}
 
 apiVersion: v1
 clusters:
 - cluster:
     certificate-authority: {{ pillar['paths']['ca_dir'] }}/{{ pillar['paths']['ca_filename'] }}
-    server: https://{{ kube_servers[0] }}:{{ pillar['api']['ssl_port'] }}
+    server: {{ api_server_url }}
   name: default-cluster
 contexts:
 - context:

--- a/salt/kubernetes-minion/kubelet.jinja
+++ b/salt/kubernetes-minion/kubelet.jinja
@@ -1,8 +1,7 @@
-{% set kube_servers = [] -%}
+{% set api_server = "api." + pillar['internal_infra_domain']  -%}
 {% set api_ssl_port = salt['pillar.get']('api:ssl_port', '6443') -%}
-{% for fqdn in salt['mine.get']('roles:kube-master', 'fqdn', expr_form='grain').values() -%}
-  {% do kube_servers.append('https://' + fqdn + ':' + api_ssl_port) -%}
-{% endfor -%}
+{% set api_server_url = 'https://' + api_server + ':' + api_ssl_port) -%}
+
 ###
 # kubernetes kubelet (minion) config
 
@@ -16,7 +15,7 @@ KUBELET_PORT="--port=10250"
 KUBELET_HOSTNAME="--hostname-override={{ grains['id'] }}.{{ pillar['internal_infra_domain'] }}"
 
 # location of the api-server
-KUBELET_API_SERVER="--api-servers={{ ','.join(kube_servers) }}"
+KUBELET_API_SERVER="--api-servers={{ api_server_url }}"
 
 # Add your own!
 KUBELET_ARGS="\


### PR DESCRIPTION
This should fix [this trello issue](https://trello.com/c/yCbzToby).

### Dependencies

Depends on #44 (rebased on top of it, where we define the local infrastructure domain).

