### PR TITLE
Revert K8S to use etcd2 storage format

### DIFF
--- a/pillar/params.sls
+++ b/pillar/params.sls
@@ -23,7 +23,7 @@ api:
   # port for listening for SSL connections (kube-api)
   int_ssl_port:   '6444'
   # etcd storage backend version for cluster
-  etcd_version:   'etcd3'
+  etcd_version:   'etcd2'
 
   server:
     # should be set from the UI


### PR DESCRIPTION
With etcd3, the kubernetes api server will sit in a (slow) restart loop
when multimaster is enabled, logging a stacktrace and then restarting.
This will manifest as, most commonly, "Unable to connect to the server:
unexpected EOF" from kubectl. This will break bootstrap as we need to
talk to K8S API to deploy dex, kube-dns, and tiller.

bsc#1063235
bsc#1063285
bsc#1063543