### PR TITLE
Fixing broken etcd configuration

### DIFF
--- a/salt/etcd-proxy/etcd.conf
+++ b/salt/etcd-proxy/etcd.conf
@@ -9,4 +9,4 @@
 # default behavior is to fail if both dirs exist.
 # If the etcd member is broken this should be fixed manually by removing both
 # directories and restarting the application.
-+ExecStartPre=/bin/bash -c "if [[ -d /var/lib/etcd/proxy ]] && [[ -d /var/lib/etcd/member ]]; then rm -rf /var/lib/etcd/member; fi"
+ExecStartPre=/bin/bash -c "if [[ -d /var/lib/etcd/proxy ]] && [[ -d /var/lib/etcd/member ]]; then rm -rf /var/lib/etcd/member; fi"


### PR DESCRIPTION
Stray + character was causing this line to not execute, and I ended up with a cluster with both folders present, preventing etcd from starting.