### PR TITLE
Fix `ca` key path

### DIFF
--- a/salt/ca/init.sls
+++ b/salt/ca/init.sls
@@ -24,7 +24,7 @@ include:
     - group: root
     - mode: 755
 
-/etc/pki/ca.key:
+/etc/pki/private/ca.key:
   file.managed:
     - replace: false
     - user: root


### PR DESCRIPTION
This was a leftover from the previous implementation. Now the ca key
is present under `/etc/pki/private` in the ca container too (as it
mounts `/etc/pki`)