### PR TITLE
Update etcd member count logic

### DIFF
--- a/salt/_modules/etcd_discovery_helpers.py
+++ b/salt/_modules/etcd_discovery_helpers.py
@@ -3,6 +3,7 @@ import logging
 
 
 LOG = logging.getLogger(__name__)
+DESIRED_MEMBER_COUNT = 3
 
 
 def __virtual__():
@@ -16,7 +17,8 @@ def get_cluster_size():
     Determines the desired number of cluster members, defaulting to
     the value supplied in the etcd:masters pillar, falling back to
     match the number nodes with the kube-master role, and if this is
-    less than 3, it will bump it to 3.
+    less than 3, it will bump it to 3 (or the number of nodes
+    available if the number of nodes is less than 3).
     """
     member_count = __pillar__["etcd"]["masters"]
 
@@ -25,9 +27,11 @@ def get_cluster_size():
         # even it's not a "good" number.
         member_count = int(member_count)
 
-        if member_count < 3:
+        if member_count < DESIRED_MEMBER_COUNT:
             LOG.warning("etcd member count too low (%d), consider increasing "
-                        "to 3", member_count)
+                        "to %d", member_count, DESIRED_MEMBER_COUNT)
+
+            return member_count
 
     else:
         # A value has not been set in the pillar, calculate a "good" number
@@ -35,9 +39,15 @@ def get_cluster_size():
         member_count = len(__salt__['mine.get'](
             'roles:kube-master', 'fqdn', expr_form='grain').values())
 
-        if member_count < 3:
-            LOG.warning("etcd member count too low (%d), increasing to 3",
-                        member_count)
-            member_count = 3
+        if member_count < DESIRED_MEMBER_COUNT:
+            # Attempt to increase the member count to 3, however, if we don't
+            # have 3 nodes in total, then match the number of nodes we have.
+            increased_member_count = len(__salt__['mine.get'](
+                'roles:kube-*', 'fqdn', expr_form='grain').values())
+            increased_member_count = min(
+                DESIRED_MEMBER_COUNT, increased_member_count)
 
-    return member_count
+            LOG.warning("etcd member count too low (%d), increasing to %d",
+                        member_count, increased_member_count)
+
+            return increased_member_count


### PR DESCRIPTION
When etcd discovery is used, and the expected member count is larger
than the available pool of nodes, etcd will fail to start. So, we add
some logic to etcd_discovery_helpers to ensure we don't attempt to
form a cluster that is larger than the available pool of nodes.