### PR TITLE
Use hostnames provided by cloud for CaaSP when CPI is enabled

### DIFF
--- a/pillar/ip_addrs.sls
+++ b/pillar/ip_addrs.sls
@@ -1,2 +1,5 @@
 mine_functions:
   network.ip_addrs: [eth0]
+  hostname:
+    - mine_function: grains.get
+    - nodename

--- a/salt/_macros/certs.jinja
+++ b/salt/_macros/certs.jinja
@@ -1,7 +1,7 @@
 
 {% macro extra_names(names=[], ips=[]) -%}
   {#- add all the names and IPs we know about -#}
-  {%- set extra = ["DNS: " + grains['caasp_fqdn'] ] -%}
+  {%- set extra = ["DNS: " + grains['caasp_fqdn'], "DNS: " + grains['nodename'] ] -%}
   {%- for _, interface_addresses in grains['ip4_interfaces'].items() -%}
     {%- for interface_address in interface_addresses -%}
       {%- do extra.append("IP: " + interface_address) -%}

--- a/salt/dex/init.sls
+++ b/salt/dex/init.sls
@@ -30,4 +30,3 @@ include:
 {{ kubectl_apply_template("salt://dex/roles.yaml",
                           "/root/roles.yaml",
                           watch=["dex_secrets", "/root/dex.yaml"]) }}
-

--- a/salt/etc-hosts/hosts.jinja
+++ b/salt/etc-hosts/hosts.jinja
@@ -1,3 +1,5 @@
+{%- set hostnames = salt['mine.get']('*', 'hostname', 'glob') %}
+
 ### service names ###
 127.0.0.1 api api.{{ pillar['internal_infra_domain'] }} {{ pillar['api']['server']['external_fqdn'] }}
 
@@ -9,7 +11,7 @@
 	{%- else %}
 		{%- set ip = addrlist|first %}
 	{%- endif %}
-{{ ip }} {{ admin_id }} {{ admin_id }}.{{ pillar['internal_infra_domain'] }}
+{{ ip }} {{ admin_id }} {{ admin_id }}.{{ pillar['internal_infra_domain'] }} {{ hostnames[admin_id] }}
 {%- endfor %}
 
 ### kubernetes masters ###
@@ -20,7 +22,7 @@
 	{%- else %}
 		{%- set ip = addrlist|first %}
 	{%- endif %}
-{{ ip }} {{ master_id }} {{ master_id }}.{{ pillar['internal_infra_domain'] }}
+{{ ip }} {{ master_id }} {{ master_id }}.{{ pillar['internal_infra_domain'] }} {{ hostnames[master_id] }}
 {%- endfor %}
 
 ### kubernetes workers ###
@@ -31,5 +33,5 @@
 	{%- else %}
 		{%- set ip = addrlist|first %}
 	{%- endif %}
-{{ ip }} {{ minion_id }} {{ minion_id }}.{{ pillar['internal_infra_domain'] }}
+{{ ip }} {{ minion_id }} {{ minion_id }}.{{ pillar['internal_infra_domain'] }} {{ hostnames[minion_id] }}
 {%- endfor %}

--- a/salt/hostname/init.sls
+++ b/salt/hostname/init.sls
@@ -1,3 +1,7 @@
 caasp_fqdn:
   grains.present:
+{% if pillar['cloud']['provider'] != '' %}
+    - value: {{ grains['nodename'] }}
+{% else %}
     - value: {{ grains['id'] }}.{{ pillar['internal_infra_domain'] }}
+{% endif %}


### PR DESCRIPTION
Some cloud provider drivers in Kubernetes like OpenStack, AWS, VMware etc.
require to match VM hostname with the nodename given by cloud platform.
If cloud provider is enabled we should rely on nodenames instead machine-id
which is dedicated solution for bare metal CaaSP deployments.