### PR TITLE
Minor changes in etcd and kubelet

### DIFF
--- a/pillar/params.sls
+++ b/pillar/params.sls
@@ -58,6 +58,9 @@ flannel:
   etcd_key:       '/flannel/network'
   iface:          'eth0'
 
+kubelet:
+  port:           '10250'
+
 proxy:
   http:           ''
   https:          ''

--- a/salt/etcd/init.sls
+++ b/salt/etcd/init.sls
@@ -32,10 +32,6 @@ etcd:
       - etcd
     - require:
       - file: /etc/zypp/repos.d/containers.repo
-  cmd.run:
-    - name: rm -rf /var/lib/etcd/*
-    - prereq:
-      - service: etcd
   iptables.append:
     - table: filter
     - family: ipv4
@@ -45,9 +41,7 @@ etcd:
     - connstate: NEW
     # TODO: add "- source: <local-subnet>"
     - dports:
-        - 2379
         - 2380
-        - 4001
     - proto: tcp
   service.running:
     - name: etcd

--- a/salt/kubernetes-minion/init.sls
+++ b/salt/kubernetes-minion/init.sls
@@ -49,7 +49,19 @@ kubelet:
     - require:
       - pkg:    kubernetes-minion
       - file:   /etc/kubernetes/manifests
-#
+  iptables.append:
+    - table:     filter
+    - family:    ipv4
+    - chain:     INPUT
+    - jump:      ACCEPT
+    - match:     state
+    - connstate: NEW
+    - dports:
+      - {{ pillar['kubelet']['port'] }}
+    - proto:     tcp
+    - require:
+      - service: kubelet
+
 # note: br_netfilter is not available in some kernels
 #       not sure we really need it...
 #

--- a/salt/kubernetes-minion/kubelet.jinja
+++ b/salt/kubernetes-minion/kubelet.jinja
@@ -9,7 +9,7 @@
 KUBELET_ADDRESS="--address=0.0.0.0"
 
 # The port for the info server to serve on
-KUBELET_PORT="--port=10250"
+KUBELET_PORT="--port={{ pillar['kubelet']['port'] }}"
 
 # Use <machine_id>.<internal_infra_domain> matching the SSL certificates
 KUBELET_HOSTNAME="--hostname-override={{ grains['id'] }}.{{ pillar['internal_infra_domain'] }}"


### PR DESCRIPTION
Minor changes in etcd and kubelet:

* do not remove `/var/lib/etcd`
* close some ports we don't really need for etcd, and open the port `10250` for `kubelet`.