### PR TITLE
Don't change the system hostname

### DIFF
--- a/salt/hostname/init.sls
+++ b/salt/hostname/init.sls
@@ -1,22 +1,3 @@
 caasp_fqdn:
   grains.present:
     - value: {{ grains['id'] }}.{{ pillar['internal_infra_domain'] }}
-
-# Both of the below are due to be removed, and can't use the `caasp_fqdn` grain
-# as it's not available in grains until the next state, so lets leave them as is
-# for the moment
-/etc/hostname:
-  file.managed:
-    - contents: {{ grains['id'] }}.{{ pillar['internal_infra_domain'] }}
-    - backup: false
-    - require:
-      - grains: caasp_fqdn
-
-hostname-static:
-  cmd.run:
-    - name: hostnamectl set-hostname --static --transient {{ grains['id'] }}.{{ pillar['internal_infra_domain'] }}
-    - unless: [[ $(hostnamectl --transient) == {{ grains['id'] }}.{{ pillar['internal_infra_domain'] }} ]]
-    - require:
-        - grains: caasp_fqdn
-  module.run:
-    - name: mine.update

--- a/salt/motd/motd.jinja
+++ b/salt/motd/motd.jinja
@@ -1,4 +1,8 @@
-Welcome to {{salt['grains.get']('id', 'ERROR')}}.{{ pillar['internal_infra_domain']}}. 
+Welcome!
+
+Machine ID: {{ salt['grains.get']('machine_id', 'ERROR') }}
+Internal FQDN: {{ salt['grains.get']('caasp_fqdn', 'ERROR') }}
+
 The roles of this node are:
 {%- for role in salt['grains.get']('roles', []) %}
   - {{role}}


### PR DESCRIPTION
Operators don't want us to change the system hostname, which we previously
did to account for environments which don't provide unique DHCP hostnames.

We'll undo this change, as we have now removed our reliance on the system
default hostname.

Tested with:

* Unique + Resolvable Hostnames
* Unique + NOT Resolvable Hostnames
* NOT Unique + Resolvable Hostnames (hostname resolves to all 3 node IPs)
* NOT Unique + NOT Resolvable Hostnames

Fixes bsc#1041789