### PR TITLE
Dex: Wait for Dex to be fully up and running

### DIFF
--- a/pillar/params.sls
+++ b/pillar/params.sls
@@ -182,7 +182,7 @@ transactional-update:
     on_calendar: 'daily' # See https://www.freedesktop.org/software/systemd/man/systemd.time.html#Calendar%20Events for syntax
 
 dex:
-  node_port: 32000
+  node_port: '32000'
 
 # configuration parameters for interacting with LDAP via Dex
 # these get filled in by velum during bootstrap. they're listed

--- a/salt/dex/ensure-dex-running.sls
+++ b/salt/dex/ensure-dex-running.sls
@@ -1,0 +1,16 @@
+
+ensure_dex_running:
+  # Wait until the Dex API is actually up and running
+  cmd.run:
+    - name: |
+        {% set dex_api_server = pillar['api']['server']['external_fqdn'] -%}
+        {% set dex_api_port = pillar['dex']['node_port'] -%}
+        {% set dex_api_server_url = 'https://' + dex_api_server + ':' + dex_api_port -%}
+
+        ELAPSED=0
+        until curl --silent --fail -o /dev/null --cacert {{ pillar['ssl']['ca_file'] }} {{ dex_api_server_url }}/.well-known/openid-configuration ; do
+          [ $ELAPSED -gt 300 ] && exit 1
+          sleep 1 && ELAPSED=$(( $ELAPSED + 1 ))
+        done
+        echo changed="no"
+    - stateful: True

--- a/salt/orch/kubernetes.sls
+++ b/salt/orch/kubernetes.sls
@@ -160,13 +160,13 @@ reboot_setup:
     - require:
       - salt: kube_master_setup
 
-dex_setup:
+wait_for_dex_api:
   salt.state:
     - tgt: 'roles:kube-master'
     - tgt_type: grain
     - batch: 5
     - sls:
-      - dex
+      - dex.ensure-dex-running
     - require:
       - salt: reboot_setup
 
@@ -180,7 +180,7 @@ set_bootstrap_complete_flag:
       - bootstrap_complete
       - true
     - require:
-      - salt: dex_setup
+      - salt: wait_for_dex_api
 
 # Ensure the node is marked as finished bootstrapping
 clear_bootstrap_in_progress_flag:


### PR DESCRIPTION
We shouldn't allow a bootstrap to complete without Dex being up and
running, so lets wait for the Dex API to start responding.

Backport of https://github.com/kubic-project/salt/pull/229