### PR TITLE
Turn off `auto_accept`

### DIFF
--- a/config/master.d/master.conf
+++ b/config/master.d/master.conf
@@ -1,5 +1,5 @@
 user: root
-auto_accept: True
+auto_accept: False
 interface: 0.0.0.0
 event_return: mysql
 presence_events: True


### PR DESCRIPTION
This works in conjunction with 

https://github.com/kubic-project/caasp-container-manifests/pull/62 and 
https://github.com/kubic-project/velum/pull/206

to allow explicit acceptance of nodes into salt. 