### PR TITLE
Add a URL off Velum as a valid OIDC redirect URI

### DIFF
--- a/salt/dex/dex.yaml
+++ b/salt/dex/dex.yaml
@@ -70,6 +70,7 @@ data:
     - id: caasp-cli
       redirectURIs:
       - 'http://127.0.0.1'
+      - 'https://{{ pillar['dashboard'] }}/oidc/done'
       name: "CaaSP CLI"
       secret: "swac7qakes7AvucH8bRucucH"
 ---


### PR DESCRIPTION
This will make it so that Dex will be happy to redirect you to velum

Backport of https://github.com/kubic-project/salt/pull/235