### PR TITLE
Explicitly refresh the mine on all minions after the `ca` has published the `ca.crt`

### DIFF
--- a/salt/orch/kubernetes.sls
+++ b/salt/orch/kubernetes.sls
@@ -66,8 +66,14 @@ etcd_discovery_setup:
     - sls:
       - etcd-discovery
     - require:
-      - salt: ca_setup
       - salt: update_modules
+
+refresh_mine:
+  salt.function:
+    - tgt: '*'
+    - name: mine.update
+    - require:
+      - salt: ca_setup
 
 etcd_proxy_setup:
   salt.state:
@@ -83,6 +89,7 @@ etcd_proxy_setup:
     - batch: 3
     - require:
       - salt: etcd_discovery_setup
+      - salt: refresh_mine
 
 flannel_setup:
   salt.state:


### PR DESCRIPTION
We will explicitly force all minions to refresh the mine after the `ca` minion has
published the `ca.crt` certificate on the mine, to avoid rendering problems with
later SLS being executed. It might happen that a minion was missing this information
on its mine, so the rendering of the SLS failed, effectively stopping the whole
orchestration process.

Fixes: bsc#1048548

This is a backport of https://github.com/kubic-project/salt/pull/169