### PR TITLE
Add prerequisite for key to be present on `cert` sls

### DIFF
--- a/salt/cert/init.sls
+++ b/salt/cert/init.sls
@@ -71,4 +71,4 @@ include:
     - mode: 644
     - require:
       - sls:  crypto
-      - file: /etc/pki
+      - x509: {{ pillar['ssl']['key_file'] }}


### PR DESCRIPTION
Add a specific dependency for the key to be present when generating
the certificate for the minion.