### PR TITLE
Allow Dex to redirect to the Dashboard's external FQDN

### DIFF
--- a/pillar/vars.sls
+++ b/pillar/vars.sls
@@ -1,4 +1,7 @@
 # some global variables that will be set dynamically
 
 # a distinguishable name/IP for the dashboard
-dashboard:     'dashboard'
+dashboard:      'dashboard'
+
+# The external FQDN for velum
+dashboard_external_fqdn: ''

--- a/salt/dex/dex.yaml
+++ b/salt/dex/dex.yaml
@@ -73,6 +73,7 @@ data:
       redirectURIs:
       - 'http://127.0.0.1'
       - 'https://{{ pillar['dashboard'] }}/oidc/done'
+      - 'https://{{ pillar['dashboard_external_fqdn'] }}/oidc/done'
       name: "CaaSP CLI"
       secret: "swac7qakes7AvucH8bRucucH"
 ---


### PR DESCRIPTION
Some scenarios where the admin node's private IP is not accessible
to the outside world require that we use a end user provided FQDN
- e.g. as is the case on OpenStack and possibly other cloud
environments. Allow redirections to this FQDN.

Part of bsc#1062291

Depends-On: https://github.com/kubic-project/velum/pull/322
Depends-On: https://github.com/kubic-project/automation/pull/164