### PR TITLE
Update transactional-update to use "salt" option

### DIFF
--- a/pillar/params.sls
+++ b/pillar/params.sls
@@ -75,3 +75,7 @@ proxy:
 reboot:
   group:          'default'
   directory:      'opensuse.org/rebootmgr/locks'
+
+transactional-update:
+  timer:
+    on_calendar: 'daily' # See https://www.freedesktop.org/software/systemd/man/systemd.time.html#Calendar%20Events for syntax

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -15,6 +15,7 @@ base:
     - flannel
     - docker
     - container-feeder
+    - transactional-update
   'roles:kube-master':
     - match: grain
     - kubernetes-master

--- a/salt/transactional-update/10-increase-update-speed.conf.jinja
+++ b/salt/transactional-update/10-increase-update-speed.conf.jinja
@@ -1,0 +1,2 @@
+[Timer]
+OnCalendar={{ salt['pillar.get']('transactional-update:timer:on_calendar', 'OnCalendar=daily') }} 

--- a/salt/transactional-update/10-update-rebootmgr-options.conf
+++ b/salt/transactional-update/10-update-rebootmgr-options.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=/usr/sbin/transactional-update cleanup dup salt

--- a/salt/transactional-update/init.sls
+++ b/salt/transactional-update/init.sls
@@ -1,0 +1,29 @@
+/etc/systemd/system/transactional-update.service.d/10-update-rebootmgr-options.conf:
+  file.managed:
+    - makedirs: true
+    - source: salt://transactional-update/10-update-rebootmgr-options.conf
+    - user: root
+    - group: root
+    - mode: 644
+
+/etc/systemd/system/transactional-update.timer.d/10-increase-update-speed.conf:
+  file.managed:
+    - makedirs: true
+    - template: jinja
+    - source: salt://transactional-update/10-increase-update-speed.conf.jinja
+    - user: root
+    - group: root
+    - mode: 644
+
+service.systemctl_reload:
+  module.run:
+    - onchanges:
+      - file: /etc/systemd/system/transactional-update.service.d/10-update-rebootmgr-options.conf
+      - file: /etc/systemd/system/transactional-update.timer.d/10-increase-update-speed.conf
+
+transactional-update.timer:
+  service.running:
+    - name: transactional-update.timer
+    - enable: True
+    - watch:
+      - file: /etc/systemd/system/transactional-update.timer.d/10-increase-update-speed.conf


### PR DESCRIPTION
This will ensure that the transactional-update code will
write a grain (`tx_update_reboot_needed:true`) on the
node instead of rebooting the node.

This also allows for increasing the frequency of the snapshots
being built