### PR TITLE
use git revision in package version

### DIFF
--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -12,8 +12,9 @@ cd $(dirname $0)
 
 YEAR=$(date +%Y)
 VERSION=$(cat ../../VERSION)
-COMMIT_UNIX_TIME=$(git show -s --format=%ct)
-VERSION="${VERSION%+*}+$(date -d @$COMMIT_UNIX_TIME +%Y%m%d).$(git rev-parse --short HEAD)"
+REVISION=$(git rev-list HEAD | wc -l)
+COMMIT=$(git rev-parse --short HEAD)
+VERSION="${VERSION%+*}+git_r${REVISION}_${COMMIT}"
 NAME=$1
 GITREPONAME=$(basename `git rev-parse --show-toplevel`)
 


### PR DESCRIPTION
this way zypper sees each new commit as an update
Otherwise, using the date, will create a conflict if 2 commits are from
the same day

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>