### PR TITLE
[2.0] Disable Velum restart post-TLS regeneration

### DIFF
--- a/salt/velum/init.sls
+++ b/salt/velum/init.sls
@@ -53,13 +53,16 @@ include:
 # TODO: We should not restart the Velum container, but this is required for the new certificates to
 #       be loaded. Soon, we should stop serving content directly with Puma and it should be done
 #       by web servers instead of application servers (apache, nginx...).
-velum_restart:
-  cmd.run:
-    - name: |-
-        velum_id=$(docker ps | grep "velum-dashboard" | awk '{print $1}')
-        if [ -n "$velum_id" ]; then
-            docker restart $velum_id
-        fi
-    - onchanges:
-      - x509: {{ pillar['ssl']['velum_key'] }}
-      - x509: {{ pillar['ssl']['velum_crt'] }}
+# TODO: This has been disabled, as the reload means a new cert warning is presented - breaking Velum's
+#       background polling. Velum's polling needs to be adapted to handle this, and once done, this can
+#       enabled again.
+# velum_restart:
+#   cmd.run:
+#     - name: |-
+#         velum_id=$(docker ps | grep "velum-dashboard" | awk '{print $1}')
+#         if [ -n "$velum_id" ]; then
+#             docker restart $velum_id
+#         fi
+#     - onchanges:
+#       - x509: {{ pillar['ssl']['velum_key'] }}
+#       - x509: {{ pillar['ssl']['velum_crt'] }}

--- a/salt/velum/init.sls
+++ b/salt/velum/init.sls
@@ -12,7 +12,7 @@ include:
 {% endif %}
 
 {{ pillar['ssl']['velum_key'] }}:
-  x509.private_key_managed:    
+  x509.private_key_managed:
     - bits: 4096
     - user: root
     - group: root
@@ -50,9 +50,9 @@ include:
       - sls:  crypto
       - {{ pillar['ssl']['velum_key'] }}
 
-# Send a USR2 to velum when the config changes
-# TODO: There should be a better way to handle this, but currently, there is not. See
-# kubernetes/kubernetes#24957
+# TODO: We should not restart the Velum container, but this is required for the new certificates to
+#       be loaded. Soon, we should stop serving content directly with Puma and it should be done
+#       by web servers instead of application servers (apache, nginx...).
 velum_restart:
   cmd.run:
     - name: |-


### PR DESCRIPTION
Temporarily disable restarting Velum when Velum's TLS certificate is
regenerated, as Velum's background polling needs to be adapted to
handle this situation. The operator has already clicked through the
invalid cert, and can restart velum at a time of their choosing to
load the valid cert.

Additionally, backport a comment correction.