### PR TITLE
Include kube-apiserver in the dex role

### DIFF
--- a/salt/dex/init.sls
+++ b/salt/dex/init.sls
@@ -2,6 +2,7 @@ include:
   - crypto
   - repositories
   - kubectl-config
+  - kube-apiserver
 
 {% set ip_addresses = [] -%}
 {% set extra_names = ["DNS: " + grains['caasp_fqdn'] ] -%}


### PR DESCRIPTION
Without this, We're seeing an error post-bootstrap, so deployments
look green, but fail with:

        The following requisites were not found:
                           require:
                               id: kube-apiserver