### PR TITLE
Do not include etcd-proxy on this last action

### DIFF
--- a/salt/reboot/init.sls
+++ b/salt/reboot/init.sls
@@ -2,9 +2,6 @@
 # Configuration for the reboot manager
 ##################################################
 
-include:
-  - etcd-proxy
-
 # `max_holders` contains the maximum number of lock holders for the cluster. It
 # must comply with the optimal cluster size as defined here:
 #   https://coreos.com/etcd/docs/latest/v2/admin_guide.html
@@ -36,7 +33,6 @@ set_max_holders_mutex:
             -d value="0"
     - require:
       - cmd: opensuseorg_cleanup
-      - service: etcd
 
 # Initialize the `data` key, which is JSON data with: the maximum number of
 # holders, and a list of current holders.
@@ -48,4 +44,3 @@ set_max_holders_data:
         curl -L -X PUT http://127.0.0.1:2379/v2/keys/{{ pillar['reboot']['directory'] }}/{{ pillar['reboot']['group'] }}/data?prevExist=false -d value='{ "max":"{{ max_holders }}", "holders":[] }'
     - require:
       - cmd: set_max_holders_mutex
-      - service: etcd


### PR DESCRIPTION
This triggers a chain reaction when the reboot sls is called
directly (salt-call state.apply reboot) on the last step of the
orchestration, since etcd-proxy includes etcd, and etcd includes
cert.

Cert sls will generate a new certificate overriding the current one
with all the correct DNS names and IP addresses, by one that only
contains `fqdn` as the only dns name.

Fixes: bsc#1040858