### PR TITLE
disable reboot manager when orchestration happens

### DIFF
--- a/salt/orch/kubernetes.sls
+++ b/salt/orch/kubernetes.sls
@@ -1,3 +1,9 @@
+disable_rebootmgr:
+  salt.state:
+    - tgt: '*'
+    - sls:
+      - rebootmgr
+
 hostname_setup:
   salt.state:
     - tgt: 'roles:kube-(master|minion)'

--- a/salt/rebootmgr/init.sls
+++ b/salt/rebootmgr/init.sls
@@ -1,0 +1,3 @@
+rebootmgr:
+  service.dead:
+    - enable: False


### PR DESCRIPTION
this will disable rebootmgr when orchestration starts.
@ereslibre @inercia PTAL.
not sure if i'm missing something.
Initially i wanted to define the service as part of the state (this is just a variation, i did a lot of them):
```
disable_rebootmgr:
  salt.state:
    - tgt: 'roles:kube-(master|minion)'
    - service:
      - name: rebootmgr
      - running: False
      - enabled: False
      - reload: True
```
i think that defining a separate `role` just for this is stupid but i couldn't find any other way. suggestions are welcomed.