### PR TITLE
Enable https for all services and create dedicated ssl pillar profile

### DIFF
--- a/pillar/params.sls
+++ b/pillar/params.sls
@@ -28,13 +28,12 @@ addons:           'false'
 
 ssl:
   enabled:        true
+  ca_dir:         '/etc/pki/trust/anchors'
   ca_file:        '/etc/pki/trust/anchors/SUSE_CaaSP_CA.crt'
   crt_file:       '/etc/pki/minion.crt'
   key_file:       '/etc/pki/minion.key'
 
 paths:
-  ca_dir:         '/etc/pki/trust/anchors'
-  ca_filename:    'SUSE_CaaSP_CA.crt'
   var_kubelet:    '/var/lib/kubelet'
   kubeconfig:     '/var/lib/kubelet/kubeconfig'
 

--- a/pillar/params.sls
+++ b/pillar/params.sls
@@ -26,6 +26,12 @@ kube_group:       'kube'
 # install the addons (ie, DNS)
 addons:           'false'
 
+ssl:
+  enabled:        true
+  ca_file:        '/etc/pki/trust/anchors/SUSE_CaaSP_CA.crt'
+  crt_file:       '/etc/pki/minion.crt'
+  key_file:       '/etc/pki/minion.key'
+
 paths:
   ca_dir:         '/etc/pki/trust/anchors'
   ca_filename:    'SUSE_CaaSP_CA.crt'

--- a/salt/cert/init.sls
+++ b/salt/cert/init.sls
@@ -34,7 +34,24 @@ include:
   {% endif %}
 {% endif %}
 
-/etc/pki/minion.key:
+{{ pillar['ssl']['ca_dir'] }}:
+  file.directory:
+    - user: root
+    - group: root
+    - mode: 755
+
+{{ pillar['ssl']['ca_file'] }}:
+  x509.pem_managed:
+    - text: {{ salt['mine.get']('roles:ca', 'x509.get_pem_entries', expr_form='grain').values()[0]['/etc/pki/ca.crt']|replace('\n', '') }}
+    - require:
+      - file: {{ pillar['ssl']['ca_dir'] }}
+  file.managed:
+    - replace: false
+    - user: root
+    - group: root
+    - mode: 644
+
+{{ pillar['ssl']['key_file'] }}::
   x509.private_key_managed:
     - bits: 4096
     - require:
@@ -46,7 +63,7 @@ include:
     - group: root
     - mode: 644
 
-/etc/pki/minion.crt:
+{{ pillar['ssl']['crt_file'] }}::
   x509.certificate_managed:
     - ca_server: {{ salt['mine.get']('roles:ca', 'x509.get_pem_entries', expr_form='grain').keys()[0] }}
     - signing_policy: minion

--- a/salt/etcd-proxy/etcd-proxy.conf.jinja
+++ b/salt/etcd-proxy/etcd-proxy.conf.jinja
@@ -4,7 +4,7 @@
 ETCD_DATA_DIR="/var/lib/etcd/"
 ETCD_NAME="{{ grains['id'] }}"
 
-ETCD_LISTEN_CLIENT_URLS="http://0.0.0.0:2379"
+ETCD_LISTEN_CLIENT_URLS="https://0.0.0.0:2379"
 ETCD_LISTEN_PEER_URLS="https://0.0.0.0:2380"
 
 ETCD_ADVERTISE_CLIENT_URLS="http://{{ grains['caasp_fqdn'] }}:2379,http://{{ grains['ip4_interfaces']['eth0'][0] }}:2379"

--- a/salt/etcd-proxy/etcd-proxy.conf.jinja
+++ b/salt/etcd-proxy/etcd-proxy.conf.jinja
@@ -9,15 +9,15 @@ ETCD_LISTEN_PEER_URLS="https://0.0.0.0:2380"
 
 ETCD_ADVERTISE_CLIENT_URLS="http://{{ grains['caasp_fqdn'] }}:2379,http://{{ grains['ip4_interfaces']['eth0'][0] }}:2379"
 
-ETCD_CA_FILE={{ pillar['paths']['ca_dir'] }}/{{ pillar['paths']['ca_filename'] }}
-ETCD_CERT_FILE=/etc/pki/minion.crt
-ETCD_KEY_FILE=/etc/pki/minion.key
-ETCD_TRUSTED_CA_FILE={{ pillar['paths']['ca_dir'] }}/{{ pillar['paths']['ca_filename'] }}
+ETCD_CA_FILE={{ pillar['ssl']['ca_file'] }}
+ETCD_CERT_FILE={{ pillar['ssl']['crt_file'] }}
+ETCD_KEY_FILE={{ pillar['ssl']['key_file'] }}
+ETCD_TRUSTED_CA_FILE={{ pillar['ssl']['ca_file'] }}
 
-ETCD_PEER_CA_FILE={{ pillar['paths']['ca_dir'] }}/{{ pillar['paths']['ca_filename'] }}
-ETCD_PEER_CERT_FILE=/etc/pki/minion.crt
-ETCD_PEER_KEY_FILE=/etc/pki/minion.key
-ETCD_PEER_TRUSTED_CA_FILE={{ pillar['paths']['ca_dir'] }}/{{ pillar['paths']['ca_filename'] }}
+ETCD_PEER_CA_FILE={{ pillar['ssl']['ca_file'] }}
+ETCD_PEER_CERT_FILE={{ pillar['ssl']['crt_file'] }}
+ETCD_PEER_KEY_FILE={{ pillar['ssl']['key_file'] }}
+ETCD_PEER_TRUSTED_CA_FILE={{ pillar['ssl']['ca_file'] }}
 # ETCD_PEER_CLIENT_CERT_AUTH=on
 # ETCD_PEER_AUTO_TLS=on
 

--- a/salt/etcd/etcd.conf.jinja
+++ b/salt/etcd/etcd.conf.jinja
@@ -11,13 +11,13 @@ ETCD_LISTEN_PEER_URLS="https://0.0.0.0:2380"
 
 ETCD_ADVERTISE_CLIENT_URLS="https://{{ grains['caasp_fqdn'] }}:2379,https://{{ grains['ip4_interfaces']['eth0'][0] }}:2379"
 
-ETCD_CA_FILE={{ pillar['paths']['ca_dir'] }}/{{ pillar['paths']['ca_filename'] }}
-ETCD_CERT_FILE=/etc/pki/minion.crt
-ETCD_KEY_FILE=/etc/pki/minion.key
+ETCD_CA_FILE={{ pillar['ssl']['ca_file'] }}
+ETCD_CERT_FILE={{ pillar['ssl']['crt_file'] }}
+ETCD_KEY_FILE={{ pillar['ssl']['key_file'] }}
 
-ETCD_PEER_CA_FILE={{ pillar['paths']['ca_dir'] }}/{{ pillar['paths']['ca_filename'] }}
-ETCD_PEER_CERT_FILE=/etc/pki/minion.crt
-ETCD_PEER_KEY_FILE=/etc/pki/minion.key
+ETCD_PEER_CA_FILE={{ pillar['ssl']['ca_file'] }}
+ETCD_PEER_CERT_FILE={{ pillar['ssl']['crt_file'] }}
+ETCD_PEER_KEY_FILE={{ pillar['ssl']['key_file'] }}
 
 ETCD_INITIAL_ADVERTISE_PEER_URLS="https://{{ grains['caasp_fqdn'] }}:2380"
 ETCD_INITIAL_CLUSTER_TOKEN="{{ pillar['etcd']['token'] }}"

--- a/salt/flannel-setup/init.sls
+++ b/salt/flannel-setup/init.sls
@@ -3,6 +3,17 @@ include:
   - cert
   - etcd-proxy
 
+{% if pillar['ssl']['enabled'] -%}
+  {% set ca = '--ca-file ' + pillar['ssl']['ca_file'] -%}
+  {% set key = '--key-file ' + pillar['ssl']['key_file'] -%}
+  {% set crt = '--cert-file ' + pillar['ssl']['crt_file'] -%}
+  {% set endpoint = '--endpoints https://' + grains['fqdn'] + ':2379' -%}
+  {% set etcd_opt = ca + ' ' + key + ' ' + cert + ' ' + endpoint
+{% else -%}
+  {% set endpoint = '--endpoints http://' + grains['fqdn'] + ':2379' -%}
+  {% set etcd_opt = endpoint
+{% endif -%}
+
 /root/flannel-config.json:
   file.managed:
     - source:   salt://flannel-setup/config.json.jinja
@@ -12,7 +23,7 @@ load_flannel_cfg:
   pkg.installed:
     - name: etcdctl
   cmd.run:
-    - name: /usr/bin/etcdctl --endpoints http://127.0.0.1:2379
+    - name: /usr/bin/etcdctl {{ etcd_opt }}
                              --no-sync
                              set {{ pillar['flannel']['etcd_key'] }}/config < /root/flannel-config.json
     - require:

--- a/salt/flannel/flanneld.sysconfig.jinja
+++ b/salt/flannel/flanneld.sysconfig.jinja
@@ -1,7 +1,20 @@
 # Flanneld configuration options
 
+{% set http_protocol = 'http' -%}
+{% if pillar['ssl']['enabled'] -%}
+{% set http_protocol = 'https' -%}
+# etcd CA file location
+FLANNEL_ETCD_CAFILE="{{ pillar['ssl']['ca_file'] }}"
+
+# etcd certificate key file location
+FLANNEL_ETCD_KEYFILE="{{ pillar['ssl']['key_file'] }}"
+
+# etcd certificate file location
+FLANNEL_ETCD_CERTFILE="{{ pillar['ssl']['crt_file'] }}"
+{% endif -%}
+
 # etcd url location.  Point this to the server where etcd runs
-FLANNEL_ETCD_ENDPOINTS="http://127.0.0.1:2379"
+FLANNEL_ETCD_ENDPOINTS="{{ http_protocol }}://{{ grains['fqdn'] }}:2379"
 
 # etcd config key.  This is the configuration key that flannel queries
 # For address range assignment

--- a/salt/kubernetes-master/addons/skydns-rc.yaml.jinja
+++ b/salt/kubernetes-master/addons/skydns-rc.yaml.jinja
@@ -93,7 +93,7 @@ spec:
           mountPath: /etc/pki
           readOnly: True
         - name: ca
-          mountPath: {{ pillar['paths']['ca_dir'] }}/{{ pillar['paths']['ca_filename'] }}
+          mountPath: {{ pillar['ssl']['ca_file'] }}
           readOnly: True
 
       ################
@@ -158,7 +158,7 @@ spec:
           path: "/etc/pki"
       - name: ca
         hostPath:
-          path: "{{ pillar['paths']['ca_dir'] }}/{{ pillar['paths']['ca_filename'] }}"
+          path: "{{ pillar['ssl']['ca_file'] }}"
 
       dnsPolicy: Default  # Don't use cluster DNS.
 

--- a/salt/kubernetes-master/apiserver.jinja
+++ b/salt/kubernetes-master/apiserver.jinja
@@ -26,7 +26,7 @@ KUBE_API_ARGS="--advertise-address={{ grains['ip4_interfaces']['eth0'][0] }} \
 {% if salt['pillar.get']('infrastructure', 'libvirt') == 'aws' -%}
                --cloud-provider=aws \
 {% endif -%}
-               --tls-cert-file=/etc/pki/minion.crt \
-               --tls-private-key-file=/etc/pki/minion.key \
+               --tls-cert-file={{ pillar['ssl']['crt_file'] }} \
+               --tls-private-key-file={{ pillar['ssl']['key_file'] }} \
                {{ salt['pillar.get']('components:apiserver:args', '') }} \
-               --client-ca-file={{ pillar['paths']['ca_dir'] }}/{{ pillar['paths']['ca_filename'] }}"
+               --client-ca-file={{ pillar['ssl']['ca_file'] }}"

--- a/salt/kubernetes-master/apiserver.jinja
+++ b/salt/kubernetes-master/apiserver.jinja
@@ -11,7 +11,14 @@ KUBE_API_ADDRESS="--insecure-bind-address=127.0.0.1 --bind-address=0.0.0.0"
 KUBE_API_PORT="--insecure-port=8080 --secure-port={{ pillar['api']['ssl_port'] }}"
 
 # Comma separated list of nodes in the etcd cluster
-KUBE_ETCD_SERVERS="--etcd-servers=http://127.0.0.1:2379"
+{% if pillar['ssl']['enabled'] -%}
+KUBE_ETCD_SERVERS="--etcd-cafile={{ pillar['ssl']['ca_file'] }} \
+                   --etcd-certfile={{ pillar['ssl']['crt_file'] }} \
+                   --etcd-keyfile={{ pillar['ssl']['key_file'] }} \
+                   --etcd-servers=https://{{ grains['fqdn'] }}:2379"
+{% else -%}
+KUBE_ETCD_SERVERS="--etcd-servers=http://{{ grains['fqdn'] }}:2379"
+{% endif -%}
 
 # Address range to use for services
 # [alvaro] should not be in the same range as the flannel network (https://github.com/coreos/flannel/issues/232)

--- a/salt/kubernetes-master/controller-manager.jinja
+++ b/salt/kubernetes-master/controller-manager.jinja
@@ -8,8 +8,8 @@ KUBE_CONTROLLER_MANAGER_ARGS="\
     --leader-elect=true \
     --cluster-name=kubernetes \
     --cluster-cidr={{ pillar['cluster_cidr'] }} \
-    --service-account-private-key-file=/etc/pki/minion.key \
-    --root-ca-file={{ pillar['paths']['ca_dir'] }}/{{ pillar['paths']['ca_filename'] }} \
+    --service-account-private-key-file={{ pillar['ssl']['key_file'] }} \
+    --root-ca-file={{ pillar['ssl']['ca_file'] }} \
 {% if salt['pillar.get']('infrastructure', 'libvirt') == 'aws' -%}
     --cloud-provider=aws \
 {% endif -%}

--- a/salt/kubernetes-minion/init.sls
+++ b/salt/kubernetes-minion/init.sls
@@ -1,8 +1,23 @@
-#######################
-# k8s components
-#######################
 include:
   - repositories
+  - cert
+  - etcd-proxy
+
+{% from 'cert/init.sls' import ip_addresses %}
+
+{% for _, interface_addresses in grains['ip4_interfaces'].items() %}
+  {% for interface_address in interface_addresses %}
+    {% do ip_addresses.append("IP: " + interface_address) %}
+  {% endfor %}
+{% endfor %}
+
+#Add some extra names the server could have
+{% set extra_names = ["DNS: " + grains['fqdn'] %}
+
+extend:
+  /etc/pki/minion.crt:
+    x509.certificate_managed:
+      - subjectAltName: "{{ ", ".join(extra_names + ip_addresses) }}"
 
 conntrack-tools:
   pkg.installed

--- a/salt/kubernetes-minion/kubeconfig.jinja
+++ b/salt/kubernetes-minion/kubeconfig.jinja
@@ -5,7 +5,7 @@
 apiVersion: v1
 clusters:
 - cluster:
-    certificate-authority: {{ pillar['paths']['ca_dir'] }}/{{ pillar['paths']['ca_filename'] }}
+    certificate-authority: {{ pillar['ssl']['ca_file'] }}
     server: {{ api_server_url }}
   name: default-cluster
 contexts:
@@ -19,5 +19,5 @@ preferences: {}
 users:
 - name: default-admin
   user:
-    client-certificate: /etc/pki/minion.crt
-    client-key: /etc/pki/minion.key
+    client-certificate: {{ pillar['ssl']['crt_file'] }} 
+    client-key: {{ pillar['ssl']['key_file'] }} 


### PR DESCRIPTION
This change is enabling https for `etcd-proxy` and `flanneld` services and it is cleaning up pillar configuration for ssl