### PR TITLE
Docker package was renamed to docker_1_12_6

### DIFF
--- a/salt/docker/init.sls
+++ b/salt/docker/init.sls
@@ -38,6 +38,7 @@ include:
 
 docker:
   pkg.installed:
+    - name: docker_1_12_6
     - install_recommends: False
     - require:
       - file: /etc/zypp/repos.d/containers.repo


### PR DESCRIPTION
Update salt to reference the new docker package name, as this was renamed
from "docker" to "docker_1_12_6"