### PR TITLE
Revert "Set MySQL as the job cache for the Salt master"

### DIFF
--- a/config/master.d/master.conf
+++ b/config/master.d/master.conf
@@ -5,11 +5,6 @@ event_return: mysql
 presence_events: True
 worker_threads: 10
 timeout: 20
-
-master_job_cache: mysql
-job_cache: False
-keep_jobs: 24
-
 file_roots:
   base:
     - /usr/share/salt/kubernetes/salt


### PR DESCRIPTION
This reverts commit de22c660a99bc1425295c86be7d7dc3e79089845 / https://github.com/kubic-project/salt/pull/132

For some reason, enabling this means devenv and CI is broken:

                  ----------
                            ID: /etc/pki/minion.crt
                      Function: x509.certificate_managed
                        Result: False
                       Comment: An exception occurred in this state: Traceback (most recent call last):
                                  File "/usr/lib/python2.7/site-packages/salt/state.py", line 1746, in call
                                    **cdata['kwargs'])
                                  File "/usr/lib/python2.7/site-packages/salt/loader.py", line 1704, in wrapper
                                    return f(*args, **kwargs)
                                  File "/usr/lib/python2.7/site-packages/salt/states/x509.py", line 494, in certificate_managed
                                    new = __salt__['x509.create_certificate'](testrun=True, **kwargs)
                                  File "/usr/lib/python2.7/site-packages/salt/modules/x509.py", line 1374, in create_certificate
                                    arg=str(kwargs))[ca_server]
                                KeyError: 'ca'
                       Started: 19:35:32.171471
                      Duration: 5323.054 ms

I don't have the slighest clue why these are related.