### PR TITLE
Idempotent salt states

### DIFF
--- a/salt/ca-cert/init.sls
+++ b/salt/ca-cert/init.sls
@@ -1,0 +1,19 @@
+include:
+  - crypto
+
+{{ pillar['paths']['ca_dir'] }}:
+  file.directory:
+    - user: root
+    - group: root
+    - mode: 755
+
+{{ pillar['paths']['ca_dir'] }}/{{ pillar['paths']['ca_filename'] }}:
+  x509.pem_managed:
+    - text: {{ salt['mine.get']('roles:ca', 'x509.get_pem_entries', expr_form='grain').values()[0]['/etc/pki/ca.crt']|replace('\n', '') }}
+    - require:
+      - file: {{ pillar['paths']['ca_dir'] }}
+  file.managed:
+    - replace: false
+    - user: root
+    - group: root
+    - mode: 644

--- a/salt/ca/init.sls
+++ b/salt/ca/init.sls
@@ -86,9 +86,9 @@ salt-minion:
     - mode: 644
 
 mine.send:
-  module.run:
+  module.wait:
     - func: x509.get_pem_entries
     - kwargs:
         glob_path: /etc/pki/ca.crt
-    - onchanges:
+    - watch:
       - x509: /etc/pki/ca.crt

--- a/salt/docker/init.sls
+++ b/salt/docker/init.sls
@@ -16,6 +16,7 @@ include:
         Environment="NO_PROXY={{ salt['pillar.get']('proxy:no_proxy', '') }}"
   cmd.run:
     - name: systemctl daemon-reload
+    - stateful: True
 
 #######################
 # docker daemon
@@ -40,16 +41,13 @@ docker:
     - append_if_not_found: True
     - require:
       - pkg: docker
-  # [inercia] when dockerd was already running and we require the
-  # service to be "service.running", Salt does not think it must
-  # restart it even when we say "watch these files", so we
-  # need this "cmd.run"...
   cmd.run:
     - name: systemctl restart docker.service
     - onlyif: systemctl status docker.service
+    - onchanges:
+      - /etc/systemd/system/docker.service.d/proxy.conf
     - require:
       - file: /etc/sysconfig/docker
-      - /etc/systemd/system/docker.service.d/proxy.conf
   service.running:
     - enable: True
     - watch:
@@ -57,4 +55,3 @@ docker:
       - pkg: docker
       - file: /etc/sysconfig/docker
       - /etc/systemd/system/docker.service.d/proxy.conf
-

--- a/salt/etcd-discovery/init.sls
+++ b/salt/etcd-discovery/init.sls
@@ -1,27 +1,16 @@
 {% if salt['pillar.get']('etcd:disco:id', '')|length > 0 %}
 
-# cleanup any previous cluster information
-previous-etcd-discovery-cleanup:
-  pkg.installed:
-    - name: etcdctl
-  cmd.run:
-    - name: etcdctl
-            --endpoint=http://{{ pillar['dashboard'] }}:{{ pillar['etcd']['disco']['port'] }}
-            rm -r /_etcd/registry/{{ pillar['etcd']['disco']['id'] }}
-    # ignore failures for this
-    - check_cmd:
-      - /bin/true
+{% set etcd_size_uri = "http://" + pillar['dashboard'] + ":" + pillar['etcd']['disco']['port'] +
+         "/v2/keys/_etcd/registry/" + pillar['etcd']['disco']['id'] + "/_config/size" %}
 
 # set the cluster size in the private Discovery registry
 etcd-discovery-setup:
   pkg.installed:
     - name: curl
   cmd.run:
-    - name: curl -L -X PUT
-            http://{{ pillar['dashboard'] }}:{{ pillar['etcd']['disco']['port'] }}/v2/keys/_etcd/registry/{{ pillar['etcd']['disco']['id'] }}/_config/size
-            -d value={{ salt.k8s_etcd.get_cluster_size() }}
+    - name: curl -L -X PUT {{ etcd_size_uri }} -d value={{ salt.k8s_etcd.get_cluster_size() }}
+    - unless: curl {{ etcd_size_uri }} | grep '"value":"{{ salt.k8s_etcd.get_cluster_size() }}"'
     - require:
       - pkg: curl
-      - cmd: previous-etcd-discovery-cleanup
 
 {% endif %}

--- a/salt/etcd/init.sls
+++ b/salt/etcd/init.sls
@@ -1,5 +1,6 @@
 include:
   - repositories
+  - ca-cert
   - cert
 
 etcd:
@@ -47,6 +48,7 @@ etcd:
     - name: etcd
     - enable: True
     - require:
+      - sls: ca-cert
       - sls: cert
       - pkg: etcd
       - iptables: etcd

--- a/salt/flannel-setup/init.sls
+++ b/salt/flannel-setup/init.sls
@@ -1,4 +1,5 @@
 include:
+  - ca-cert
   - cert
   - etcd-proxy
 
@@ -15,7 +16,8 @@ load_flannel_cfg:
                              --no-sync
                              set {{ pillar['flannel']['etcd_key'] }}/config < /root/flannel-config.json
     - require:
+      - sls: ca-cert
       - sls: cert
       - service: etcd
-    - watch:
+    - onchanges:
       - file: /root/flannel-config.json

--- a/salt/kubernetes-minion/init.sls
+++ b/salt/kubernetes-minion/init.sls
@@ -68,12 +68,14 @@ kubelet:
   cmd.run:
     - name: |
         ELAPSED=0
-        until kubectl uncordon {{ grains['caasp_fqdn'] }} ; do
+        until output=$(kubectl uncordon {{ grains['caasp_fqdn'] }}) ; do
             [ $ELAPSED -gt 60 ] && exit 1
             sleep 1 && ELAPSED=$(( $ELAPSED + 1 ))
         done
+        echo changed="$(echo $output | grep 'already uncordoned' &> /dev/null && echo no || echo yes)"
     - env:
       - KUBECONFIG: {{ pillar['paths']['kubeconfig'] }}
+    - stateful: True
 
 #######################
 # config files

--- a/salt/orch/kubernetes.sls
+++ b/salt/orch/kubernetes.sls
@@ -1,4 +1,3 @@
-
 hostname_setup:
   salt.state:
     - tgt: 'roles:kube-(master|minion)'
@@ -23,8 +22,8 @@ update_mine:
 
 update_modules:
   salt.function:
-    - name: saltutil.sync_modules
     - tgt: '*'
+    - name: saltutil.sync_modules
     - kwarg:
         refresh: True
 

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -4,6 +4,7 @@ base:
     - ca
   'roles:kube-(master|minion)':
     - match: grain_pcre
+    - ca-cert
     - repositories
     - motd
     - users


### PR DESCRIPTION
- Adapt some `cmd.run` to use `onchanges`, so they only execute when their
  `watched` states change.

- Add `stateful: True` to some `cmd.run`s, so following the salt protocol
  for this we ensure that the command didn't change anything in the system
  state.

- Move `ca-cert` to its own SLS, so `cert` will only now generate the
  `/etc/pki/minion.{key,crt}` files.

- The `cert` SLS will now be the only responsible for generating
  certificates depending on the role of the machine. This way we ensure
  that without mattering how this SLS is included it behaves in the same
  way under all conditions. We might want to use a certificate for different
  services, but that will need some extra changes.

- Change some `module.run` to `module.wait` so they only execute when the
  `watched` states change.

- Remove cleanups that make it impossible to have idempotent states.