### PR TITLE
Set kube-apiserver storage backend as option

### DIFF
--- a/pillar/params.sls
+++ b/pillar/params.sls
@@ -21,6 +21,9 @@ api:
   ssl_port:       '6443'
   # port for listening for SSL connections (kube-api)
   int_ssl_port:   '6444'
+  # etcd storage backend version for cluster
+  etcd_version:   'etcd2'
+
 
 # DNS service IP and some other stuff (must be inside the 'services_cidr')
 dns:

--- a/salt/kube-apiserver/apiserver.jinja
+++ b/salt/kube-apiserver/apiserver.jinja
@@ -37,4 +37,4 @@ KUBE_API_ARGS="--advertise-address={{ grains['ip4_interfaces']['eth0'][0] }} \
                --tls-private-key-file={{ pillar['ssl']['key_file'] }} \
                {{ salt['pillar.get']('components:apiserver:args', '') }} \
                --client-ca-file={{ pillar['ssl']['ca_file'] }} \
-               --storage-backend=etcd2"
+               --storage-backend={{ pillar['api']['etcd_version'] }}"


### PR DESCRIPTION
Parametrize Kubernetes apiserver storage backend. This will be used
in future for migration process from storage etcd2 to etcd3.