### PR TITLE
[2.0] Remove duplicated storage-backend option for Kubernetes API, bsc#1061810

### DIFF
--- a/salt/kube-apiserver/apiserver.jinja
+++ b/salt/kube-apiserver/apiserver.jinja
@@ -51,6 +51,4 @@ KUBE_API_ARGS="--advertise-address={{ grains['ip4_interfaces']['eth0'][0] }} \
                --oidc-client-id=caasp-cli \
                --oidc-ca-file={{ pillar['ssl']['ca_file'] }} \
                --oidc-username-claim=email \
-               --oidc-groups-claim=groups \
-               --storage-backend=etcd2 \
-               --storage-media-type=application/json"
+               --oidc-groups-claim=groups"


### PR DESCRIPTION
Option storage-backend is provided two times for Kubernetes API configuration.
We have to keep only one option with value provided from pillar.

(cherry picked from commit c4b42e689a0044a73715ff9e3619f709b3bca982)

Backport of https://github.com/kubic-project/salt/pull/240