### PR TITLE
Fix flannel config for 0.8.0

### DIFF
--- a/salt/flannel/flanneld.sysconfig.jinja
+++ b/salt/flannel/flanneld.sysconfig.jinja
@@ -1,6 +1,6 @@
 # Flanneld configuration options
 
-{% set flannel_opt = "-logtostderr -v " + pillar['flannel']['log_level'] + " -iface " + pillar['flannel']['iface'] + " -ip-masq" -%}
+{% set flannel_opt = "-v " + pillar['flannel']['log_level'] + " -iface " + pillar['flannel']['iface'] + " -ip-masq" -%}
 {% set http_protocol = 'http' -%}
 {% if pillar['ssl']['enabled'] -%}
   {% set http_protocol = 'https' -%}


### PR DESCRIPTION
Flannel in 0.8.0 rejects the "-logtostderr" flag we were providing, this
doesn't seem to have ever been an option, however it was silently ignored
in the past.