### PR TITLE
Ensure k8s_etcd.get_cluster_size works for multi-master

### DIFF
--- a/salt/_modules/k8s_etcd.py
+++ b/salt/_modules/k8s_etcd.py
@@ -38,7 +38,10 @@ def get_cluster_size():
         member_count = len(__salt__['mine.get'](
             'roles:kube-master', 'caasp_fqdn', expr_form='grain').values())
 
-        if member_count < DESIRED_MEMBER_COUNT:
+        if member_count >= DESIRED_MEMBER_COUNT:
+            # We have enough members, use this count.
+            return member_count
+        else:
             # Attempt to increase the member count to 3, however, if we don't
             # have 3 nodes in total, then match the number of nodes we have.
             increased_member_count = len(__salt__['mine.get'](


### PR DESCRIPTION
If we had enough masters to form a etcd cluster, we would end up returning
"None" from this method, preventing the cluster formation.