### PR TITLE
Use haproxy to load balance Kube API requests

### DIFF
--- a/pillar/params.sls
+++ b/pillar/params.sls
@@ -17,8 +17,10 @@ internal_infra_domain: 'infra.caasp.local'
 api:
   # the API service IP (must be inside the 'services_cidr')
   cluster_ip:     '172.24.0.1'
-  # port for listening for SSL connections
+  # port for listening for SSL connections (load balancer)
   ssl_port:       '6443'
+  # port for listening for SSL connections (kube-api)
+  int_ssl_port:   '6444'
 
 # DNS service IP and some other stuff (must be inside the 'services_cidr')
 dns:

--- a/salt/etc-hosts/hosts.jinja
+++ b/salt/etc-hosts/hosts.jinja
@@ -1,3 +1,6 @@
+### service names ###
+127.0.0.1 api api.{{ pillar['internal_infra_domain'] }}
+
 ### admin nodes ###
 {%- set admins = salt['mine.get']('roles:admin', 'network.ip_addrs', 'grain') %}
 {%- for admin_id, addrlist in admins.items() %}
@@ -17,7 +20,7 @@
 	{%- else %}
 		{%- set ip = addrlist|first %}
 	{%- endif %}
-{{ ip }} api api.{{ pillar['internal_infra_domain'] }} {{ master_id }} {{ master_id }}.{{ pillar['internal_infra_domain'] }}
+{{ ip }} {{ master_id }}.{{ pillar['internal_infra_domain'] }}
 {%- endfor %}
 
 ### kubernetes workers ###

--- a/salt/haproxy/haproxy.cfg.jinja
+++ b/salt/haproxy/haproxy.cfg.jinja
@@ -1,0 +1,30 @@
+{%- if "kube-master" in salt['grains.get']('roles', []) -%}
+{%- set bind_ip = "0.0.0.0" -%}
+{%- else -%}
+{%- set bind_ip = "127.0.0.1" -%}
+{%- endif -%}
+global
+        log /dev/log    local0
+        log /dev/log    local1 notice
+        daemon
+
+defaults
+        log     global
+        mode    tcp
+        option  tcplog
+        option  dontlognull
+        timeout connect 5000
+        timeout client 50000
+        timeout server 50000
+
+# Listen on the standard Kube-API Public port, 6443 by default, and proxy to the masters on
+# the Kube-API internal port, 6444 by default.
+listen kubernetes-master
+        bind {{ bind_ip }}:{{ pillar['api']['ssl_port'] }}
+        mode tcp
+        default-server inter 10s fall 3
+        balance roundrobin
+
+{%- for minion_id, _ in salt['mine.get']('roles:kube-master', 'network.ip_addrs', 'grain').items() %}
+        server master-{{ minion_id }} {{ minion_id }}.{{ pillar['internal_infra_domain'] }}:{{ pillar['api']['int_ssl_port'] }} check
+{% endfor -%}

--- a/salt/haproxy/haproxy.manifest
+++ b/salt/haproxy/haproxy.manifest
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: haproxy
+  namespace: kube-system
+  labels:
+    name: haproxy
+spec:
+  restartPolicy: Always
+  hostNetwork: true
+  tolerations:
+    - key: node-role.kubernetes.io/master
+      operator: Exists
+      effect: NoSchedule
+  containers:
+    - name: haproxy
+      image: sles12/haproxy:1.6.0
+      resources:
+        requests:
+          memory: 128Mi
+        limits:
+          memory: 128Mi
+      volumeMounts:
+        - name: haproxy-cfg
+          mountPath: /etc/haproxy
+  volumes:
+    - name: haproxy-cfg
+      hostPath:
+        path: /etc/haproxy

--- a/salt/haproxy/init.sls
+++ b/salt/haproxy/init.sls
@@ -1,0 +1,47 @@
+/etc/haproxy/haproxy.cfg:
+  file.managed:
+    - source: salt://haproxy/haproxy.cfg.jinja
+    - template: jinja
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
+    - dir_mode: 755
+
+haproxy:
+  file.managed:
+    - name: /etc/kubernetes/manifests/haproxy.yaml
+    - source: salt://haproxy/haproxy.manifest
+    - template: jinja
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
+    - dir_mode: 755
+{% if "kube-master" in salt['grains.get']('roles', []) %}
+  iptables.append:
+{% else %}
+  iptables.delete:
+{% endif %}
+    - table:      filter
+    - family:     ipv4
+    - chain:      INPUT
+    - jump:       ACCEPT
+    - match:      state
+    - connstate:  NEW
+    - dports:
+      - {{ pillar['api']['ssl_port'] }}
+    - proto:      tcp
+
+# Send a HUP to haproxy when the config changes
+# TODO: There should be a better way to handle this, but currently, there is not. See
+# kubernetes/kubernetes#24957
+haproxy_restart:
+  cmd.run:
+    - name: |-
+        haproxy_id=$(docker ps | grep -E "k8s_haproxy.*\.{{ pillar['internal_infra_domain'] | replace(".", "\.") }}_kube-system_" | awk '{print $1}')
+        if [ -n "$haproxy_id" ]; then
+            docker kill -s HUP $haproxy_id
+        fi
+    - onchanges:
+      - file: /etc/haproxy/haproxy.cfg

--- a/salt/kube-apiserver/apiserver.jinja
+++ b/salt/kube-apiserver/apiserver.jinja
@@ -8,7 +8,7 @@
 KUBE_API_ADDRESS="--insecure-bind-address=127.0.0.1 --bind-address=0.0.0.0"
 
 # The port on the local server to listen on.
-KUBE_API_PORT="--insecure-port=8080 --secure-port={{ pillar['api']['ssl_port'] }}"
+KUBE_API_PORT="--insecure-port=8080 --secure-port={{ pillar['api']['int_ssl_port'] }}"
 
 # Comma separated list of nodes in the etcd cluster
 {% if pillar['ssl']['enabled'] -%}

--- a/salt/kube-apiserver/init.sls
+++ b/salt/kube-apiserver/init.sls
@@ -5,8 +5,6 @@ include:
   - etcd-proxy
   - kubernetes-common
 
-{% set api_ssl_port = salt['pillar.get']('api:ssl_port', '6443') %}
-
 {% set ip_addresses = [] -%}
 {% set extra_names = ["DNS: " + grains['caasp_fqdn'] ] -%}
 
@@ -95,7 +93,7 @@ kube-apiserver:
     - match:      state
     - connstate:  NEW
     - dports:
-        - {{ api_ssl_port }}
+      - {{ pillar['api']['int_ssl_port'] }}
     - proto:      tcp
     - require:
       - sls:      kubernetes-common

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -11,6 +11,7 @@ base:
     - transactional-update
   'roles:kube-(master|minion)':
     - match: grain_pcre
+    - haproxy
     - ca-cert
     - repositories
     - motd


### PR DESCRIPTION
Now that we can have multiple masters, we need a way for the various
services and end-users to be load balanced over the set of kube-api
servers.

We install haproxy on each node, inside a docker container, configured
to load balance requests over all the cluster masters. This haproxy
is configured to listen on 0.0.0.0 on the masters, and 127.0.0.1 on
the workers.

This is to allow the minions to simply "talk" to 127.0.0.0, and be
routed to an active kube-api server.