### PR TITLE
Add orchestration for etcd storage 'etcd2' to 'etcd3'

### DIFF
--- a/salt/etcd/create-or-update-etcd-pillar
+++ b/salt/etcd/create-or-update-etcd-pillar
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker exec $(docker ps | grep velum-dashboard | awk '{print $1}') entrypoint.sh bundle exec rails runner 'ActiveRecord::Base.logger=nil; pillar = Pillar.find_or_create_by(pillar: "api:etcd_version"); pillar.value = "etcd3"; pillar.save'

--- a/salt/etcd/migrate.sls
+++ b/salt/etcd/migrate.sls
@@ -1,0 +1,12 @@
+/tmp/create-or-update-etcd-pillar:
+  file.managed:
+    - source: salt://etcd/create-or-update-etcd-pillar
+    - user: root
+    - group: root
+    - mode: 755
+
+create-or-update-etcd-pillar:
+  cmd.run:
+    - name: bash /tmp/create-or-update-etcd-pillar
+    - require:
+      - file: /tmp/create-or-update-etcd-pillar

--- a/salt/orch/etcd-migrate.sls
+++ b/salt/orch/etcd-migrate.sls
@@ -1,0 +1,84 @@
+# Generic Updates
+update_pillar:
+  salt.function:
+    - tgt: '*'
+    - name: saltutil.refresh_pillar
+
+update_grains:
+  salt.function:
+    - tgt: '*'
+    - name: saltutil.refresh_grains
+
+update_mine:
+  salt.function:
+    - tgt: '*'
+    - name: mine.update
+    - require:
+       - salt: update_pillar
+       - salt: update_grains
+
+master-stop-services:
+  salt.state:
+    - tgt: 'roles:kube-master'
+    - tgt_type: grain
+    - sls:
+      - kube-apiserver.stop
+      - kube-controller-manager.stop
+      - kube-scheduler.stop
+      - etcd.stop
+    - require:
+       - salt: update_mine
+
+worker-stop-services:
+  salt.state:
+    - tgt: 'roles:kube-minion'
+    - tgt_type: grain
+    - sls:
+      - kubelet.stop
+      - kube-proxy.stop
+      - etcd.stop
+    - require:
+       - salt: master-stop-services
+
+backup-etcd:
+  salt.function:
+    - tgt: 'roles:kube-(master|minion)'
+    - tgt_type: grain_pcre
+    - name: cmd.run
+    - arg:
+      - mkdir /tmp/backup; btrfs subvolume snapshot /var/lib/etcd /tmp/backup/etcd
+    - require:
+       - salt: worker-stop-services
+
+migrate-etcd:
+  salt.function:
+    - tgt: 'roles:kube-(master|minion)'
+    - tgt_type: grain_pcre
+    - name: cmd.run
+    - arg:
+      - if ! [ -d /var/lib/etcd/proxy ]; then set -a; source /etc/sysconfig/etcdctl; env ETCDCTL_API=3 etcdctl migrate --data-dir=/var/lib/etcd; fi
+    - require:
+      - salt: backup-etcd
+
+create-etcd-pillar:
+  salt.state:
+    - tgt: 'roles:admin'
+    - tgt_type: grain
+    - sls:
+      - etcd.migrate
+    - require:
+      - salt: migrate-etcd
+
+refresh-pillars:
+  salt.function:
+    - tgt: '*'
+    - name: saltutil.refresh_pillar
+    - require:
+      - salt: create-etcd-pillar
+
+start-all-services-again:
+  salt.state:
+    - tgt: '*'
+    - highstate: True
+    - require:
+      - salt: refresh-pillars


### PR DESCRIPTION
In Kubernetes v1.7 default storage backend for apiserver is 'etcd3'.
We need orchestrate migration between version 'etcd2' and 'etcd3'.

To migrate etcd storage version we have to execute following command on Admin node:
```
docker exec -ti $(docker ps | grep salt-master | cut -d" " -f1) salt-run state.orchestrate orch.etcd-migrate
```

For testing please do following steps:
1. Deploy and bootstrap CaaSP2.0 Beta 1 version
2. On Admin node please remount filesystem as RW
```
btrfs property set -ts /.snapshots/1/snapshot ro false
mount -o remount,rw /
```
3. Copy on Admin node etcd/migrate.sls, etcd/create-or-update-etcd-pillar and orch/etcd-migrate.sls to /usr/share/salt/kubernetes/salt/
```
cp etcd/migrate.sls /usr/share/salt/kubernetes/salt/etcd/
cp etcd/create-or-update-etcd-pillar /usr/share/salt/kubernetes/salt/etcd/
cp orch/etcd-migrate.sls /usr/share/salt/kubernetes/salt/orch/
```
4. Run migration script
```
docker exec -ti $(docker ps | grep salt-master | cut -d" " -f1) salt-run state.orchestrate orch.etcd-migrate
```
