### PR TITLE
Making the cluster-dns and cluster-domain arguments default

### DIFF
--- a/salt/kubernetes-minion/kubelet.jinja
+++ b/salt/kubernetes-minion/kubelet.jinja
@@ -19,10 +19,8 @@ KUBELET_API_SERVER="--api-servers={{ api_server_url }}"
 
 # Add your own!
 KUBELET_ARGS="\
-{% if pillar.get('addons', '').lower() == 'true' -%}
     --cluster-dns={{ pillar['dns']['cluster_ip'] }} \
     --cluster-domain={{ pillar['dns']['domain'] }} \
-{% endif -%}
     --node-ip={{ grains['ip4_interfaces']['eth0'][0] }} \
 {% if grains['lsb_distrib_id'] == "CAASP" -%}
     --pod-manifest-path=/etc/kubernetes/manifests \


### PR DESCRIPTION
Right now, caasp doesn't support kube-dns out of the box.
If customers wanted to have dns support, they have to bring it up on
their own by using `kubectl create -f kubedns.yaml`. But this will not
work until you add the cluster-dns and cluster-domain arguments to
kubelet args and restart the kubelet.

While doing this manually in every node is one pain point, salt will try
to bring it back to its original state. Meaning that the changes you
made to the kubelet args will no longer be there. So, unless you bring up
the caasp cluster with the addon set to true, you cannot have kube-dns
working reliably on the cluster.

This change will make it a little easier, by having these arguements by
default in every node.