### PR TITLE
Delay reboots during upgrade by 15 seconds

### DIFF
--- a/salt/orch/update.sls
+++ b/salt/orch/update.sls
@@ -57,9 +57,10 @@ update_modules:
   salt.function:
     - tgt: {{ master_id }}
     - name: cmd.run
-    - bg: True
     - arg:
-      - systemctl reboot
+      - sleep 15; systemctl reboot
+    - kwarg:
+        bg: True
     - require:
       - salt: {{ master_id }}-clean-shutdown
 
@@ -133,9 +134,10 @@ update_modules:
   salt.function:
     - tgt: {{ worker_id }}
     - name: cmd.run
-    - bg: True
     - arg:
-      - systemctl reboot
+      - sleep 15; systemctl reboot
+    - kwarg:
+        bg: True
     - require:
       - salt: {{ worker_id }}-clean-shutdown
 


### PR DESCRIPTION
Even with backgrounding the call, salt-minion sometimes still does not
have enough time to respond before systemd shuts down salt-minion on
some environments. By adding a 15 second delay, we give salt-minion
much more time than it should need in a healthy cluster to respond.

Additionally, switch from the deprecated syntax for supplying bg=True,
to the newer syntax which no longer logs a warning.

Followup up fix for bsc#1049200

Backport of https://github.com/kubic-project/salt/pull/181