### PR TITLE
Don't wait for minion responses when rebooting

### DIFF
--- a/salt/orch/update.sls
+++ b/salt/orch/update.sls
@@ -51,6 +51,7 @@ update_modules:
   salt.function:
     - tgt: {{ master_id }}
     - name: cmd.run
+    - bg: True
     - arg:
       - systemctl reboot
     - require:
@@ -122,6 +123,7 @@ update_modules:
   salt.function:
     - tgt: {{ worker_id }}
     - name: cmd.run
+    - bg: True
     - arg:
       - systemctl reboot
     - require:


### PR DESCRIPTION
When we instruct a minion to reboot, we can't reliably
wait for the response from salt-minion letting us know
that the "systemctl reboot" command succeeded, as systemd
may choose to shutdown the salt-minion service before it
can sent out the "Yes, that worked" response.

Salt does not make any attempt to finish in progress
tasks when it receives a SIGTERM, leaving us with few
other viable choices for this.