### PR TITLE
[WIP] Add IPv4/IPv6 entriees for the hostname (bsc#1044094)

### DIFF
--- a/salt/etc-hosts/hosts.jinja
+++ b/salt/etc-hosts/hosts.jinja
@@ -1,3 +1,8 @@
+### hostname resolved as IPv4 and IPv6 ###
+# note: this will probably lead to a dupliccated 127.0.0.1 entry, but not a big deal for localhost
+127.0.0.1  {{ grains['host'] }}
+::ffff:{{ grains['ip4_interfaces']['eth0'][0] }}  {{ grains['host'] }}
+
 ### admin nodes ###
 {%- set admins = salt['mine.get']('roles:admin', 'network.ip_addrs', 'grain') %}
 {%- for admin_id, addrlist in admins.items() %}


### PR DESCRIPTION
In order to get rid of the IPv4/IPv6 grain rendering warnings we must introduce some entries in `/etc/hosts` where the _hostname_ is resolved to the local IPs (IPv4 and IPv6) (the IPs are not really important as long as they are there).

Caveats and limitations:
* these entries will not be updated on `hostname` changes (I think we would need a new beacon for that).
* unconfigured hosts will contain entries like:

    ```
    127.0.0.1  linux
    ::ffff:192.168.122.70  linux
    ```
* `127.0.0.1` will probably have two entries in `/etc/hosts` (not a big deal, specially for `127.0.0.1`)