### PR TITLE
Set etcd3 as default backend storage

### DIFF
--- a/pillar/params.sls
+++ b/pillar/params.sls
@@ -23,7 +23,7 @@ api:
   # port for listening for SSL connections (kube-api)
   int_ssl_port:   '6444'
   # etcd storage backend version for cluster
-  etcd_version:   'etcd2'
+  etcd_version:   'etcd3'
 
 
 # DNS service IP and some other stuff (must be inside the 'services_cidr')


### PR DESCRIPTION
Depends on: https://github.com/kubic-project/velum/pull/303