### PR TITLE
Config files for the Salt master from the caasp-container-manifests repo

### DIFF
--- a/config/master.d/api.conf
+++ b/config/master.d/api.conf
@@ -1,0 +1,13 @@
+rest_cherrypy:
+  interface: 0.0.0.0
+  port: 8000
+  disable_ssl: true
+
+external_auth:
+  pam:
+    saltapi:
+      - .*
+      - '@wheel'
+      - '@runner'
+      - '@jobs'
+      - '@events'

--- a/config/master.d/master.conf
+++ b/config/master.d/master.conf
@@ -1,0 +1,13 @@
+user: root
+auto_accept: True
+interface: 0.0.0.0
+event_return: mysql
+presence_events: True
+
+file_roots:
+  base:
+    - /usr/share/salt/kubernetes/salt
+
+pillar_roots:
+  base:
+    - /usr/share/salt/kubernetes/pillar

--- a/config/master.d/peer.conf
+++ b/config/master.d/peer.conf
@@ -1,0 +1,3 @@
+peer:
+  .*:
+    - x509.sign_remote_certificate

--- a/config/master.d/reactor.conf
+++ b/config/master.d/reactor.conf
@@ -1,0 +1,4 @@
+
+reactor:
+  - 'salt/presence/change':
+    - /usr/share/salt/kubernetes/reactor/presence.sls

--- a/config/master.d/returner.conf
+++ b/config/master.d/returner.conf
@@ -1,0 +1,77 @@
+
+mysql:
+  # salt does not support specifying the UNIX socket location here - as a workaround,
+  # use the MYSQL_UNIX_PORT environment variable used by libmysqlclient
+  # you still need the 'host' value here, or it will use the defaults and try to connect
+  # on a host named 'salt'
+  host: 'localhost'
+  user: 'root'
+  pass: 'salt'
+  db: 'velum_production'
+
+ext_pillar:
+  - mysql:
+    # This queries allows us to override our pillar values up to a depth of 3.
+    #
+    # Considering we have on our static pillar:
+    #
+    #   certificate_information:
+    #     subject_properties:
+    #       C: DE
+    #       O: SUSE
+    #       ...
+    #
+    # We are able to prioritize pillar information overriding the default values.
+    #
+    # In this example, if we had a mysql row:
+    #   INSERT INTO pillars(pillar, value) VALUES ("certificate_information.subject_properties.O",
+    #                                              "My Company");
+    #
+    # We would see on the pillar:
+    #
+    #   certificate_information:
+    #     subject_properties:
+    #       C: DE
+    #       O: My Company
+    #       ...
+    #
+    # Please, note that this will only work until a depth of 3 properties. If we want to provide
+    # more depth, we would need to add more columns, as salt treats each column as a nested property
+    # inside the previous one. For further information, please visit:
+    #   https://docs.saltstack.com/en/latest/ref/pillar/all/salt.pillar.sql_base.html
+    #
+    # Lists can be represented as collisions:
+    #   INSERT INTO pillars(pillar, value) VALUES ("my_service.extra_ips", "127.0.0.1");
+    #   INSERT INTO pillars(pillar, value) VALUES ("my_service.extra_ips", "127.0.0.2");
+    #
+    # Will be represented as:
+    #
+    #   my_service:
+    #     extra_ips:
+    #       - 127.0.0.1
+    #       - 127.0.0.2
+    #
+    # Query for first level pillar values (no dots in `pillar` key)
+    - query: 'SELECT pillar,
+                     value
+                     FROM pillars WHERE
+                       (LENGTH(pillar) - LENGTH(REPLACE(pillar, ".", "")) = 0) AND
+                       (minion_id IS NULL OR minion_id = %s)'
+      as_list: True
+    # Query for second level pillar values (one dot in `pillar` key)
+    - query: 'SELECT SUBSTRING_INDEX(SUBSTRING_INDEX(pillar, ".", 1), ".", -1) AS key1,
+                     SUBSTRING_INDEX(SUBSTRING_INDEX(pillar, ".", 2), ".", -1) AS key2,
+                     value
+                     FROM pillars WHERE
+                       (LENGTH(pillar) - LENGTH(REPLACE(pillar, ".", "")) = 1) AND
+                       (minion_id IS NULL OR minion_id = %s)'
+      as_list: True
+    # Query for third level pillar values (two dots in `pillar` key)
+    - query: 'SELECT SUBSTRING_INDEX(SUBSTRING_INDEX(pillar, ".", 1), ".", -1) AS key1,
+                     SUBSTRING_INDEX(SUBSTRING_INDEX(pillar, ".", 2), ".", -1) AS key2,
+                     SUBSTRING_INDEX(SUBSTRING_INDEX(pillar, ".", 3), ".", -1) AS key3,
+                     value
+                     FROM pillars WHERE
+                       (LENGTH(pillar) - LENGTH(REPLACE(pillar, ".", "")) = 2) AND
+                       (minion_id IS NULL OR minion_id = %s)'
+      as_list: True

--- a/reactor/presence.sls
+++ b/reactor/presence.sls
@@ -1,0 +1,6 @@
+# remove unused keys for minions that are not present anymore
+{% for minion_id in data['lost'] %}
+remove_unused_keys_for_{{ minion_id }}:
+   wheel.key.delete:
+     - match: {{ minion_id }}
+{% endfor %}


### PR DESCRIPTION
Moved from the `caasp-container-manifests` repo

Ideally all these config files should go into the `salt-master` docker image (as well as the Salt code, pillars, etc), but there is no problem in keeping the mounts in the manifests.

I have also included our first `reactor` action for presence of minions. It should be considered as an example more than really useful code...

Related to kubic-project/caasp-container-manifests#41
