### PR TITLE
Add kubectl client certificate

### DIFF
--- a/salt/kubectl-client-cert/init.sls
+++ b/salt/kubectl-client-cert/init.sls
@@ -1,0 +1,28 @@
+include:
+  - crypto
+
+/etc/pki/kubectl-client-cert.key:
+  x509.private_key_managed:
+    - bits: 4096
+    - user: root
+    - group: root
+    - mode: 444
+    - require:
+      - sls:  crypto
+      - file: /etc/pki
+
+/etc/pki/kubectl-client-cert.crt:
+  x509.certificate_managed:
+    - ca_server: {{ salt['mine.get']('roles:ca', 'ca.crt', expr_form='grain').keys()[0] }}
+    - signing_policy: minion
+    - public_key: /etc/pki/kubectl-client-cert.key
+    - CN: CaaSP
+    - days_valid: {{ pillar['certificate_information']['days_valid']['certificate'] }}
+    - days_remaining: {{ pillar['certificate_information']['days_remaining']['certificate'] }}
+    - backup: True
+    - user: root
+    - group: root
+    - mode: 644
+    - require:
+      - sls:  crypto
+      - x509: /etc/pki/kubectl-client-cert.key

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -23,6 +23,7 @@ base:
   'roles:kube-master':
     - match: grain
     - kubernetes-master
+    - kubectl-client-cert
   'roles:kube-minion':
     - match: grain
     - kubernetes-minion


### PR DESCRIPTION
This certificate will be served by Velum when downloading the `kubeconfig`
file, and is specific for that usage.

Fixes: bsc#1046963