### PR TITLE
Update default etcd cluster size to match number of masters

### DIFF
--- a/pillar/params.sls
+++ b/pillar/params.sls
@@ -34,8 +34,16 @@ paths:
 # - the token must be shared between all the machines in the cluster
 # - the discovery id is also unique for all the machines in the
 #   cluster (in fact, it can be the same as the token)
+# - if masters is null, we will determine the number of etcd members
+#   based on the number of nodes with the kube-master role applied
+# - For an etcd cluster to be effective, the number of cluster members
+#   must be both odd and reasonably small, for example - 1,3,5 are
+#   valid while 2,4,6 are not. In addition, clusters larger than 5 are
+#   likely spending more time coordinating amongst themselves than they
+#   are serving clients. As such, it's not recommended to use a cluster
+#   of 7+ nodes.
 etcd:
-  masters:        '1'
+  masters:        null
   token:          'k8s'
   disco:
     port:         '2379'

--- a/salt/_modules/etcd_discovery_helpers.py
+++ b/salt/_modules/etcd_discovery_helpers.py
@@ -1,0 +1,43 @@
+from __future__ import absolute_import
+import logging
+
+
+LOG = logging.getLogger(__name__)
+
+
+def __virtual__():
+    return "etcd_discovery_helpers"
+
+
+def get_cluster_size():
+    """
+    Determines the etcd discovery cluster size
+
+    Determines the desired number of cluster members, defaulting to
+    the value supplied in the etcd:masters pillar, falling back to
+    match the number nodes with the kube-master role, and if this is
+    less than 3, it will bump it to 3.
+    """
+    member_count = __pillar__["etcd"]["masters"]
+
+    if member_count is not None:
+        # A value has been set in the pillar, respect the users choice
+        # even it's not a "good" number.
+        member_count = int(member_count)
+
+        if member_count < 3:
+            LOG.warning("etcd member count too low (%d), consider increasing "
+                        "to 3", member_count)
+
+    else:
+        # A value has not been set in the pillar, calculate a "good" number
+        # for the user.
+        member_count = len(__salt__['mine.get'](
+            'roles:kube-master', 'fqdn', expr_form='grain').values())
+
+        if member_count < 3:
+            LOG.warning("etcd member count too low (%d), increasing to 3",
+                        member_count)
+            member_count = 3
+
+    return member_count

--- a/salt/etcd-discovery/init.sls
+++ b/salt/etcd-discovery/init.sls
@@ -19,7 +19,7 @@ set_size:
   cmd.run:
     - name: curl -L -X PUT
             http://{{ pillar['dashboard'] }}:{{ pillar['etcd']['disco']['port'] }}/v2/keys/_etcd/registry/{{ pillar['etcd']['disco']['id'] }}/_config/size
-            -d value={{ pillar['etcd']['masters'] }}
+            -d value={{ salt['etcd_discovery_helpers.get_cluster_size']() }}
     - require:
       - cmd: cleanup
 

--- a/salt/orch/kubernetes.sls
+++ b/salt/orch/kubernetes.sls
@@ -3,6 +3,13 @@ mine_update:
     - name: mine.update
     - tgt: '*'
 
+sync_modules:
+  salt.function:
+    - name: saltutil.sync_modules
+    - tgt: '*'
+    - kwarg:
+        refresh: True
+
 refresh_pillar:
   salt.function:
     - name: saltutil.refresh_pillar
@@ -26,6 +33,7 @@ etcd_discovery_setup:
       - etcd-discovery
     - require:
       - salt: ca_setup
+      - salt: sync_modules
 
 etcd_nodes_setup:
   salt.state:


### PR DESCRIPTION
Update the etcd role to dynamically choose the cluster size by default, using
the number of masters as the value. This dynamic value may still be overridden
by a pillar value.

We intentially don't make any attempts to prevent "invalid" cluster sizes here,
as doing so would cause issues during master addtion and removal (when that
becomes a suppored operation).