### PR TITLE
bsc#1045381 Ensure updates do not conflict with etc-hosts

### DIFF
--- a/salt/orch/update-etc-hosts.sls
+++ b/salt/orch/update-etc-hosts.sls
@@ -1,19 +1,19 @@
-{% if salt.saltutil.runner('mine.get', tgt='P@roles:kube-(master|minion) and G@bootstrap_complete:true', fun='caasp_fqdn', tgt_type='compound')|length > 0 %}
+{% if salt.saltutil.runner('mine.get', tgt='P@roles:kube-(master|minion) and G@bootstrap_complete:true and not G@update_in_progress:true', fun='caasp_fqdn', tgt_type='compound')|length > 0 %}
 update_pillar:
   salt.function:
-    - tgt: 'P@roles:kube-(master|minion) and G@bootstrap_complete:true'
+    - tgt: 'P@roles:kube-(master|minion) and G@bootstrap_complete:true and not G@update_in_progress:true'
     - tgt_type: compound
     - name: saltutil.refresh_pillar
 
 update_grains:
   salt.function:
-    - tgt: 'P@roles:kube-(master|minion) and G@bootstrap_complete:true'
+    - tgt: 'P@roles:kube-(master|minion) and G@bootstrap_complete:true and not G@update_in_progress:true'
     - tgt_type: compound
     - name: saltutil.refresh_grains
 
 update_mine:
   salt.function:
-    - tgt: 'P@roles:kube-(master|minion) and G@bootstrap_complete:true'
+    - tgt: 'P@roles:kube-(master|minion) and G@bootstrap_complete:true and not G@update_in_progress:true'
     - tgt_type: compound
     - name: mine.update
     - require:
@@ -22,7 +22,7 @@ update_mine:
 
 etc_hosts_setup:
   salt.state:
-    - tgt: 'P@roles:kube-(master|minion) and G@bootstrap_complete:true'
+    - tgt: 'P@roles:kube-(master|minion) and G@bootstrap_complete:true and not G@update_in_progress:true'
     - tgt_type: compound
     - queue: True
     - sls:
@@ -32,7 +32,7 @@ etc_hosts_setup:
 
 kube_master_setup:
   salt.state:
-    - tgt: 'G@roles:kube-master and G@bootstrap_complete:true'
+    - tgt: 'G@roles:kube-master and G@bootstrap_complete:true and not G@update_in_progress:true'
     - tgt_type: compound
     - queue: True
     - sls:


### PR DESCRIPTION
This ensure that the etc-hosts orchestration does not
run during an upgrade, as this can cause conflicts on
the nodes, which cause salt to fail to complete an
`orch.update` run.