### PR TITLE
Add missing `tgt_type` so we target the minions we intend to

### DIFF
--- a/salt/orch/kubernetes.sls
+++ b/salt/orch/kubernetes.sls
@@ -130,6 +130,7 @@ reboot_setup:
 set_bootstrap_grain:
   salt.function:
     - tgt: 'roles:kube-(master|minion)'
+    - tgt_type: grain_pcre
     - name: grains.setval
     - arg:
       - bootstrap_complete


### PR DESCRIPTION
This last step on the orchestration was returning a `False` result
because no targets were found to execute the grain set.

I can confirm before this change the orchestration returned 1 failed state, and after the change it returns success.