### PR TITLE
[2.0] Correctly handle FQDN `dashboard` values in Velum cert

### DIFF
--- a/salt/_modules/caasp_filters.py
+++ b/salt/_modules/caasp_filters.py
@@ -1,0 +1,29 @@
+from __future__ import absolute_import
+from salt._compat import ipaddress
+
+
+def is_ip(ip):
+    '''
+    Returns a bool telling if the passed IP is a valid IPv4 or IPv6 address.
+    '''
+    return is_ipv4(ip) or is_ipv6(ip)
+
+
+def is_ipv4(ip):
+    '''
+    Returns a bool telling if the value passed to it was a valid IPv4 address
+    '''
+    try:
+        return ipaddress.ip_address(ip).version == 4
+    except ValueError:
+        return False
+
+
+def is_ipv6(ip):
+    '''
+    Returns a bool telling if the value passed to it was a valid IPv6 address
+    '''
+    try:
+        return ipaddress.ip_address(ip).version == 6
+    except ValueError:
+        return False

--- a/salt/velum/init.sls
+++ b/salt/velum/init.sls
@@ -2,8 +2,14 @@ include:
   - ca-cert
   - cert
 
-{% set ip_addresses = ["IP: " + pillar['dashboard']] -%}
+{% set ip_addresses = [] -%}
 {% set extra_names = ["DNS: " + grains['caasp_fqdn'], "DNS: " + pillar['dashboard_external_fqdn']] -%}
+
+{% if salt['caasp_filters.is_ip'](pillar['dashboard']) %}
+{% do ip_addresses.append("IP: " + pillar['dashboard']) %}
+{% else %}
+{% do extra_names.append("DNS: " + pillar['dashboard']) %}
+{% endif %}
 
 {{ pillar['ssl']['velum_key'] }}:
   x509.private_key_managed:    


### PR DESCRIPTION
Ensure we correctly handle FQDN values for the `dashboard` pillar when
generating the Velum TLS certificate.

Fixes bsc#1064284

Backport of https://github.com/kubic-project/salt/pull/274