### PR TITLE
Add help message to etc/sysconfig/etcdctl

### DIFF
--- a/salt/etcd/etcdctl.conf.jinja
+++ b/salt/etcd/etcdctl.conf.jinja
@@ -1,4 +1,11 @@
-# etcd common flags
+# etcd common flags required to use etcdctl
+#
+# These variables have to be exported if you want to use etcdctl for
+# debugging purposes (for example to use: `etcdctl cluster-health`).
+# Use the following command to make these variables visible to
+# etcdctl:
+# set -a; source /etc/sysconfig/etcdctl; set +a
+
 ETCDCTL_ENDPOINT="https://{{ grains['caasp_fqdn'] }}:2379"
 
 # etcd v2 style flags


### PR DESCRIPTION
Quick tip about how to source the variables defined inside of the file to quickly have etcdctl work.

I always find myself copy&pasting the contents of this file to `--flag-xyz`, sourcing the file is much more convenient but you have to know about `set -a`.