### PR TITLE
Randomize the api.infra.caasp.local IP between all the API servers

### DIFF
--- a/salt/hosts-minion/init.sls
+++ b/salt/hosts-minion/init.sls
@@ -1,14 +1,28 @@
-{%- for minion_id, addrlist in salt['mine.get']('roles:kube-master', 'network.ip_addrs', 'grain').items() %}
-{{ minion_id }}-host-entry:
+{% set api_servers = salt['mine.get']('roles:kube-master', 'network.ip_addrs', 'grain') %}
+{% set api_servers_addrs = api_servers.values() %}
+
+# TODO: remove once we have a haproxy between the kubelet and the API server
+api-host-entry:
   host.present:
-{% if addrlist is string %}
-    - ip: {{ addrlist }}
+{% if api_servers_addrs is string %}
+    - ip: {{ api_servers_addrs }}
 {% else %}
-    - ip: {{ addrlist|first }}
+    - ip: {{ api_servers_addrs|first }}
 {% endif %}
     - names:
       - api
       - api.{{ pillar['internal_infra_domain'] }}
-      - {{ minion_id }}
-      - {{ minion_id }}.{{ pillar['internal_infra_domain'] }}
+{% endfor %}
+
+{%- for server_id, addrlist in api_servers.items() %}
+{{ server_id }}-host-entry:
+   host.present:
+{% if addrlist is string %}
+     - ip: {{ addrlist }}
+{% else %}
+     - ip: {{ addrlist|first }}
+{% endif %}
+     - names:
+       - {{ server_id }}
+       - {{ server_id }}.{{ pillar['internal_infra_domain'] }}
 {% endfor %}


### PR DESCRIPTION
Our current solution can lead all the workers to the same API server in a multi-master environment. We currently generate something like this `/etc/hosts` file in the minions (the same in all the workers):

```
10.10.0.2 api api.infra.caasp.local a0848146a8854c519ce698d28901e824 a0848146a8854c519ce698d28901e824.caasp.infra.local
10.10.0.5 api api.infra.caasp.local f9848a36ae854c519ce398d25907e828 f9848a36ae854c519ce398d25907e828.caasp.infra.local
```

while it would be better to have something like:

```
10.10.0.2 api api.infra.caasp.local
10.10.0.2 a0848146a8854c519ce698d28901e824 a0848146a8854c519ce698d28901e824.caasp.infra.local
10.10.0.5 f9848a36ae854c519ce398d25907e828 f9848a36ae854c519ce398d25907e828.caasp.infra.local
```

with `api.infra.caasp.local` being `10.10.0.2` **or** `10.0.0.5` randomly on each minion.
