### PR TITLE
WIP: Silence a confusing, and invalid, error event

### DIFF
--- a/salt/orch/update-etc-hosts.sls
+++ b/salt/orch/update-etc-hosts.sls
@@ -32,7 +32,9 @@ etc_hosts_setup:
       - etc-hosts
     - require:
       - salt: update_mine
+{% endif %}
 
+{%- if salt.saltutil.runner('mine.get', tgt=updates_master_target, fun='caasp_fqdn', tgt_type='compound')|length > 0 %}
 kube_master_setup:
   salt.state:
     - tgt: {{ updates_master_target }}


### PR DESCRIPTION
When there are no masters for the update-etc-hosts orch to apply to, the state will
fail with "kube_master_setup", "No highstate or sls specified, no execution made".
This is not actually a failure, and is expected in some scenarios.

WIP as, when no states are ran, I don't know how salt reacts. Needs checking, as we may just trade 1 known error for another unknown.