### PR TITLE
Removing hardcoded LDAP admin password

### DIFF
--- a/pillar/params.sls
+++ b/pillar/params.sls
@@ -176,3 +176,20 @@ transactional-update:
 
 dex:
   node_port: 32000
+
+# configuration parameters for interacting with LDAP via Dex
+# these get filled in by velum during bootstrap. they're listed
+# here for documentation purposes.
+ldap:
+  host: ''
+  port: 0
+  bind_dn: ''
+  bind_pw: ''
+  domain: ''
+  group_dn: ''
+  people_dn: ''
+  base_dn: ''
+  admin_group_dn: ''
+  admin_group_name: ''
+  tls_method: ''
+  mail_attribute: ''

--- a/salt/addons/addons/kubedns-sa.yaml
+++ b/salt/addons/addons/kubedns-sa.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-dns
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile

--- a/salt/dex/dex.yaml
+++ b/salt/dex/dex.yaml
@@ -44,25 +44,24 @@ data:
       config:
         host: "{{ pillar['dashboard'] }}:389"
         startTLS: true
-        bindDN: cn=admin,{{ pillar['ldap_internal_infra_domain'] }}
-        bindPW: admin
+        bindDN: "{{ pillar['ldap']['bind_dn'] }}"
+        bindPW: "{{ pillar['ldap']['bind_pw'] }}"
         rootCA: {{ pillar['ssl']['ca_file'] }}
         userSearch:
-          baseDN: ou=People,{{ pillar['ldap_internal_infra_domain'] }}
+          baseDN: "{{ pillar['ldap']['people_dn'] }}"
           filter: "(objectClass=inetOrgPerson)"
-          username: mail
+          username: "{{ pillar['ldap']['mail_attribute'] }}"
           idAttr: DN
-          emailAttr: mail
+          emailAttr: "{{ pillar['ldap']['mail_attribute'] }}"
           nameAttr: cn          
         groupSearch:
-          baseDN: ou=Groups,{{ pillar['ldap_internal_infra_domain'] }}
+          baseDN: "{{ pillar['ldap']['group_dn'] }}"
           filter: "(objectClass=groupOfUniqueNames)"
 
           userAttr: DN
           groupAttr: uniqueMember
 
-          nameAttr: cn       
-
+          nameAttr: cn
     oauth2:
       skipApprovalScreen: true
 

--- a/salt/dex/init.sls
+++ b/salt/dex/init.sls
@@ -93,32 +93,29 @@ dex_secrets:
     - env:
       - KUBECONFIG: {{ pillar['paths']['kubeconfig'] }}
     - require:
+      - kube-apiserver
       - x509: /etc/pki/dex.crt
       - {{ pillar['paths']['kubeconfig'] }}
 
 dex_instance:
   cmd.run:
     - name: |
-        until kubectl get sa dex --namespace=kube-system && kubectl get clusterrolebinding system:dex && kubectl get configmap dex --namespace=kube-system && kubectl get deployment dex --namespace=kube-system && kubectl get service dex --namespace=kube-system ; do
-            kubectl create -f /root/dex.yaml
-            sleep 5
-        done
+        kubectl apply -f /root/dex.yaml || kubectl apply -f /root/dex.yaml
     - env:
       - KUBECONFIG: {{ pillar['paths']['kubeconfig'] }}
     - require:
+      - kube-apiserver
       - file: /root/dex.yaml
       - {{ pillar['paths']['kubeconfig'] }}
 
 kubernetes_roles:
   cmd.run:
     - name: |
-        until kubectl get role find-dex --namespace=kube-system && kubectl get rolebinding find-dex --namespace=kube-system ; do
-            kubectl create -f /root/roles.yaml
-            sleep 5
-        done
+        kubectl apply -f /root/roles.yaml || kubectl apply -f /root/roles.yaml
     - env:
       - KUBECONFIG: {{ pillar['paths']['kubeconfig'] }}
     - require:
+      - kube-apiserver
       - file: /root/roles.yaml
       - {{ pillar['paths']['kubeconfig'] }}
       - dex_instance

--- a/salt/dex/roles.yaml
+++ b/salt/dex/roles.yaml
@@ -39,7 +39,7 @@ metadata:
   name: administrators-in-ldap
 subjects:
 - kind: Group
-  name: Administrators
+  name: "{{ pillar['ldap']['admin_group_name'] }}"
   apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole


### PR DESCRIPTION
LDAP password is now generated when admin node starts, and LDAP parameters are passed via the pillar during bootstrap.