### PR TITLE
Disable Salt's Job Cache

### DIFF
--- a/config/master.d/master.conf
+++ b/config/master.d/master.conf
@@ -1,3 +1,7 @@
+# Note to future editors of this file, salt's job cache
+# is buggy, usually showing itself at scale rather than
+# in small deployments. Test at scale before choosing to
+# enable it again.
 user: root
 auto_accept: False
 interface: 0.0.0.0
@@ -5,10 +9,6 @@ event_return: mysql
 presence_events: True
 worker_threads: 10
 timeout: 20
-
-master_job_cache: mysql
-job_cache: True
-keep_jobs: 24
 
 file_roots:
   base:


### PR DESCRIPTION
Salt's job cache is buggy, causing random failures to lookup mine data, which
in turn causes our deployments to fail.

Fixes bsc#1054256