### PR TITLE
Configure ETCD_INITIAL_ADVERTISE_PEER_URLS only with FQDN

### DIFF
--- a/salt/etcd-proxy/etcd-proxy.conf.jinja
+++ b/salt/etcd-proxy/etcd-proxy.conf.jinja
@@ -26,5 +26,5 @@ ETCD_DISCOVERY="http://{{ pillar['dashboard'] }}:{{ pillar['etcd']['disco']['por
 ETCD_DISCOVERY_FALLBACK="proxy"
 
 ETCD_INITIAL_CLUSTER_TOKEN="{{ pillar['etcd']['token'] }}"
-ETCD_INITIAL_ADVERTISE_PEER_URLS="https://{{ grains['fqdn'] }}:2380,https://{{ grains['ip4_interfaces']['eth0'][0] }}:2380"
+ETCD_INITIAL_ADVERTISE_PEER_URLS="https://{{ grains['fqdn'] }}:2380"
 ETCD_INITIAL_CLUSTER_STATE="new"


### PR DESCRIPTION
We have to remove IP based ETCD_INITIAL_ADVERTISE_PEER_URLS,
because they use HTTPS, which is failing for IP URLS with following error

```
health check for peer 100fbbb05571e58f could not connect: x509:
  cannot validate certificate for 10.17.3.176 because it doesn't contain any IP SANs
```