### PR TITLE
Kube-API: Set storage-backend to etcd2

### DIFF
--- a/salt/kube-apiserver/apiserver.jinja
+++ b/salt/kube-apiserver/apiserver.jinja
@@ -36,4 +36,5 @@ KUBE_API_ARGS="--advertise-address={{ grains['ip4_interfaces']['eth0'][0] }} \
                --tls-cert-file={{ pillar['ssl']['crt_file'] }} \
                --tls-private-key-file={{ pillar['ssl']['key_file'] }} \
                {{ salt['pillar.get']('components:apiserver:args', '') }} \
-               --client-ca-file={{ pillar['ssl']['ca_file'] }}"
+               --client-ca-file={{ pillar['ssl']['ca_file'] }} \
+               --storage-backend=etcd2"


### PR DESCRIPTION
In our current configuration, kube-api logs a series of errors unless this is
set.