### PR TITLE
Do not run etcd discovery on every orchestration run, only the first time

### DIFF
--- a/salt/etcd-discovery/init.sls
+++ b/salt/etcd-discovery/init.sls
@@ -9,7 +9,7 @@ etcd-discovery-setup:
     - name: curl
   cmd.run:
     - name: curl -L -X PUT {{ etcd_size_uri }} -d value={{ salt.k8s_etcd.get_cluster_size() }}
-    - unless: curl {{ etcd_size_uri }} | grep '"value":"{{ salt.k8s_etcd.get_cluster_size() }}"'
+    - onlyif: curl {{ etcd_size_uri }} | grep '"message":"Key not found"'
     - require:
       - pkg: curl
 


### PR DESCRIPTION
When adding new nodes, the `orch.kubernetes` orchestration was failing because
etcd is refusing to start since the etcd discovery mechanism was already used
when bootstrapping the cluster.

With this change we ensure that we use the discovery mechanism only when we
are boostrapping the cluster (no machines have the `bootstrap_complete` grain
set to true).

Required for the add nodes feature.