### PR TITLE
When generating the certificate use the pillar path

### DIFF
--- a/salt/cert/init.sls
+++ b/salt/cert/init.sls
@@ -48,7 +48,7 @@ include:
   x509.certificate_managed:
     - ca_server: {{ salt['mine.get']('roles:ca', 'ca.crt', expr_form='grain').keys()[0] }}
     - signing_policy: minion
-    - public_key: /etc/pki/minion.key
+    - public_key: {{ pillar['ssl']['key_file'] }}
     - CN: {{ grains['caasp_fqdn'] }}
     - C: {{ pillar['certificate_information']['subject_properties']['C']|yaml_dquote }}
     - Email: {{ pillar['certificate_information']['subject_properties']['Email']|yaml_dquote }}


### PR DESCRIPTION
Since we added the minion certificate location to the pillar, also
take the public key location from the pillar, or the certificate
generation will fail if the pillar value changes.