### PR TITLE
Only run `service.dead` on salt minions that we know support it.

### DIFF
--- a/salt/orch/kubernetes.sls
+++ b/salt/orch/kubernetes.sls
@@ -1,6 +1,7 @@
 disable_rebootmgr:
   salt.state:
-    - tgt: '*'
+    - tgt: 'roles:kube-(master|minion)'
+    - tgt_type: grain_pcre
     - sls:
       - rebootmgr
 


### PR DESCRIPTION
The `ca` container was reporting this error during the orchestration:

```
service.dead	{
    "__run_num__": 0,
    "_stamp": "2017-06-12T10:33:29.009340",
    "changes": {},
    "comment": "State 'service.dead' was not found in SLS 'rebootmgr'\nReason: 'service' __virtual__ returned False: No service execution module loaded: check support for service management on SLES-12 \n",
    "name": "rebootmgr",
    "result": false,
    "retcode": 2
}
```

Also, the overall result of the orchestration was not successfully (despite
individual highstates reported success) because of this. Containers don't
have `systemctl` available, so `salt` doesn't know how to handle this.

Right now, rely on our roles for doing this (despite we could have used
`virtual` grain -- but for some reason a container reports `physical`, which
doesn't help) -- at least with the `salt` version we are currently using.

The orchestration result overall looks like this with this change:

```
        "outputter": "highstate",
        "retcode": 0
    },
    "success": true,
    "user": "saltapi"
}
```