### PR TITLE
Increase salt-master timeout

### DIFF
--- a/config/master.d/master.conf
+++ b/config/master.d/master.conf
@@ -4,6 +4,7 @@ interface: 0.0.0.0
 event_return: mysql
 presence_events: True
 worker_threads: 10
+timeout: 20
 file_roots:
   base:
     - /usr/share/salt/kubernetes/salt


### PR DESCRIPTION
When dealing with a large number of minions, timeouts are visible when
using the default value of 5 seconds. Increasing the CPU/RAM resources
allocated to the master helps, but given it it's short bursts of heavy usage
(bootstrap and upgrade), this shouldn't be necessary.

We increase the timeout from 5 to 20 seconds, allowing tasks to take longer
yet still succeed.