### PR TITLE
salt-api: listen to localhost [bsc#1043589]

### DIFF
--- a/config/master.d/api.conf
+++ b/config/master.d/api.conf
@@ -1,5 +1,5 @@
 rest_cherrypy:
-  interface: 0.0.0.0
+  host: 127.0.0.1
   port: 8000
   disable_ssl: true
 


### PR DESCRIPTION
Do not expose the salt-api to the entire world. This is needed only by Velum to trigger salt actions. Given both the containers use the same network namespace we can just bind this service to localhost.

By doing that we are going to reduce the attack surface.

This fixes one of the two issues reported by bsc#1043589

Note well: `interface` is not a valid option for salt-api, see [here](https://docs.saltstack.com/en/latest/ref/netapi/all/salt.netapi.rest_cherrypy.html).