### PR TITLE
Configure kube-{scheduler/controller-manager} leader elections

### DIFF
--- a/salt/kubernetes-master/apiserver.jinja
+++ b/salt/kubernetes-master/apiserver.jinja
@@ -22,6 +22,7 @@ KUBE_ADMISSION_CONTROL="--admission-control=NamespaceLifecycle,LimitRanger,Servi
 
 # Add your own!
 KUBE_API_ARGS="--advertise-address={{ grains['ip4_interfaces']['eth0'][0] }} \
+               --apiserver-count={{ salt['mine.get']('roles:kube-master', 'fqdn', expr_form='grain').values()|length }} \
 {% if salt['pillar.get']('infrastructure', 'libvirt') == 'aws' -%}
                --cloud-provider=aws \
 {% endif -%}

--- a/salt/kubernetes-master/scheduler.jinja
+++ b/salt/kubernetes-master/scheduler.jinja
@@ -4,4 +4,7 @@
 # default config should be adequate
 
 # Add your own!
-KUBE_SCHEDULER_ARGS="--v=2 {{ pillar['components']['scheduler']['args']}}"
+KUBE_SCHEDULER_ARGS="\
+    --leader-elect=true \
+    --v=2 \
+    {{ pillar['components']['scheduler']['args']}}"


### PR DESCRIPTION
Adds the leader-election flag to kube-scheduler (was already present on
kube-controller-manager)

Also sets the apiserver-count on kube-apiserver