### PR TITLE
Add orchestration step for velum /etc/hosts, bsc#1062728

### DIFF
--- a/salt/etc-hosts/init.sls
+++ b/salt/etc-hosts/init.sls
@@ -13,19 +13,3 @@ dummy_step:
   cmd.run:
     - name: "echo saltstack bug 14553"
 {% endif %}
-
-{# Velum container will not see any updates of the /etc/hosts. It can't be fixed with bind-mount #}
-{# of /etc/hosts in the container, because of fileblock.replace copies the new file over the old /etc/hosts. #}
-{# So the old /etc/hosts will remain mounted in the container (as bind-mount works at inode level). #}
-{# For more info see https://github.com/kubic-project/salt/pull/265#issuecomment-337256898 #}
-{% if "admin" in salt['grains.get']('roles', []) %}
-update-velum-hosts:
-  cmd.run:
-    - name: |-
-        velum_id=$( docker ps | grep velum-dashboard | awk '{print $1}')
-        if [ -n "$velum_id" ]; then
-            docker cp /etc/hosts $velum_id:/etc/hosts
-        fi
-    - onchanges:
-      - file: /etc/hosts
-{% endif %}

--- a/salt/etc-hosts/velum.sls
+++ b/salt/etc-hosts/velum.sls
@@ -1,0 +1,13 @@
+# Velum container will not see any updates of the /etc/hosts. It can't be fixed with bind-mount
+# of /etc/hosts in the container, because of fileblock.replace copies the new file over the old /etc/hosts.
+# So the old /etc/hosts will remain mounted in the container (as bind-mount works at inode level).
+# For more info see https://github.com/kubic-project/salt/pull/265#issuecomment-337256898
+{% if "admin" in salt['grains.get']('roles', []) %}
+update-velum:
+  cmd.run:
+    - name: |-
+        velum_id=$( docker ps | grep velum-dashboard | awk '{print $1}')
+        if [ -n "$velum_id" ]; then
+            docker cp /etc/hosts $velum_id:/etc/hosts
+        fi
+{% endif %}

--- a/salt/orch/kubernetes.sls
+++ b/salt/orch/kubernetes.sls
@@ -192,3 +192,13 @@ clear_bootstrap_in_progress_flag:
       - false
     - require:
       - salt: set_bootstrap_complete_flag
+
+# Ensure that /etc/hosts on velum is updated, bsc#1062728
+update_velum_etc_hosts:
+  salt.state:
+    - tgt: 'roles:admin'
+    - tgt_type: grain
+    - sls:
+      - etc-hosts.velum
+    - require:
+      - salt: clear_bootstrap_in_progress_flag

--- a/salt/orch/update-etc-hosts.sls
+++ b/salt/orch/update-etc-hosts.sls
@@ -33,6 +33,17 @@ etc_hosts_setup:
     - require:
       - salt: update_mine
 
+# Ensure that /etc/hosts on velum is updated, bsc#1062728
+update_velum_etc_hosts:
+  salt.state:
+    - tgt: 'roles:admin'
+    - tgt_type: compound
+    - queue: True
+    - sls:
+      - etc-hosts.velum
+    - require:
+      - salt: etc_hosts_setup
+
 kube_master_setup:
   salt.state:
     - tgt: {{ updates_master_target }}


### PR DESCRIPTION
On slow environments, velum can be created with empty /etc/hosts file
even with highstate orchestration step. We would like exclusively take care
about updating /etc/hosts on velum as last step in orchestration.