### PR TITLE
Move External FQDN to 127.0.0.1 address

### DIFF
--- a/salt/etc-hosts/hosts.jinja
+++ b/salt/etc-hosts/hosts.jinja
@@ -1,5 +1,5 @@
 ### service names ###
-127.0.0.1 api api.{{ pillar['internal_infra_domain'] }}
+127.0.0.1 api api.{{ pillar['internal_infra_domain'] }} {{ pillar['api']['server']['external_fqdn'] }}
 
 ### admin nodes ###
 {%- set admins = salt['mine.get']('roles:admin', 'network.ip_addrs', 'grain') %}
@@ -20,7 +20,7 @@
 	{%- else %}
 		{%- set ip = addrlist|first %}
 	{%- endif %}
-{{ ip }} {{ master_id }} {{ master_id }}.{{ pillar['internal_infra_domain'] }} {{ pillar['api']['server']['external_fqdn'] }}
+{{ ip }} {{ master_id }} {{ master_id }}.{{ pillar['internal_infra_domain'] }}
 {%- endfor %}
 
 ### kubernetes workers ###


### PR DESCRIPTION
This was added to ensure Dex was always reachable, however, with multi masters,
this name was assigned to 3 different lines in /etc/hosts. Most consumers of
/etc/hosts do not deal with this as they would a round-robin DNS entry which
returns multiple IPs.

When the "selected" master is powered off, this name continues to resolve
the same dead IP address. As Dex uses a NodePort service, putting this to
127.0.0.1 works as we expect it to.