### PR TITLE
Add floating network to cloud-provider integration with OpenStack

### DIFF
--- a/pillar/params.sls
+++ b/pillar/params.sls
@@ -162,6 +162,8 @@ cloud:
     password:       ''
     # OpenStack subnet UUID for the CaasP private network
     subnet:         ''
+    # OpenStack floating network UUID
+    floating:       ''
     # OpenStack load balancer monitor max retries
     lb_mon_retries: '3'
     # OpenStack Cinder Block Storage API version

--- a/salt/kubernetes-common/openstack-config.jinja
+++ b/salt/kubernetes-common/openstack-config.jinja
@@ -8,6 +8,7 @@ region="{{ pillar['cloud']['openstack']['region'] }}"
 [LoadBalancer]
 lb-version=v2
 subnet-id="{{ pillar['cloud']['openstack']['subnet'] }}"
+floating-network-id="{{ pillar['cloud']['openstack']['floating'] }}"
 create-monitor=yes
 monitor-delay=1m
 monitor-timeout=30s


### PR DESCRIPTION
Backport of PR #242 242

We would like add new pillar value floating, which will be used to configure floating network
for cloud provider intergration with OpenStack. If this option is specified, it will create floating ip
for loadbalancer automatically.

(cherry picked from commit 497891de69f904f9de8cb87e7bb186926af990ce)