### PR TITLE
Apply select states to Admin node

### DIFF
--- a/salt/etc-hosts/hosts.jinja
+++ b/salt/etc-hosts/hosts.jinja
@@ -1,4 +1,15 @@
-### kubernetes API server(s) ###
+### admin nodes ###
+{%- set admins = salt['mine.get']('roles:admin', 'network.ip_addrs', 'grain') %}
+{%- for admin_id, addrlist in admins.items() %}
+	{%- if addrlist is string %}
+		{%- set ip = addrlist %}
+	{%- else %}
+		{%- set ip = addrlist|first %}
+	{%- endif %}
+{{ ip }} {{ admin_id }} {{ admin_id }}.{{ pillar['internal_infra_domain'] }}
+{%- endfor %}
+
+### kubernetes masters ###
 {%- set masters = salt['mine.get']('roles:kube-master', 'network.ip_addrs', 'grain') %}
 {%- for master_id, addrlist in masters.items() %}
 	{%- if addrlist is string %}
@@ -9,7 +20,7 @@
 {{ ip }} api api.{{ pillar['internal_infra_domain'] }} {{ master_id }} {{ master_id }}.{{ pillar['internal_infra_domain'] }}
 {%- endfor %}
 
-### kubernetes minions ###
+### kubernetes workers ###
 {%- set minions = salt['mine.get']('roles:kube-minion', 'network.ip_addrs', 'grain') %}
 {%- for minion_id, addrlist in minions.items() %}
 	{%- if addrlist is string %}
@@ -19,4 +30,3 @@
 	{%- endif %}
 {{ ip }} {{ minion_id }} {{ minion_id }}.{{ pillar['internal_infra_domain'] }}
 {%- endfor %}
-

--- a/salt/etc-hosts/init.sls
+++ b/salt/etc-hosts/init.sls
@@ -1,3 +1,5 @@
+{# In Kubernetes, /etc/hosts is mounted in from the host. file.blockreplace fails on this #}
+{% if salt['grains.get']('virtual_subtype', None) != 'Docker' %}
 /etc/hosts:
   file.blockreplace:
     - marker_start: "#-- start Salt-CaaSP managed hosts - DO NOT MODIFY --"
@@ -5,3 +7,9 @@
     - source:       salt://etc-hosts/hosts.jinja
     - template:     jinja
     - append_if_not_found: True
+{% else %}
+{# See https://github.com/saltstack/salt/issues/14553 #}
+dummy_step:
+  cmd.run:
+    - name: "echo saltstack bug 14553"
+{% endif %}

--- a/salt/orch/kubernetes.sls
+++ b/salt/orch/kubernetes.sls
@@ -7,7 +7,7 @@ disable_rebootmgr:
 
 hostname_setup:
   salt.state:
-    - tgt: 'roles:kube-(master|minion)'
+    - tgt: 'roles:(admin|kube-(master|minion))'
     - tgt_type: grain_pcre
     - sls:
       - hostname
@@ -43,7 +43,7 @@ update_modules:
 
 etc_hosts_setup:
   salt.state:
-    - tgt: 'roles:kube-(master|minion)'
+    - tgt: 'roles:(admin|kube-(master|minion))'
     - tgt_type: grain_pcre
     - sls:
       - etc-hosts
@@ -94,6 +94,15 @@ flannel_setup:
     - require:
       - salt: etcd_proxy_setup
 
+admin_setup:
+  salt.state:
+    - tgt: 'roles:admin'
+    - tgt_type: grain
+    - highstate: True
+    - batch: 5
+    - require:
+      - salt: flannel_setup
+
 kube_master_setup:
   salt.state:
     - tgt: 'roles:kube-master'
@@ -101,7 +110,7 @@ kube_master_setup:
     - highstate: True
     - batch: 5
     - require:
-      - salt: flannel_setup
+      - salt: admin_setup
 
 kube_minion_setup:
   salt.state:
@@ -125,7 +134,7 @@ reboot_setup:
 
 set_bootstrap_grain:
   salt.function:
-    - tgt: 'roles:kube-(master|minion)'
+    - tgt: 'roles:(admin|kube-(master|minion))'
     - tgt_type: grain_pcre
     - name: grains.setval
     - arg:

--- a/salt/orch/kubernetes.sls
+++ b/salt/orch/kubernetes.sls
@@ -1,6 +1,6 @@
 disable_rebootmgr:
   salt.state:
-    - tgt: 'roles:kube-(master|minion)'
+    - tgt: 'roles:(admin|kube-(master|minion))'
     - tgt_type: grain_pcre
     - sls:
       - rebootmgr

--- a/salt/orch/update-etc-hosts.sls
+++ b/salt/orch/update-etc-hosts.sls
@@ -1,19 +1,22 @@
-{% if salt.saltutil.runner('mine.get', tgt='P@roles:kube-(master|minion) and G@bootstrap_complete:true and not G@update_in_progress:true', fun='caasp_fqdn', tgt_type='compound')|length > 0 %}
+{%- set updates_all_target = 'P@roles:(admin|kube-(master|minion)) and G@bootstrap_complete:true and not G@update_in_progress:true' %}
+{%- set updates_master_target = 'G@roles:kube-master and G@bootstrap_complete:true and not G@update_in_progress:true' %}
+
+{%- if salt.saltutil.runner('mine.get', tgt=updates_all_target, fun='caasp_fqdn', tgt_type='compound')|length > 0 %}
 update_pillar:
   salt.function:
-    - tgt: 'P@roles:kube-(master|minion) and G@bootstrap_complete:true and not G@update_in_progress:true'
+    - tgt: {{ updates_all_target }}
     - tgt_type: compound
     - name: saltutil.refresh_pillar
 
 update_grains:
   salt.function:
-    - tgt: 'P@roles:kube-(master|minion) and G@bootstrap_complete:true and not G@update_in_progress:true'
+    - tgt: {{ updates_all_target }}
     - tgt_type: compound
     - name: saltutil.refresh_grains
 
 update_mine:
   salt.function:
-    - tgt: 'P@roles:kube-(master|minion) and G@bootstrap_complete:true and not G@update_in_progress:true'
+    - tgt: {{ updates_all_target }}
     - tgt_type: compound
     - name: mine.update
     - require:
@@ -22,7 +25,7 @@ update_mine:
 
 etc_hosts_setup:
   salt.state:
-    - tgt: 'P@roles:kube-(master|minion) and G@bootstrap_complete:true and not G@update_in_progress:true'
+    - tgt: {{ updates_all_target }}
     - tgt_type: compound
     - queue: True
     - sls:
@@ -32,7 +35,7 @@ etc_hosts_setup:
 
 kube_master_setup:
   salt.state:
-    - tgt: 'G@roles:kube-master and G@bootstrap_complete:true and not G@update_in_progress:true'
+    - tgt: {{ updates_master_target }}
     - tgt_type: compound
     - queue: True
     - sls:

--- a/salt/rebootmgr/init.sls
+++ b/salt/rebootmgr/init.sls
@@ -1,3 +1,11 @@
+{# In devenv, the rebootmgr service does not exist on admin #}
+{% if salt['grains.get']('virtual_subtype', None) != 'Docker' %}
 rebootmgr:
   service.dead:
     - enable: False
+{% else %}
+{# See https://github.com/saltstack/salt/issues/14553 #}
+rebootmgr_dummy_step:
+  cmd.run:
+    - name: "echo saltstack bug 14553"
+{% endif %}

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -6,6 +6,8 @@ base:
     - match: grain_pcre
     - hostname
     - etc-hosts
+    - rebootmgr
+    - transactional-update
   'roles:kube-(master|minion)':
     - match: grain_pcre
     - ca-cert
@@ -18,7 +20,6 @@ base:
     - flannel
     - docker
     - container-feeder
-    - transactional-update
   'roles:kube-master':
     - match: grain
     - kubernetes-master

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -2,6 +2,10 @@ base:
   'roles:ca':
     - match: grain
     - ca
+  'roles:(admin|kube-(master|minion))':
+    - match: grain_pcre
+    - hostname
+    - etc-hosts
   'roles:kube-(master|minion)':
     - match: grain_pcre
     - ca-cert
@@ -9,8 +13,6 @@ base:
     - repositories
     - motd
     - users
-    - hostname
-    - etc-hosts
     - cert
     - etcd-proxy
     - flannel

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -6,12 +6,12 @@ base:
     - match: grain_pcre
     - hostname
     - etc-hosts
+    - proxy
     - rebootmgr
     - transactional-update
   'roles:kube-(master|minion)':
     - match: grain_pcre
     - ca-cert
-    - proxy
     - repositories
     - motd
     - users

--- a/salt/transactional-update/init.sls
+++ b/salt/transactional-update/init.sls
@@ -1,3 +1,5 @@
+{# In devenv, the transactional-update service does not exist on admin #}
+{% if salt['grains.get']('virtual_subtype', None) != 'Docker' %}
 /etc/systemd/system/transactional-update.service.d/10-update-rebootmgr-options.conf:
   file.managed:
     - makedirs: true
@@ -27,3 +29,10 @@ transactional-update.timer:
     - enable: True
     - watch:
       - file: /etc/systemd/system/transactional-update.timer.d/10-increase-update-speed.conf
+{% else %}
+{# See https://github.com/saltstack/salt/issues/14553 #}
+transactional_update_dummy_step:
+  cmd.run:
+    - name: "echo saltstack bug 14553"
+{% endif %}
+


### PR DESCRIPTION
Render the /etc/hosts file on the admin node, so nodes are reacable via
their internal FQDNs everywhere. Additionally, include the admin node
in the /etc/hosts files. (bsc#1045186)

Once the system bootstraps, we now disable rebootmgr on the
admin node. This allows the velum initiated updates to takeover
and prevent any unexpected surprises. (bsc#1046602)

Adds the proxy setup to the admin node (bsc#1043538)