### PR TITLE
Don't rely on fqdn grain

### DIFF
--- a/pillar/fqdn.sls
+++ b/pillar/fqdn.sls
@@ -2,3 +2,6 @@ mine_functions:
   fqdn:
     - mine_function: grains.get
     - fqdn
+  caasp_fqdn:
+    - mine_function: grains.get
+    - caasp_fqdn

--- a/salt/_modules/k8s_etcd.py
+++ b/salt/_modules/k8s_etcd.py
@@ -36,13 +36,13 @@ def get_cluster_size():
         # A value has not been set in the pillar, calculate a "good" number
         # for the user.
         member_count = len(__salt__['mine.get'](
-            'roles:kube-master', 'fqdn', expr_form='grain').values())
+            'roles:kube-master', 'caasp_fqdn', expr_form='grain').values())
 
         if member_count < DESIRED_MEMBER_COUNT:
             # Attempt to increase the member count to 3, however, if we don't
             # have 3 nodes in total, then match the number of nodes we have.
             increased_member_count = len(__salt__['mine.get'](
-                'roles:kube-*', 'fqdn', expr_form='grain').values())
+                'roles:kube-*', 'caasp_fqdn', expr_form='grain').values())
             increased_member_count = min(
                 DESIRED_MEMBER_COUNT, increased_member_count)
 

--- a/salt/cert/init.sls
+++ b/salt/cert/init.sls
@@ -2,7 +2,7 @@ include:
   - crypto
 
 {% set ip_addresses = [] -%}
-{% set extra_names = ["DNS: " + grains['id'] + "." +  pillar['internal_infra_domain'] ] -%}
+{% set extra_names = ["DNS: " + grains['caasp_fqdn'] ] -%}
 
 {{ pillar['paths']['ca_dir'] }}:
   file.directory:
@@ -38,7 +38,7 @@ include:
     - ca_server: {{ salt['mine.get']('roles:ca', 'x509.get_pem_entries', expr_form='grain').keys()[0] }}
     - signing_policy: minion
     - public_key: /etc/pki/minion.key
-    - CN: {{ grains['id'] }}.{{ pillar['internal_infra_domain'] }}
+    - CN: {{ grains['caasp_fqdn'] }}
     - C: {{ pillar['certificate_information']['subject_properties']['C']|yaml_dquote }}
     - Email: {{ pillar['certificate_information']['subject_properties']['Email']|yaml_dquote }}
     - GN: {{ pillar['certificate_information']['subject_properties']['GN']|yaml_dquote }}

--- a/salt/cert/init.sls
+++ b/salt/cert/init.sls
@@ -2,7 +2,7 @@ include:
   - crypto
 
 {% set ip_addresses = [] -%}
-{% set extra_names = ["DNS: " + grains['fqdn']] -%}
+{% set extra_names = ["DNS: " + grains['id'] + "." +  pillar['internal_infra_domain'] ] -%}
 
 {{ pillar['paths']['ca_dir'] }}:
   file.directory:
@@ -38,7 +38,7 @@ include:
     - ca_server: {{ salt['mine.get']('roles:ca', 'x509.get_pem_entries', expr_form='grain').keys()[0] }}
     - signing_policy: minion
     - public_key: /etc/pki/minion.key
-    - CN: {{ grains['fqdn'] }}
+    - CN: {{ grains['id'] }}.{{ pillar['internal_infra_domain'] }}
     - C: {{ pillar['certificate_information']['subject_properties']['C']|yaml_dquote }}
     - Email: {{ pillar['certificate_information']['subject_properties']['Email']|yaml_dquote }}
     - GN: {{ pillar['certificate_information']['subject_properties']['GN']|yaml_dquote }}

--- a/salt/etcd-proxy/etcd-proxy.conf.jinja
+++ b/salt/etcd-proxy/etcd-proxy.conf.jinja
@@ -7,7 +7,7 @@ ETCD_NAME="{{ grains['id'] }}"
 ETCD_LISTEN_CLIENT_URLS="http://0.0.0.0:2379"
 ETCD_LISTEN_PEER_URLS="https://0.0.0.0:2380"
 
-ETCD_ADVERTISE_CLIENT_URLS="http://{{ grains['fqdn'] }}:2379,http://{{ grains['ip4_interfaces']['eth0'][0] }}:2379"
+ETCD_ADVERTISE_CLIENT_URLS="http://{{ grains['caasp_fqdn'] }}:2379,http://{{ grains['ip4_interfaces']['eth0'][0] }}:2379"
 
 ETCD_CA_FILE={{ pillar['paths']['ca_dir'] }}/{{ pillar['paths']['ca_filename'] }}
 ETCD_CERT_FILE=/etc/pki/minion.crt
@@ -26,5 +26,5 @@ ETCD_DISCOVERY="http://{{ pillar['dashboard'] }}:{{ pillar['etcd']['disco']['por
 ETCD_DISCOVERY_FALLBACK="proxy"
 
 ETCD_INITIAL_CLUSTER_TOKEN="{{ pillar['etcd']['token'] }}"
-ETCD_INITIAL_ADVERTISE_PEER_URLS="https://{{ grains['fqdn'] }}:2380"
+ETCD_INITIAL_ADVERTISE_PEER_URLS="https://{{ grains['caasp_fqdn'] }}:2380"
 ETCD_INITIAL_CLUSTER_STATE="new"

--- a/salt/etcd/etcd.conf.jinja
+++ b/salt/etcd/etcd.conf.jinja
@@ -1,6 +1,6 @@
 {% set servers = [] -%}
-{% for minion_id, fqdn in salt['mine.get']('roles:etcd', 'fqdn', expr_form='grain').items() -%}
-  {% do servers.append(minion_id + '=https://' + fqdn + ':2380') -%}
+{% for minion_id, caasp_fqdn in salt['mine.get']('roles:etcd', 'caasp_fqdn', expr_form='grain').items() -%}
+  {% do servers.append(minion_id + '=https://' + caasp_fqdn + ':2380') -%}
 {% endfor -%}
 
 ETCD_DATA_DIR="/var/lib/etcd/"
@@ -9,7 +9,7 @@ ETCD_NAME="{{ grains['id'] }}"
 ETCD_LISTEN_CLIENT_URLS="https://0.0.0.0:2379"
 ETCD_LISTEN_PEER_URLS="https://0.0.0.0:2380"
 
-ETCD_ADVERTISE_CLIENT_URLS="https://{{ grains['fqdn'] }}:2379,https://{{ grains['ip4_interfaces']['eth0'][0] }}:2379"
+ETCD_ADVERTISE_CLIENT_URLS="https://{{ grains['caasp_fqdn'] }}:2379,https://{{ grains['ip4_interfaces']['eth0'][0] }}:2379"
 
 ETCD_CA_FILE={{ pillar['paths']['ca_dir'] }}/{{ pillar['paths']['ca_filename'] }}
 ETCD_CERT_FILE=/etc/pki/minion.crt
@@ -19,7 +19,7 @@ ETCD_PEER_CA_FILE={{ pillar['paths']['ca_dir'] }}/{{ pillar['paths']['ca_filenam
 ETCD_PEER_CERT_FILE=/etc/pki/minion.crt
 ETCD_PEER_KEY_FILE=/etc/pki/minion.key
 
-ETCD_INITIAL_ADVERTISE_PEER_URLS="https://{{ grains['fqdn'] }}:2380"
+ETCD_INITIAL_ADVERTISE_PEER_URLS="https://{{ grains['caasp_fqdn'] }}:2380"
 ETCD_INITIAL_CLUSTER_TOKEN="{{ pillar['etcd']['token'] }}"
 ETCD_INITIAL_CLUSTER="{{ ",".join(servers) }}"
 ETCD_INITIAL_CLUSTER_STATE="new"

--- a/salt/hostname/init.sls
+++ b/salt/hostname/init.sls
@@ -1,13 +1,22 @@
-{% set hostname = grains['id'] + '.' + pillar['internal_infra_domain'] %}
+caasp_fqdn:
+  grains.present:
+    - value: {{ grains['id'] }}.{{ pillar['internal_infra_domain'] }}
 
+# Both of the below are due to be removed, and can't use the `caasp_fqdn` grain
+# as it's not available in grains until the next state, so lets leave them as is
+# for the moment
 /etc/hostname:
   file.managed:
-    - contents: {{ hostname }}
+    - contents: {{ grains['id'] }}.{{ pillar['internal_infra_domain'] }}
     - backup: false
+    - require:
+      - grains: caasp_fqdn
 
 hostname-static:
   cmd.run:
-    - name: hostnamectl set-hostname --static --transient {{ hostname }}
-    - unless: [[ $(hostnamectl --transient) == {{ hostname }} ]]
+    - name: hostnamectl set-hostname --static --transient {{ grains['id'] }}.{{ pillar['internal_infra_domain'] }}
+    - unless: [[ $(hostnamectl --transient) == {{ grains['id'] }}.{{ pillar['internal_infra_domain'] }} ]]
+    - require:
+        - grains: caasp_fqdn
   module.run:
     - name: mine.update

--- a/salt/kubernetes-master/apiserver.jinja
+++ b/salt/kubernetes-master/apiserver.jinja
@@ -22,7 +22,7 @@ KUBE_ADMISSION_CONTROL="--admission-control=NamespaceLifecycle,LimitRanger,Servi
 
 # Add your own!
 KUBE_API_ARGS="--advertise-address={{ grains['ip4_interfaces']['eth0'][0] }} \
-               --apiserver-count={{ salt['mine.get']('roles:kube-master', 'fqdn', expr_form='grain').values()|length }} \
+               --apiserver-count={{ salt['mine.get']('roles:kube-master', 'caasp_fqdn', expr_form='grain').values()|length }} \
 {% if salt['pillar.get']('infrastructure', 'libvirt') == 'aws' -%}
                --cloud-provider=aws \
 {% endif -%}

--- a/salt/kubernetes-minion/init.sls
+++ b/salt/kubernetes-minion/init.sls
@@ -68,7 +68,7 @@ kubelet:
   cmd.run:
     - name: |
         ELAPSED=0
-        until kubectl uncordon {{ grains['fqdn'] }} ; do
+        until kubectl uncordon {{ grains['caasp_fqdn'] }} ; do
             [ $ELAPSED -gt 60 ] && exit 1
             sleep 1 && ELAPSED=$(( $ELAPSED + 1 ))
         done

--- a/salt/kubernetes-minion/kubelet.jinja
+++ b/salt/kubernetes-minion/kubelet.jinja
@@ -12,7 +12,7 @@ KUBELET_ADDRESS="--address=0.0.0.0"
 KUBELET_PORT="--port={{ pillar['kubelet']['port'] }}"
 
 # Use <machine_id>.<internal_infra_domain> matching the SSL certificates
-KUBELET_HOSTNAME="--hostname-override={{ grains['id'] }}.{{ pillar['internal_infra_domain'] }}"
+KUBELET_HOSTNAME="--hostname-override={{ grains['caasp_fqdn'] }}"
 
 # location of the api-server
 KUBELET_API_SERVER="--api-servers={{ api_server_url }}"

--- a/salt/kubernetes-minion/stop.sls
+++ b/salt/kubernetes-minion/stop.sls
@@ -5,7 +5,7 @@
 drain-kubelet:
   cmd.run:
     - name: |
-        kubectl drain {{ grains['fqdn'] }} --ignore-daemonsets --grace-period=300 --timeout=340s
+        kubectl drain {{ grains['caasp_fqdn'] }} --ignore-daemonsets --grace-period=300 --timeout=340s
     - env:
       - KUBECONFIG: {{ pillar['paths']['kubeconfig'] }}
     - check_cmd:


### PR DESCRIPTION
The FQDN grain is unrelable, and depending on the node (and it's current
state) will give us different values. It's use needs to be dropped entirely,

Fixes bsc#1041951
Partially Fixes bsc#1041789