### PR TITLE
Add cluster role binding for tiller

### DIFF
--- a/salt/addons/init.sls
+++ b/salt/addons/init.sls
@@ -66,4 +66,15 @@ apply-tiller:
     - require:
       - kube-apiserver
       - file:      /etc/kubernetes/addons/tiller.yaml
+
+create-tiller-clusterrolebinding:
+  cmd.run:
+    - name: |
+        kubectl create clusterrolebinding system:tiller --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
+    - env:
+      - KUBECONFIG: {{ pillar['paths']['kubeconfig'] }}
+    - unless:
+      - kubectl get clusterrolebindings | grep tiller | cat
+    - require:
+      - kube-apiserver
 {% endif %}


### PR DESCRIPTION
Tiller requires a cluster role binding to work correctly with the new
RBAC changes. Add this cluster role binding so that helm commands work
correctly.