### PR TITLE
Allow for clean shutdown of nodes

### DIFF
--- a/salt/docker/stop.sls
+++ b/salt/docker/stop.sls
@@ -1,0 +1,4 @@
+# Stop and disable the docker daemon
+docker:
+  service.dead:
+    - enable: False

--- a/salt/etcd-proxy/stop.sls
+++ b/salt/etcd-proxy/stop.sls
@@ -1,0 +1,2 @@
+include:
+  - etcd.stop

--- a/salt/etcd/stop.sls
+++ b/salt/etcd/stop.sls
@@ -1,0 +1,4 @@
+# Stop and disable the etcd daemon
+etcd:
+  service.dead:
+    - enable: False

--- a/salt/flannel/stop.sls
+++ b/salt/flannel/stop.sls
@@ -1,0 +1,5 @@
+# Stop and disable the flannel daemon
+flannel:
+  service.dead:
+    - name: flanneld
+    - enable: False

--- a/salt/kubernetes-master/stop.sls
+++ b/salt/kubernetes-master/stop.sls
@@ -1,0 +1,12 @@
+# Stop and disable the Kubernetes master daemons
+kube-apiserver:
+  service.dead:
+    - enable: False
+
+kube-scheduler:
+  service.dead:
+    - enable: False
+
+kube-controller-manager:
+  service.dead:
+    - enable: False

--- a/salt/kubernetes-minion/stop.sls
+++ b/salt/kubernetes-minion/stop.sls
@@ -1,0 +1,24 @@
+# Stop and disable the Kubernetes minion daemons, ensuring pods have been drained
+# and the node is marked as unschedulable.
+
+# If this fails we should ignore it and proceed anyway as Kubernetes will recover
+drain-kubelet:
+  cmd.run:
+    - name: |
+        kubectl drain {{ grains['fqdn'] }} --ignore-daemonsets --grace-period=300 --timeout=340s
+    - env:
+      - KUBECONFIG: {{ pillar['paths']['kubeconfig'] }}
+    - check_cmd:
+      - /bin/true
+
+kubelet:
+  service.dead:
+    - enable: False
+    - require:
+      - cmd: drain-kubelet
+
+kube-proxy:
+  service.dead:
+    - enable: False
+    - require:
+      - cmd: drain-kubelet


### PR DESCRIPTION
Add a stop SLS for each service we wish to shutdown clearly, doing any
necessary pre-stop actions such as draining and cordoning kubelet.

There are few TODOs inline, any suggestions on the salt way to handle
these would be nice. I'm throwing this up now as it works enough to unblock
other parts of the upgrade, but I don't think it should be merged as-in. 

In the meantime, I'll go looking to see if there's a kubernetes module we can
use in place of shelling out to kubectl.