### PR TITLE
Fixing broken build

### DIFF
--- a/salt/etcd/init.sls
+++ b/salt/etcd/init.sls
@@ -40,7 +40,6 @@ etcd:
       - sls: cert
       - pkg: etcd
       - iptables: etcd
-      - file: /var/lib/etcd
     - watch:
       - file: /etc/sysconfig/etcd
 


### PR DESCRIPTION
Need to remove a reference to /var/lib/etcd if salt isn't managing it
anymore