### PR TITLE
Remove concurrent=True from orchestrations

### DIFF
--- a/salt/orch/kubernetes.sls
+++ b/salt/orch/kubernetes.sls
@@ -9,7 +9,6 @@ hostname_setup:
   salt.state:
     - tgt: 'roles:kube-(master|minion)'
     - tgt_type: grain_pcre
-    - concurrent: True
     - sls:
       - hostname
 
@@ -38,7 +37,6 @@ etc_hosts_setup:
   salt.state:
     - tgt: 'roles:kube-(master|minion)'
     - tgt_type: grain_pcre
-    - concurrent: True
     - sls:
       - etc-hosts
     - require:


### PR DESCRIPTION
Salt's documentation calls this option out as dangerous, staging
that the state must be able to be ran concurrently. This is not
something we can reasonably ensure works, so lets not use it.

From Salt's documentation:

    This flag is potentially dangerous. It is designed for use
    when multiple state runs can safely be run at the same
    time. Do not use this flag for performance optimization.