### PR TITLE
Include short hostname for masters

### DIFF
--- a/salt/etc-hosts/hosts.jinja
+++ b/salt/etc-hosts/hosts.jinja
@@ -20,7 +20,7 @@
 	{%- else %}
 		{%- set ip = addrlist|first %}
 	{%- endif %}
-{{ ip }} {{ master_id }}.{{ pillar['internal_infra_domain'] }} {{ pillar['api']['server']['external_fqdn'] }}
+{{ ip }} {{ master_id }} {{ master_id }}.{{ pillar['internal_infra_domain'] }} {{ pillar['api']['server']['external_fqdn'] }}
 {%- endfor %}
 
 ### kubernetes workers ###


### PR DESCRIPTION
The short hostname for masters was not being set, as it was for both
the admin node, and worker nodes

Fixes bsc#1057794