### PR TITLE
Update tiller deployment to use sles-based docker image

### DIFF
--- a/salt/addons/addons/tiller.yaml.jinja
+++ b/salt/addons/addons/tiller.yaml.jinja
@@ -26,7 +26,7 @@ spec:
       - env:
         - name: TILLER_NAMESPACE
           value: kube-system
-        image: gcr.io/kubernetes-helm/tiller:v2.5.1
+        image: sles12/tiller:2.5.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:


### PR DESCRIPTION
Currently the tiller image being used for the tiller deployment is
from the upstream registry at gcr.io. We should be using the SLES
based docker image instead of the upstream one.

Fixes: bsc#1062380