### PR TITLE
Wait for etcd to be alive

### DIFF
--- a/pillar/params.sls
+++ b/pillar/params.sls
@@ -58,7 +58,6 @@ addons:
   tiller: 'false'
 
 ssl:
-  enabled:        true
   ca_dir:         '/etc/pki/trust/anchors'
   ca_file:        '/etc/pki/trust/anchors/SUSE_CaaSP_CA.crt'
   crt_file:       '/etc/pki/minion.crt'

--- a/salt/etcd-discovery/init.sls
+++ b/salt/etcd-discovery/init.sls
@@ -1,12 +1,17 @@
 {% if salt['pillar.get']('etcd:disco:id', '')|length > 0 %}
 
-{% set etcd_size_uri = "http://" + pillar['dashboard'] + ":" + pillar['etcd']['disco']['port'] +
-         "/v2/keys/_etcd/registry/" + pillar['etcd']['disco']['id'] + "/_config/size" %}
+{% set etcd_base = "http://" + pillar['dashboard'] + ":" + pillar['etcd']['disco']['port'] %}
+{% set etcd_size_uri = etcd_base + "/v2/keys/_etcd/registry/" + pillar['etcd']['disco']['id'] + "/_config/size" %}
 
 # set the cluster size in the private Discovery registry
 etcd-discovery-setup:
   pkg.installed:
     - name: curl
+  # wait for etcd before trying to set anything...
+  http.wait_for_successful_query:
+    - name:       {{ etcd_base }}/health
+    - wait_for:   300
+    - status:     200
   cmd.run:
     - name: curl -L -X PUT {{ etcd_size_uri }} -d value={{ salt.caasp_etcd.get_cluster_size() }}
     - onlyif: curl {{ etcd_size_uri }} | grep '"message":"Key not found"'

--- a/salt/flannel-setup/init.sls
+++ b/salt/flannel-setup/init.sls
@@ -17,13 +17,16 @@ include:
 load_flannel_cfg:
   pkg.installed:
     - name: etcdctl
-  cmd.run:
+  caasp_cmd.run:
     - name: /usr/bin/etcdctl {{ etcd_opt }}
                              --no-sync
                              set {{ pillar['flannel']['etcd_key'] }}/config < /root/flannel-config.json
+    - retry:
+        attempts: 10
+        interval: 4
     - require:
       - sls: ca-cert
       - sls: cert
-      - service: etcd
+      - etcd # this will be removed when CNI is in
     - onchanges:
       - file: /root/flannel-config.json

--- a/salt/flannel-setup/init.sls
+++ b/salt/flannel-setup/init.sls
@@ -3,16 +3,11 @@ include:
   - cert
   - etcd
 
-{% if pillar['ssl']['enabled'] -%}
-  {% set ca = '--ca-file ' + pillar['ssl']['ca_file'] -%}
-  {% set key = '--key-file ' + pillar['ssl']['key_file'] -%}
-  {% set crt = '--cert-file ' + pillar['ssl']['crt_file'] -%}
-  {% set endpoint = '--endpoints https://' + grains['caasp_fqdn'] + ':2379' -%}
-  {% set etcd_opt = ca + ' ' + key + ' ' + crt + ' ' + endpoint -%}
-{% else -%}
-  {% set endpoint = '--endpoints http://' + grains['caasp_fqdn'] + ':2379' -%}
-  {% set etcd_opt = endpoint -%}
-{% endif -%}
+{% set ca = '--ca-file ' + pillar['ssl']['ca_file'] -%}
+{% set key = '--key-file ' + pillar['ssl']['key_file'] -%}
+{% set crt = '--cert-file ' + pillar['ssl']['crt_file'] -%}
+{% set endpoint = '--endpoints https://' + grains['caasp_fqdn'] + ':2379' -%}
+{% set etcd_opt = ca + ' ' + key + ' ' + crt + ' ' + endpoint -%}
 
 /root/flannel-config.json:
   file.managed:

--- a/salt/flannel/flanneld.sysconfig.jinja
+++ b/salt/flannel/flanneld.sysconfig.jinja
@@ -2,13 +2,11 @@
 
 {% set flannel_opt = "-v " + pillar['flannel']['log_level'] + " -iface " + grains['gateway_iface'] + " -ip-masq" -%}
 {% set http_protocol = 'http' -%}
-{% if pillar['ssl']['enabled'] -%}
-  {% set http_protocol = 'https' -%}
-  {% set etcd_ca = "-etcd-cafile " + pillar['ssl']['ca_file'] -%}
-  {% set etcd_key = "-etcd-keyfile " + pillar['ssl']['key_file'] -%}
-  {% set etcd_crt = "-etcd-certfile " + pillar['ssl']['crt_file'] -%}
-  {% set flannel_opt = flannel_opt + " " + etcd_ca + " " + etcd_key + " " + etcd_crt -%}
-{% endif -%}
+{% set http_protocol = 'https' -%}
+{% set etcd_ca = "-etcd-cafile " + pillar['ssl']['ca_file'] -%}
+{% set etcd_key = "-etcd-keyfile " + pillar['ssl']['key_file'] -%}
+{% set etcd_crt = "-etcd-certfile " + pillar['ssl']['crt_file'] -%}
+{% set flannel_opt = flannel_opt + " " + etcd_ca + " " + etcd_key + " " + etcd_crt -%}
 
 # etcd url location.  Point this to the server where etcd runs
 FLANNEL_ETCD_ENDPOINTS="{{ http_protocol }}://{{ grains['caasp_fqdn'] }}:2379"

--- a/salt/flannel/init.sls
+++ b/salt/flannel/init.sls
@@ -38,5 +38,5 @@ flannel:
       - pkg: flannel
       - iptables: flannel
     - watch:
-      - service: etcd
+      - etcd  # this will be removed when CNI is in
       - file: /etc/sysconfig/flanneld

--- a/salt/kube-apiserver/apiserver.jinja
+++ b/salt/kube-apiserver/apiserver.jinja
@@ -11,14 +11,10 @@ KUBE_API_ADDRESS="--insecure-bind-address=127.0.0.1 --bind-address=0.0.0.0"
 KUBE_API_PORT="--insecure-port=8080 --secure-port={{ pillar['api']['int_ssl_port'] }}"
 
 # Comma separated list of nodes in the etcd cluster
-{% if pillar['ssl']['enabled'] -%}
 KUBE_ETCD_SERVERS="--etcd-cafile={{ pillar['ssl']['ca_file'] }} \
                    --etcd-certfile={{ pillar['ssl']['kube_apiserver_crt'] }} \
                    --etcd-keyfile={{ pillar['ssl']['kube_apiserver_key'] }} \
                    --etcd-servers=https://{{ grains['caasp_fqdn'] }}:2379"
-{% else -%}
-KUBE_ETCD_SERVERS="--etcd-servers=http://{{ grains['caasp_fqdn'] }}:2379"
-{% endif -%}
 
 # Address range to use for services
 # [alvaro] should not be in the same range as the flannel network (https://github.com/coreos/flannel/issues/232)

--- a/salt/reboot/init.sls
+++ b/salt/reboot/init.sls
@@ -25,8 +25,8 @@ set_max_holders_mutex:
   cmd.run:
     - name: curl -L -X PUT {{ reboot_uri }}/mutex?prevExist=false -d value="0"
     - onlyif: curl {{ reboot_uri }}/mutex?prevExist=false | grep -i "key not found"
-    - require:
-      - service: etcd
+    - watch:
+      - etcd
 
 # Initialize the `data` key, which is JSON data with: the maximum number of
 # holders, and a list of current holders.
@@ -37,6 +37,6 @@ set_max_holders_data:
     - name: >-
         curl -L -X PUT {{ reboot_uri }}/data?prevExist=false -d value='{ "max":"{{ max_holders }}", "holders":[] }'
     - onlyif: curl {{ reboot_uri }}/data?prevExist=false | grep -i "key not found"
-    - require:
+    - watch:
       - cmd: set_max_holders_mutex
-      - service: etcd
+      - etcd


### PR DESCRIPTION
Wait for `etcd` to be alive before trying to set anything
Remove the 'ssl:enabled' pillar: we do not really support non-SSL deployments...
