### PR TITLE
WIP: Additional certificates for repositories for Docker (bsc#1039877)

### DIFF
--- a/pillar/certificates.sls
+++ b/pillar/certificates.sls
@@ -14,3 +14,13 @@ certificate_information:
   days_remaining:
     ca_certificate: 90
     certificate: 90
+
+# we can add certificates for particular registries like this:
+#
+# registries:
+#  - "something.com:5000": |
+#    <CA contents>
+#  - "some-other.com:6000": |
+#    <CA contents>
+#
+registries: []

--- a/salt/docker/init.sls
+++ b/salt/docker/init.sls
@@ -3,6 +3,25 @@ include:
   - flannel
 
 ######################
+# additional ca.crt(s)
+#######################
+
+{%- set registries = salt['pillar.get']('registries', []) %}
+{%- for registry in registries %}
+  {%- for host_port, cert in registry.items() %}
+    {% set host = host_port.split(":")[0] %}
+/etc/docker/certs.d/{{ host_port }}/ca.crt:
+  file.managed:
+    - makedirs: True
+    - contents: |
+        {{ cert | indent(8) }}
+  {%- endfor %}
+{%- endfor %}
+
+# ... from https://docs.docker.com/registry/insecure/#using-self-signed-certificates
+# we do not need to restart docker after adding a certificate
+
+######################
 # proxy for the daemon
 #######################
 


### PR DESCRIPTION
Follow the instruction found [here](https://docs.docker.com/registry/insecure/#using-self-signed-certificates) for adding customers' certificates to Docker so they can pull from other registries.

## How to test this

* download [the caasp-registry.sh script](https://github.com/inercia/caasp-tf/blob/master/provision/admin/caasp-registry.sh) and copy it to `/root` in the Admin Node
* `ssh admin-node` and `./caasp-registry.sh start`. That will generate the certificates in the `/root/certificates.local` and start the registry.
* Import the `alpine` image to the registry with `./caasp-registry.sh import alpine`
* edit the `/usr/share/salt/kubernetes/pillar/certificates.sls` in the Admin Node and add the `/root/certificates.local/ca.pem` certificate as:
    ```
    repositories:
        - dashboard:5000: |
             ---- BEGIN CERTIFICATE -----
             ...
    ```
* orchestrate
* get the Admin Node's `IP` and `ssh node1` and `echo "IP dashboard" > /etc/hosts`
* try to pull the `alpine` image from the registry with `docker pull dashboard:5000/alpine`. After that, you should see the `dashboard:5000/alpine` image when doing `docker images`.

## TODO:
- [x] more testing
- [x] document how to test it
- [ ] update the pillar format
