### PR TITLE
Make the kubernetes version configurable

### DIFF
--- a/pillar/params.sls
+++ b/pillar/params.sls
@@ -39,6 +39,12 @@ kube_log_level:   '2'
 # install the addons (ie, DNS)
 addons:           'false'
 
+versions:
+  # kubernetes version to use
+  # it can be "" (no specifi version is foced, just installed), "latest",
+  # a specific version or (for Salt>=2017.7.0) a version with wildcards (ie, "1.5*")
+  kubernetes:     ''
+
 ssl:
   enabled:        true
   ca_dir:         '/etc/pki/trust/anchors'

--- a/salt/kubernetes-master/apiserver.jinja
+++ b/salt/kubernetes-master/apiserver.jinja
@@ -4,6 +4,8 @@
 # The following values are used to configure the kube-apiserver
 #
 
++{% set kubernetes_version = salt['pillar.get']('versions:kubernetes', '') %}
+
 # The address on the local server to listen to.
 KUBE_API_ADDRESS="--insecure-bind-address=127.0.0.1 --bind-address=0.0.0.0"
 
@@ -25,7 +27,13 @@ KUBE_ETCD_SERVERS="--etcd-servers=http://{{ grains['caasp_fqdn'] }}:2379"
 KUBE_SERVICE_ADDRESSES="--service-cluster-ip-range={{ pillar['services_cidr'] }}"
 
 # default admission control policies
+{% if kubernetes_version.startswith("1.6") or kubernetes_version.startswith("1.7") %}
+KUBE_ADMISSION_CONTROL="--admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,DefaultStorageClass,ResourceQuota,DefaultTolerationSeconds"
+{% elif kubernetes_version.startswith("1.4") or kubernetes_version.startswith("1.5") %}
+KUBE_ADMISSION_CONTROL="--admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota"
+{% else %}
 KUBE_ADMISSION_CONTROL="--admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota"
+{% endif %}
 
 # Add your own!
 KUBE_API_ARGS="--advertise-address={{ grains['ip4_interfaces']['eth0'][0] }} \


### PR DESCRIPTION
Make the kubernetes version configurable
Some minor improvements in dependencies between states.
Use the [recommended admission controllers](https://kubernetes.io/docs/admin/admission-controllers/#is-there-a-recommended-set-of-plug-ins-to-use) depending on the k8s version.