### PR TITLE
Make cert always include `fqdn`

### DIFF
--- a/salt/cert/init.sls
+++ b/salt/cert/init.sls
@@ -2,6 +2,7 @@ include:
   - crypto
 
 {% set ip_addresses = [] -%}
+{% set extra_names = ["DNS: " + grains['fqdn']] -%}
 
 {{ pillar['paths']['ca_dir'] }}:
   file.directory:
@@ -48,8 +49,8 @@ include:
     - ST: {{ pillar['certificate_information']['subject_properties']['ST']|yaml_dquote }}
     - basicConstraints: "critical CA:false"
     - keyUsage: nonRepudiation, digitalSignature, keyEncipherment
-    {% if ip_addresses|length > 0 %}
-    - subjectAltName: "{{ ", ".join(ip_addresses) }}"
+    {% if (ip_addresses|length > 0) or (extra_names|length > 0) %}
+    - subjectAltName: "{{ ", ".join(extra_names + ip_addresses) }}"
     {% endif %}
     - days_valid: {{ pillar['certificate_information']['days_valid']['certificate'] }}
     - days_remaining: {{ pillar['certificate_information']['days_remaining']['certificate'] }}

--- a/salt/kubernetes-master/init.sls
+++ b/salt/kubernetes-master/init.sls
@@ -3,7 +3,7 @@ include:
   - cert
   - etcd-proxy
 
-{% from 'cert/init.sls' import ip_addresses %}
+{% from 'cert/init.sls' import ip_addresses, extra_names %}
 
 {% do ip_addresses.append("IP: " + pillar['api']['cluster_ip']) %}
 {% for _, interface_addresses in grains['ip4_interfaces'].items() %}
@@ -16,9 +16,8 @@ include:
 {% endfor %}
 
 # add some extra names the API server could have
-{% set extra_names = ["DNS: " + grains['fqdn'],
-                      "DNS: api",
-                      "DNS: api." + pillar['internal_infra_domain']] %}
+{% set extra_names = extra_names + ["DNS: api",
+                                    "DNS: api." + pillar['internal_infra_domain']] %}
 {% for extra_name in pillar['api']['server']['extra_names'] %}
   {% do extra_names.append("DNS: " + extra_name) %}
 {% endfor %}


### PR DESCRIPTION
Make cert always include `fqdn`
    
The only component that was adding `fqdn` to the list of dns names of SAN
certificates is the `kube-master` role.
    
However, depending on the size of the cluster and other possible reasons
it might happen that a etcd member falls in a `kube-minion` instance,
where the certificate is missing local ip addresses, as well as the `fqdn`
of the machine. With this change, we are enforcing `cert` to always
generate this information automatically, while we still allow to extend
it, in case that's still necessary (for example, as kubernetes-master still
requires).
    
Check https://bugzilla.novell.com/show_bug.cgi?id=1039269#c9 for further
information.
    
Fixes: bsc#1039269