### PR TITLE
Revert "Kube-API: Set storage-backend to etcd2"

### DIFF
--- a/salt/kube-apiserver/apiserver.jinja
+++ b/salt/kube-apiserver/apiserver.jinja
@@ -36,5 +36,4 @@ KUBE_API_ARGS="--advertise-address={{ grains['ip4_interfaces']['eth0'][0] }} \
                --tls-cert-file={{ pillar['ssl']['crt_file'] }} \
                --tls-private-key-file={{ pillar['ssl']['key_file'] }} \
                {{ salt['pillar.get']('components:apiserver:args', '') }} \
-               --client-ca-file={{ pillar['ssl']['ca_file'] }} \
-               --storage-backend=etcd2"
+               --client-ca-file={{ pillar['ssl']['ca_file'] }}"


### PR DESCRIPTION
Etcd storage backend etcd2 is deprecated.
We would like to ship CaaSP v2.0 with default storage-backend etcd3, which doesn't need to migration in future.