### PR TITLE
Set MySQL as the job cache for the Salt master

### DIFF
--- a/config/master.d/master.conf
+++ b/config/master.d/master.conf
@@ -5,6 +5,11 @@ event_return: mysql
 presence_events: True
 worker_threads: 10
 timeout: 20
+
+master_job_cache: mysql
+job_cache: False
+keep_jobs: 24
+
 file_roots:
   base:
     - /usr/share/salt/kubernetes/salt


### PR DESCRIPTION
First of all, we can specify an external job cache. If we don't do that,
then the `keep_jobs` option only applies to the local cache. This means that
Salt will not clean up jobs, events and returns older than the specified
`keep_jobs` value (default: 24h) for the MySQL returner that we have already
configured.

Moreover, since we'd already be using MySQL as a job cache, we don't
have to use the local system (/var/cache/salt/master/jobs/) as a cache
(note that Salt would still be using this directory to avoid JID
collisions). The documentation also says that the local cache can be a
burden for large deployments.

See bsc#1044133

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>