### PR TITLE
Change update orchestration to use systemctl

### DIFF
--- a/salt/orch/update.sls
+++ b/salt/orch/update.sls
@@ -44,7 +44,7 @@ update_modules:
     - tgt: {{ master_id }}
     - name: cmd.run
     - arg:
-      - rebootmgrctl reboot now
+      - systemctl reboot
     - require:
       - salt: {{ master_id }}-clean-shutdown
 
@@ -96,7 +96,7 @@ update_modules:
     - tgt: {{ worker_id }}
     - name: cmd.run
     - arg:
-      - rebootmgrctl reboot now
+      - systemctl reboot
     - require:
       - salt: {{ worker_id }}-clean-shutdown
 


### PR DESCRIPTION
We were using rebootmgr, but with that service disabled
we now need to use systemctl.

Salt has a bug where it will mark any call to `system.reboot` as
failed when a system actually reboots, so we cannot use the
built-in salt methods.

See saltstack/salt#24297 and saltstack/salt#31557