### PR TITLE
Do not fail if `salt.function` has no minions to target

### DIFF
--- a/salt/orch/update-etc-hosts.sls
+++ b/salt/orch/update-etc-hosts.sls
@@ -1,11 +1,14 @@
+{% if salt.saltutil.runner('mine.get', tgt='P@roles:kube-(master|minion) and G@bootstrap_complete:true', fun='caasp_fqdn', tgt_type='compound')|length > 0 %}
 update_pillar:
   salt.function:
-    - tgt: '*'
+    - tgt: 'P@roles:kube-(master|minion) and G@bootstrap_complete:true'
+    - tgt_type: compound
     - name: saltutil.refresh_pillar
 
 update_grains:
   salt.function:
-    - tgt: '*'
+    - tgt: 'P@roles:kube-(master|minion) and G@bootstrap_complete:true'
+    - tgt_type: compound
     - name: saltutil.refresh_grains
 
 update_mine:
@@ -36,3 +39,4 @@ kube_master_setup:
       - kubernetes-master
     - require:
       - salt: etc_hosts_setup
+{% endif %}


### PR DESCRIPTION
Currently, `update-etc-hosts` orchestration fails because `update_mine`
`salt.function` cannot target any minions at the beginning, and since
this is a prerequisite for other states, the Reactor orchestration
fails.

Only call to these `salt.function` if there are any minions to target.