### PR TITLE
Remove duplicated storage-backend option for API server configuration, bsc#1061810

### DIFF
--- a/salt/kube-apiserver/apiserver.jinja
+++ b/salt/kube-apiserver/apiserver.jinja
@@ -51,6 +51,4 @@ KUBE_API_ARGS="--advertise-address={{ grains['ip4_interfaces']['eth0'][0] }} \
                --oidc-client-id=caasp-cli \
                --oidc-ca-file={{ pillar['ssl']['ca_file'] }} \
                --oidc-username-claim=email \
-               --oidc-groups-claim=groups \
-               --storage-backend=etcd2 \
-               --storage-media-type=application/json"
+               --oidc-groups-claim=groups"


### PR DESCRIPTION
Remove duplicated storage-backend option for API server configuration
   
Option storage-backend is provided two times for API server configuration.
We have to keep only one with value provided from pillar.
