### PR TITLE
WIP: Refresh CA mine first, then the rest

### DIFF
--- a/salt/orch/kubernetes.sls
+++ b/salt/orch/kubernetes.sls
@@ -59,6 +59,21 @@ ca_setup:
       - salt: etc_hosts_setup
       - salt: update_mine
 
+refresh_ca_mine:
+  salt.function:
+    - tgt: 'roles:ca'
+    - tgt_type: grain
+    - name: mine.update
+    - require:
+      - salt: ca_setup
+
+refresh_all_mines:
+  salt.function:
+    - tgt: '*'
+    - name: mine.update
+    - require:
+      - salt: refresh_ca_mine
+
 etcd_discovery_setup:
   salt.state:
     - tgt: 'roles:kube-master'
@@ -67,13 +82,6 @@ etcd_discovery_setup:
       - etcd-discovery
     - require:
       - salt: update_modules
-
-refresh_mine:
-  salt.function:
-    - tgt: '*'
-    - name: mine.update
-    - require:
-      - salt: ca_setup
 
 etcd_proxy_setup:
   salt.state:
@@ -89,7 +97,7 @@ etcd_proxy_setup:
     - batch: 3
     - require:
       - salt: etcd_discovery_setup
-      - salt: refresh_mine
+      - salt: refresh_all_mines
 
 flannel_setup:
   salt.state:


### PR DESCRIPTION
After publishing the `ca.crt` into the mine, we need to make sure that
the `mine.update` happens first on the `ca`, so we know that it syncs
this information with the master first, then we can proceed to run
`mine.update` on all nodes, so they again sync with the master and
find the information the `ca` minion published on it.

Fixes: bsc#1049137
Fixes: bsc#1048548