### PR TITLE
Ensure systemd is reloaded after units are changed

### DIFF
--- a/salt/docker/init.sls
+++ b/salt/docker/init.sls
@@ -14,9 +14,10 @@ include:
         Environment="HTTP_PROXY={{ salt['pillar.get']('proxy:http', '') }}"
         Environment="HTTPS_PROXY={{ salt['pillar.get']('proxy:https', '') }}"
         Environment="NO_PROXY={{ salt['pillar.get']('proxy:no_proxy', '') }}"
-  cmd.run:
-    - name: systemctl daemon-reload
-    - stateful: True
+  module.run:
+    - name: service.systemctl_reload
+    - onchanges:
+      - file: /etc/systemd/system/docker.service.d/proxy.conf
 
 #######################
 # docker daemon

--- a/salt/etcd/init.sls
+++ b/salt/etcd/init.sls
@@ -59,6 +59,10 @@ etcd:
   file.managed:
     - source: salt://etcd/etcd.conf
     - makedirs: True
+  module.run:
+    - name: service.systemctl_reload
+    - onchanges:
+      - file: /etc/systemd/system/etcd.service.d/etcd.conf
 
 # note: this will be used to run etcdctl client command
 /etc/sysconfig/etcdctl:

--- a/salt/transactional-update/init.sls
+++ b/salt/transactional-update/init.sls
@@ -7,6 +7,10 @@
     - user: root
     - group: root
     - mode: 644
+  module.run:
+    - name: service.systemctl_reload
+    - onchanges:
+      - file: /etc/systemd/system/transactional-update.service.d/10-update-rebootmgr-options.conf
 
 /etc/systemd/system/transactional-update.timer.d/10-increase-update-speed.conf:
   file.managed:
@@ -16,11 +20,9 @@
     - user: root
     - group: root
     - mode: 644
-
-service.systemctl_reload:
   module.run:
+    - name: service.systemctl_reload
     - onchanges:
-      - file: /etc/systemd/system/transactional-update.service.d/10-update-rebootmgr-options.conf
       - file: /etc/systemd/system/transactional-update.timer.d/10-increase-update-speed.conf
 
 transactional-update.timer:


### PR DESCRIPTION
Ensure systemd is reloaded as soon as a unit is changed, rather than relying
on a task later within the orchestration to execute.

Fixes bsc#1057641