### PR TITLE
Upgrade: Wait longer for minions to reboot

### DIFF
--- a/salt/orch/update.sls
+++ b/salt/orch/update.sls
@@ -60,6 +60,7 @@ update_modules:
 {{ master_id }}-wait-for-start:
   salt.wait_for_event:
     - name: salt/minion/*/start
+    - timeout: 1200
     - id_list:
       - {{ master_id }}
     - require:
@@ -130,6 +131,7 @@ update_modules:
 {{ worker_id }}-wait-for-start:
   salt.wait_for_event:
     - name: salt/minion/*/start
+    - timeout: 1200
     - id_list:
       - {{ worker_id }}
     - require:


### PR DESCRIPTION
Wait 1200 seconds (20 minutes) for minions to reboot, instead of the
default 300 seconds (5 minutes). We increase this to cover off cases
where slower to boot physical hardware is used.

20 minutes was chosen as, I've seen physical hardware take 10-12 minutes
in the past, and someone likely has something that is slower to reboot.

bsc#1048683

Backport of https://github.com/kubic-project/salt/pull/167