### PR TITLE
Wait for the API server after starting the service

### DIFF
--- a/salt/addons/init.sls
+++ b/salt/addons/init.sls
@@ -31,14 +31,10 @@ include:
     - template:    jinja
 
 deploy_addons.sh:
-  # We need to wait for Kube API server to actually start, see k8s issue #47739
-  http.wait_for_successful_query:
-    - name:        'http://127.0.0.1:8080/healthz'
-    - status:      200
   cmd.script:
     - source:      salt://addons/deploy_addons.sh
     - require:
-      - service:   kube-apiserver
+      - kube-apiserver
       - file:      /etc/kubernetes/addons/namespace.yaml
       - file:      /etc/kubernetes/addons/kubedns-cm.yaml
       - file:      /etc/kubernetes/addons/kubedns-svc.yaml

--- a/salt/kube-apiserver/init.sls
+++ b/salt/kube-apiserver/init.sls
@@ -87,7 +87,6 @@ kube-apiserver:
       - kubernetes-master
     - require:
       - file: /etc/zypp/repos.d/containers.repo
-
   iptables.append:
     - table:      filter
     - family:     ipv4
@@ -115,3 +114,9 @@ kube-apiserver:
       - file:     kube-apiserver
       - sls:      ca-cert
       - {{ pillar['ssl']['kube_apiserver_crt'] }}
+  # wait for the API server (see k8s issue #47739) so it can be used
+  http.wait_for_successful_query:
+    - name:       'http://127.0.0.1:8080/healthz'
+    - status:     200
+    - require:
+      - service:  kube-apiserver


### PR DESCRIPTION
Wait for the API server port after starting the service. So we can just `require: kube-apiserver` for invoking  `kubectl` safely...