### PR TITLE
Keep updated /etc/hosts on velum-dashboard container, bsc#1062728

### DIFF
--- a/salt/etc-hosts/init.sls
+++ b/salt/etc-hosts/init.sls
@@ -13,3 +13,15 @@ dummy_step:
   cmd.run:
     - name: "echo saltstack bug 14553"
 {% endif %}
+
+{% if "admin" in salt['grains.get']('roles', []) %}
+update-velum-hosts:
+  cmd.run:
+    - name: |-
+        velum_id=$( docker ps | grep velum-dashboard | awk '{print $1}')
+        if [ -n "$velum_id" ]; then
+            docker cp /etc/hosts $velum_id:/etc/hosts
+        fi
+    - onchanges:
+      - file: /etc/hosts
+{% endif %}


### PR DESCRIPTION
We would like to keep /etc/hosts file updated for velum-dashboard with
Admin host. Velum needs to know external name of Kube API which will be used
to register in Dex service. Problem was discovered and discribed in bug 1062728