### PR TITLE
Prevent update-etc-hosts conflicting with bootstrap

### DIFF
--- a/salt/orch/update-etc-hosts.sls
+++ b/salt/orch/update-etc-hosts.sls
@@ -1,5 +1,5 @@
-{%- set updates_all_target = 'P@roles:(admin|kube-(master|minion)) and G@bootstrap_complete:true and not G@update_in_progress:true' %}
-{%- set updates_master_target = 'G@roles:kube-master and G@bootstrap_complete:true and not G@update_in_progress:true' %}
+{%- set updates_all_target = 'P@roles:(admin|kube-(master|minion)) and G@bootstrap_complete:true and not G@bootstrap_in_progress:true and not G@update_in_progress:true' %}
+{%- set updates_master_target = 'G@roles:kube-master and G@bootstrap_complete:true and not G@bootstrap_in_progress:true and not G@update_in_progress:true' %}
 
 {%- if salt.saltutil.runner('mine.get', tgt=updates_all_target, fun='caasp_fqdn', tgt_type='compound')|length > 0 %}
 update_pillar:


### PR DESCRIPTION
Fix another case where the etc hosts update orchestration would otherwise
conflict with the bootstrap / add node orchestration.

bsc#1059577