### PR TITLE
Disable DHCP client hostnames, bsc#1058036

### DIFF
--- a/salt/hostname/init.sls
+++ b/salt/hostname/init.sls
@@ -1,3 +1,13 @@
 caasp_fqdn:
   grains.present:
     - value: {{ grains['id'] }}.{{ pillar['internal_infra_domain'] }}
+
+{% if pillar['cloud']['provider'] == 'openstack' %}
+dhclient_set_hostname:
+  file.replace:
+    - name: /etc/sysconfig/network/dhcp
+    - pattern: '^DHCLIENT_SET_HOSTNAME.*$'
+    - repl: DHCLIENT_SET_HOSTNAME="no"
+    - flags: ['IGNORECASE', 'MULTILINE']
+    - append_if_not_found: True
+{% endif %}


### PR DESCRIPTION
In CaaSP hostnames are set by salt client, but they are overwritten by wicked service.
This fix is disabling DHCLIENT_SET_HOSTNAME option for wicked.