### PR TITLE
Define etcdctl config file with SSL variables

### DIFF
--- a/salt/etcd/etcdctl.conf.jinja
+++ b/salt/etcd/etcdctl.conf.jinja
@@ -1,0 +1,4 @@
+ETCDCTL_ENDPOINT="https://{{ grains['caasp_fqdn'] }}:2379"
+ETCDCTL_CA_FILE={{ pillar['ssl']['ca_file'] }}
+ETCDCTL_CERT_FILE={{ pillar['ssl']['crt_file'] }}
+ETCDCTL_KEY_FILE={{ pillar['ssl']['key_file'] }}

--- a/salt/etcd/init.sls
+++ b/salt/etcd/init.sls
@@ -55,3 +55,16 @@ etcd:
       - pkg: etcd
       - user: etcd
       - group: etcd
+
+# note: this will be used to run etcdctl client command
+/etc/sysconfig/etcdctl:
+  file.managed:
+    - source: salt://etcd/etcdctl.conf.jinja
+    - template: jinja
+    - user: etcd
+    - group: etcd
+    - mode: 644
+    - require:
+      - pkg: etcd
+      - user: etcd
+      - group: etcd


### PR DESCRIPTION
Let's add /etc/sysconfig/etcdctl with paths to the client
server TLS files and endpoint. This will make possible to run
etcdctl command in easy way, e.g.

  source /etc/sysconfig/etcdctl
  etcdctl cluster-health