### PR TITLE
Do not generate an empty --proxy line in curlrc

### DIFF
--- a/salt/proxy/init.sls
+++ b/salt/proxy/init.sls
@@ -1,18 +1,25 @@
 {% if salt['pillar.get']('proxy:systemwide', '').lower() == 'true' %}
 
+{% set proxy_http  = salt['pillar.get']('proxy:http', '') %}
+{% set proxy_https = salt['pillar.get']('proxy:https', '') %}
+{% set no_proxy    = salt['pillar.get']('proxy:no_proxy', '') %}
+
 /etc/sysconfig/proxy:
   file.managed:
     - makedirs: True
     - contents: |
         PROXY_ENABLED="yes"
-        HTTP_PROXY="{{ salt['pillar.get']('proxy:http', '') }}"
-        HTTPS_PROXY="{{ salt['pillar.get']('proxy:https', '') }}"
-        NO_PROXY="{{ pillar['dashboard'] }},{{ salt['pillar.get']('proxy:no_proxy', '') }}"
+        HTTP_PROXY="{{ proxy_http }}"
+        HTTPS_PROXY="{{ proxy_https }}"
+        NO_PROXY="{{ pillar['dashboard'] }},{{ no_proxy }}"
 
+# curl does not like an empty --proxy in curlrc...
+{% if proxy_http|length > 0 %}
 /root/.curlrc:
   file.managed:
     - contents: |
-        --proxy "{{ salt['pillar.get']('proxy:http', '') }}"
-        --noproxy "{{ pillar['dashboard'] }},{{ salt['pillar.get']('proxy:no_proxy', '') }}"
+        --proxy "{{ proxy_http }}"
+        --noproxy "{{ pillar['dashboard'] }},{{ no_proxy }}"
+{% endif %}
 
 {% endif %}


### PR DESCRIPTION
It is ok to generate empty values in `/etc/sysconfig/proxy`, but `curl` does not like having an empty `--proxy` line and generates some warnings...