### PR TITLE
[2.0] Revert K8S to a storage media type of json

### DIFF
--- a/salt/kube-apiserver/apiserver.jinja
+++ b/salt/kube-apiserver/apiserver.jinja
@@ -43,6 +43,7 @@ KUBE_API_ARGS="--advertise-address={{ grains['ip4_interfaces']['eth0'][0] }} \
                {{ salt['pillar.get']('components:apiserver:args', '') }} \
                --client-ca-file={{ pillar['ssl']['ca_file'] }} \
                --storage-backend={{ pillar['api']['etcd_version'] }} \
+               --storage-media-type=application/json \
                --service-account-key-file={{ pillar['paths']['service_account_key'] }} \
                --service-account-lookup=true \
                --runtime-config=admissionregistration.k8s.io/v1alpha1 \


### PR DESCRIPTION
With the default value (protobuf), the kubernetes api server will sit
in a (slow) restart loop when multimaster is enabled, logging a stacktrace
and then restarting. This will manifest as, most commonly, "Unable to
connect to the server: unexpected EOF" from kubectl. This will break
bootstrap as we need to talk to K8S API to deploy dex, kube-dns, and
tiller.

bsc#1063235
bsc#1063285
bsc#1063543