### PR TITLE
Option for using the proxy settings system-wide (bsc#1036627)

### DIFF
--- a/pillar/params.sls
+++ b/pillar/params.sls
@@ -65,6 +65,7 @@ proxy:
   http:           ''
   https:          ''
   no_proxy:       ''
+  systemwide:     'true'
 
 # Configuration for the reboot manager (https://github.com/SUSE/rebootmgr).
 # notes:

--- a/salt/proxy/init.sls
+++ b/salt/proxy/init.sls
@@ -1,0 +1,12 @@
+{% if salt['pillar.get']('proxy:systemwide', '').lower() == 'true' %}
+
+/etc/sysconfig/proxy:
+  file.managed:
+    - makedirs: True
+    - contents: |
+        PROXY_ENABLED="yes"
+        HTTP_PROXY="{{ salt['pillar.get']('proxy:http', '') }}"
+        HTTPS_PROXY="{{ salt['pillar.get']('proxy:https', '') }}"
+        NO_PROXY="{{ pillar['dashboard'] }},{{ salt['pillar.get']('proxy:no_proxy', '') }}"
+
+{% endif %}

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -5,6 +5,7 @@ base:
   'roles:kube-(master|minion)':
     - match: grain_pcre
     - ca-cert
+    - proxy
     - repositories
     - motd
     - users


### PR DESCRIPTION
We will use the proxy settings system-wide when `pillar["proxy:systemwide"]` is set to `true` (enabled by default).

### How to test it

* invoke `k8s-setup` with `-Vpillar=proxy:http~http://error.com:8080,proxy:https~https://error.com:443`. This will add some additional Pillar values for setting the proxy.
* create the cluster
* orchestrate
* `ssh` into the machines and verify that `/etc/sysconfig/proxy` has the values we set in the Pillar
* from one of the master/minions, do `curl www.suse.com` and verify it fails (because the proxy is incorrect)
* from one of the master/minions, do `curl <dashboard-IP>` and verify it dumps the HTML code for the Dashboard.
* from one of the master/minions, do `docker pull alpine` and verify it fails.