### PR TITLE
Stop managing /var/lib/etcd in salt

### DIFF
--- a/salt/etcd/init.sls
+++ b/salt/etcd/init.sls
@@ -14,18 +14,6 @@ etcd:
       - etcd
     - require:
       - group: etcd
-  file.directory:
-    - name: /var/lib/etcd
-    - user: etcd
-    - group: etcd
-    - dir_mode: 700
-    - recurse:
-      - user
-      - group
-      - mode
-    - require:
-      - user: etcd
-      - group: etcd
   pkg.installed:
     - pkgs:
       - iptables


### PR DESCRIPTION
This dir is created by the etcd rpm, and permissions
are maintained by etcd when it is running

The salt and etcd disagree an what these permissions are
causing extra "changed" entries. As etcd is changing
them to what it needs, and the directory is created
by etcd (and its RPM) we should not try and manage it.