### PR TITLE
Handle curl proxy settings

### DIFF
--- a/salt/proxy/init.sls
+++ b/salt/proxy/init.sls
@@ -9,4 +9,10 @@
         HTTPS_PROXY="{{ salt['pillar.get']('proxy:https', '') }}"
         NO_PROXY="{{ pillar['dashboard'] }},{{ salt['pillar.get']('proxy:no_proxy', '') }}"
 
+/root/.curlrc:
+  file.managed:
+    - contents: |
+        --proxy "{{ salt['pillar.get']('proxy:http', '') }}"
+        --noproxy "{{ pillar['dashboard'] }},{{ salt['pillar.get']('proxy:no_proxy', '') }}"
+
 {% endif %}


### PR DESCRIPTION
YaST is also configuring proxy settings inside of `/root/.curlrc`, this is needed because zypper is using libcurl. So if you run zypper from a cronjob or `su`, the `/etc/sysconfig/proxy` variables are not parsed
and set in the environment. Which means, zypper will not use the proxy and fail. With `/root/.curlrc`, libcurl will use the proxies configured there.

Thanks to @thkukuk for the [explanation](https://github.com/kubic-project/velum/pull/214#issuecomment-311910779).