### PR TITLE
Ensure that reactor states only run on completed nodes

### DIFF
--- a/salt/orch/kubernetes.sls
+++ b/salt/orch/kubernetes.sls
@@ -126,3 +126,13 @@ reboot_setup:
       - reboot
     - require:
       - salt: kube_master_setup
+
+set_bootstrap_grain:
+  salt.function:
+    - tgt: 'roles:kube-(master|minion)'
+    - name: grains.setval
+    - arg:
+      - bootstrap_complete
+      - true
+    - require:
+      - salt: reboot_setup

--- a/salt/orch/update-etc-hosts.sls
+++ b/salt/orch/update-etc-hosts.sls
@@ -10,8 +10,8 @@ update_grains:
 
 update_mine:
   salt.function:
-    - tgt: 'roles:kube-(master|minion)'
-    - tgt_type: grain_pcre
+    - tgt: 'P@roles:kube-(master|minion) and G@bootstrap_complete:true'
+    - tgt_type: compound
     - name: mine.update
     - require:
       - salt: update_pillar
@@ -19,8 +19,8 @@ update_mine:
 
 etc_hosts_setup:
   salt.state:
-    - tgt: 'roles:kube-(master|minion)'
-    - tgt_type: grain_pcre
+    - tgt: 'P@roles:kube-(master|minion) and G@bootstrap_complete:true'
+    - tgt_type: compound
     - queue: True
     - sls:
       - etc-hosts
@@ -29,8 +29,8 @@ etc_hosts_setup:
 
 kube_master_setup:
   salt.state:
-    - tgt: 'roles:kube-master'
-    - tgt_type: grain
+    - tgt: 'G@roles:kube-master and G@bootstrap_complete:true'
+    - tgt_type: compound
     - queue: True
     - sls:
       - kubernetes-master


### PR DESCRIPTION
This ensures that we do not run reactor orchestrations on
nodes that have not completed bootstrapping.

This ensures that a node cannot have 2 states applied to
it at the same time.