### PR TITLE
Handle proxies in the docker daemon (bsc#1036627)

### DIFF
--- a/pillar/params.sls
+++ b/pillar/params.sls
@@ -58,6 +58,11 @@ flannel:
   etcd_key:       '/flannel/network'
   iface:          'eth0'
 
+proxy:
+  http:           ''
+  https:          ''
+  no_proxy:       ''
+
 # Configuration for the reboot manager (https://github.com/SUSE/rebootmgr).
 # notes:
 # - The default group for rebootmgr is "default", so we are simply taking


### PR DESCRIPTION
This can be tested by deploying a cluster with [our Terraform scripts](https://github.com/kubic-project/terraform), doing:

1. `k8s-setup ... -Vpillar=proxy.http~http://something.com:8080,proxy.https~https://something.com:443` (requires kubic-project/terraform#66)
2. orchestrating the cluster
3. checking that, in any machine of the cluster, we can run `systemctl show --property=Environment docker` and get something like `Environment=HTTP_PROXY=http://something.com:8080`
