### PR TITLE
Match up TLS cert generation to genca.sh

### DIFF
--- a/salt/ca/signing_policies.conf
+++ b/salt/ca/signing_policies.conf
@@ -3,8 +3,8 @@ x509_signing_policies:
     - minions: '*'
     - signing_private_key: /etc/pki/private/ca.key
     - signing_cert: /etc/pki/ca.crt
-    - basicConstraints: "critical CA:false"
-    - keyUsage: "critical keyEncipherment"
+    - basicConstraints: "CA:false"
+    - keyUsage: "nonRepudiation digitalSignature keyEncipherment"
     - subjectKeyIdentifier: hash
-    - authorityKeyIdentifier: keyid,issuer:always
+    - authorityKeyIdentifier: keyid
     - copypath: /etc/pki/issued_certs/


### PR DESCRIPTION
* Remove critical constraints
* Add nonRepudiation and digitalSignature key usages
* Include only the keyid Authority Identifier

Matches to https://github.com/kubic-project/caasp-container-manifests/pull/75

bsc#1046708