### PR TITLE
WIP: Use reactors to notify Velum of important events

### DIFF
--- a/config/master.d/50-master.conf
+++ b/config/master.d/50-master.conf
@@ -5,7 +5,6 @@
 user: root
 auto_accept: False
 interface: 0.0.0.0
-event_return: mysql
 presence_events: True
 timeout: 20
 

--- a/config/master.d/50-reactor.conf
+++ b/config/master.d/50-reactor.conf
@@ -2,7 +2,18 @@ reactor:
   - 'salt/presence/change':
     - /usr/share/salt/kubernetes/reactor/presence.sls
     - /usr/share/salt/kubernetes/reactor/etc-hosts.sls
+    - /usr/share/salt/kubernetes/reactor/presence-notifier.sls
   - 'salt/beacon/*/default_network_interface_settings/*':
     - /usr/share/salt/kubernetes/reactor/etc-hosts.sls
   - 'salt/minion/*/start':
     - /usr/share/salt/kubernetes/reactor/etc-hosts.sls
+  - 'salt/run/*/new':
+    - /usr/share/salt/kubernetes/reactor/orchestration-trigger-notifier.sls
+  - 'salt/run/*/ret':
+    - /usr/share/salt/kubernetes/reactor/orchestration-result-notifier.sls
+  - 'salt/job/*/ret/*':
+    - /usr/share/salt/kubernetes/reactor/highstate-notifier.sls
+  - 'salt/auth':
+    - /usr/share/salt/kubernetes/reactor/auth-notifier.sls
+  - 'minion_start':
+    - /usr/share/salt/kubernetes/reactor/minion-start-notifier.sls

--- a/config/master.d/50-returner.conf
+++ b/config/master.d/50-returner.conf
@@ -1,8 +1,0 @@
-mysql:
-  # salt does not support specifying the UNIX socket location here - as a workaround,
-  # use the MYSQL_UNIX_PORT environment variable used by libmysqlclient
-  # you still need the 'host' value here, or it will use the defaults and try to connect
-  # on a host named 'salt'
-  host: 'localhost'
-  user: 'salt'
-  db: 'velum_production'

--- a/reactor/auth-notifier.sls
+++ b/reactor/auth-notifier.sls
@@ -1,0 +1,15 @@
+notify:
+  runner.http.query:
+    - url: https://localhost/internal-api/v1/auth
+    - method: POST
+    - header_list:
+      - 'Content-Type: application/json'
+    - ca_bundle: /etc/pki/ca.crt
+    - username: {{ salt['environ.get']('VELUM_INTERNAL_API_USERNAME') }}
+    - password: {{ salt['environ.get']('VELUM_INTERNAL_API_PASSWORD') }}
+    - data: |
+        {
+          "event_data": {
+            "minion_id": {{ data['id']|json }}
+          }
+        }

--- a/reactor/highstate-notifier.sls
+++ b/reactor/highstate-notifier.sls
@@ -1,0 +1,18 @@
+{% if data["fun"] == "state.highstate" %}
+notify:
+  runner.http.query:
+    - url: https://localhost/internal-api/v1/highstates
+    - method: PUT
+    - header_list:
+      - 'Content-Type: application/json'
+    - ca_bundle: /etc/pki/ca.crt
+    - username: {{ salt['environ.get']('VELUM_INTERNAL_API_USERNAME') }}
+    - password: {{ salt['environ.get']('VELUM_INTERNAL_API_PASSWORD') }}
+    - data: |
+        {
+          "event_data": {
+            "minion_id": {{ data['id']|json }},
+            "success": {{ data['success']|json }}
+          }
+        }
+{% endif %}

--- a/reactor/minion-start-notifier.sls
+++ b/reactor/minion-start-notifier.sls
@@ -1,0 +1,15 @@
+notify:
+  runner.http.query:
+    - url: https://localhost/internal-api/v1/minions
+    - method: POST
+    - header_list:
+      - 'Content-Type: application/json'
+    - ca_bundle: /etc/pki/ca.crt
+    - username: {{ salt['environ.get']('VELUM_INTERNAL_API_USERNAME') }}
+    - password: {{ salt['environ.get']('VELUM_INTERNAL_API_PASSWORD') }}
+    - data: |
+        {
+          "event_data": {
+            "minion_id": {{ data['id']|json }}
+          }
+        }

--- a/reactor/orchestration-result-notifier.sls
+++ b/reactor/orchestration-result-notifier.sls
@@ -1,0 +1,20 @@
+{% if data["fun"] == "runner.state.orchestrate" %}
+notify:
+  runner.http.query:
+    - url: https://localhost/internal-api/v1/orchestrations/{{ data['jid'] }}
+    - method: PUT
+    - header_list:
+      - 'Content-Type: application/json'
+    - ca_bundle: /etc/pki/ca.crt
+    - username: {{ salt['environ.get']('VELUM_INTERNAL_API_USERNAME') }}
+    - password: {{ salt['environ.get']('VELUM_INTERNAL_API_PASSWORD') }}
+    - data: |
+        {
+          "event_data": {
+            "orchestration": {{ data['fun_args']|first|json }},
+            "retcode": {{ data['return']['retcode']|json }},
+            "success": {{ data['success']|json }},
+            "_stamp": {{ data['_stamp']|json }}
+          }
+        }
+{% endif %}

--- a/reactor/orchestration-trigger-notifier.sls
+++ b/reactor/orchestration-trigger-notifier.sls
@@ -1,0 +1,19 @@
+{% if data["fun"] == "runner.state.orchestrate" %}
+notify:
+  runner.http.query:
+    - url: https://localhost/internal-api/v1/orchestrations
+    - method: POST
+    - header_list:
+      - 'Content-Type: application/json'
+    - ca_bundle: /etc/pki/ca.crt
+    - username: {{ salt['environ.get']('VELUM_INTERNAL_API_USERNAME') }}
+    - password: {{ salt['environ.get']('VELUM_INTERNAL_API_PASSWORD') }}
+    - data: |
+        {
+          "event_data": {
+            "jid": {{ data['jid']|json }},
+            "orchestration": {{ data['fun_args']|first|json }},
+            "_stamp": {{ data['_stamp']|json }}
+          }
+        }
+{% endif %}

--- a/reactor/presence-notifier.sls
+++ b/reactor/presence-notifier.sls
@@ -1,0 +1,16 @@
+notify:
+  runner.http.query:
+    - url: https://localhost/internal-api/v1/presence
+    - method: PUT
+    - header_list:
+      - 'Content-Type: application/json'
+    - ca_bundle: /etc/pki/ca.crt
+    - username: {{ salt['environ.get']('VELUM_INTERNAL_API_USERNAME') }}
+    - password: {{ salt['environ.get']('VELUM_INTERNAL_API_PASSWORD') }}
+    - data: |
+        {
+          "event_data": {
+            "new": {{ data['new']|json }},
+            "lost": {{ data['lost']|json }}
+          }
+        }

--- a/salt/_pillar/velum.py
+++ b/salt/_pillar/velum.py
@@ -50,13 +50,8 @@ def ext_pillar(minion_id,
     log = logging.getLogger(__name__)
     cache = salt.cache.Cache(__opts__)
 
-    if username is None:
-        with open(os.environ['VELUM_INTERNAL_API_USERNAME_FILE'], 'r') as f:
-            username = f.read().strip()
-
-    if password is None:
-        with open(os.environ['VELUM_INTERNAL_API_PASSWORD_FILE'], 'r') as f:
-            password = f.read().strip()
+    username = username or os.environ['VELUM_INTERNAL_API_USERNAME']
+    password = password or os.environ['VELUM_INTERNAL_API_PASSWORD']
 
     data = __salt__['http.query'](url=url,
                                   ca_bundle=ca_bundle,


### PR DESCRIPTION
**Work in progress**, please do not review yet.

- [x] Use SSL/TLS for callbacks and pillar
- [x] Use API auth for callbacks and pillar (basic auth?)
- [x] Implement pillar caching locally, so if Velum does not respond or is temporarily unavailable we still render the latest pillar we had.

Depends on:
* https://github.com/kubic-project/velum/pull/299
* https://github.com/kubic-project/caasp-container-manifests/pull/100
* https://github.com/kubic-project/container-images/pull/21