### PR TITLE
Fix JINJA escaping for docker_opts in docker state module

### DIFF
--- a/salt/docker/init.sls
+++ b/salt/docker/init.sls
@@ -25,7 +25,7 @@ include:
 {% set docker_opts = salt['pillar.get']('docker:args', '')%}
 {% set docker_reg  = salt['pillar.get']('docker:registry', '') %}
 {% if docker_reg|length > 0 %}
-  {% set docker_opts = docker_opts + " --insecure-registry={{ docker_reg }} --registry-mirror=http://{{ docker_reg }}" %}
+  {% set docker_opts = docker_opts + " --insecure-registry=" + docker_reg + " --registry-mirror=http://" + docker_reg  %}
 {% endif %}
 
 docker:


### PR DESCRIPTION
Fix is easy so I didn't open bug for it.