### PR TITLE
Ensure grains are always refreshed periodically

### DIFF
--- a/pillar/schedule.sls
+++ b/pillar/schedule.sls
@@ -1,0 +1,9 @@
+schedule:
+  update_grains:
+    function: event.fire
+    maxrunning: 1
+    minutes: 10
+    jid_include: true
+    args:
+    - {'force_refresh': True}
+    - grains_refresh

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -6,6 +6,7 @@ base:
     - certificates
     - ip_addrs
     - fqdn
+    - schedule
   'roles:kube-(master|minion)':
     - match: grain_pcre
     - beacons


### PR DESCRIPTION
Salt's grains_refresh_every configuration param does not quite do
what we need it to, it's failing to refresh grains from the `grains`
file - leading to updates going undetected.

This change adds a slightly modified version of what this config
param internally does, adding the force_refresh: True argument,
ensuring we correctly refresh.

bsc#1048583