### PR TITLE
Fix random iptables crashes bsc 1064186

### DIFF
--- a/salt/_states/caasp_retriable.py
+++ b/salt/_states/caasp_retriable.py
@@ -1,0 +1,58 @@
+from __future__ import absolute_import
+import time
+
+import salt.exceptions
+import salt.utils
+
+
+def retry(name, target, retry={}, **kwargs):
+    '''
+    Wraps an existing salt state into a retriable form.
+
+    name
+        A user-defined name.
+
+    target
+        Name of the salt state to invoke.
+
+    retry
+        This allows you to provide `attempts` and `interval`, what will retry
+        the command as much ``attempts`` times, separated by `interval`
+        seconds. By default performs 1 attempt with a 1 second interval.
+
+    All other arguments are passed to the orginal salt state.
+
+    '''
+
+    retry_ = {'attempts': 1, 'interval': 1}
+    retry_.update(retry)
+
+    ret = None
+
+    for attempt in xrange(retry_['attempts']):
+        ret = __states__[target](name=name, **kwargs)
+
+        if ret['result']:
+            return {
+                'name': "caasp_retriable.{0}.{1}".format(name, target),
+                'changes': ret['changes'],
+                'result': True,
+                'comment': "Command executed succesfully after {0} retries. "
+                "Last output: {1}".format(attempt + 1, ret['comment'])}
+
+        if attempt + 1 == retry_['attempts']:
+            break
+
+        if retry_['interval'] > 0:
+            time.sleep(retry_['interval'])
+
+    return {
+        'name': "caasp_retriable.{0}.{1}".format(name, target),
+        'changes': ret['changes'],
+        'result': False,
+        'comment': "Command failed after {0} retries. "
+                   "Last output: {1} "
+                   "Params: {2}".format(
+                       retry_['attempts'],
+                       ret['comment'],
+                       kwargs)}

--- a/salt/etcd/init.sls
+++ b/salt/etcd/init.sls
@@ -21,7 +21,11 @@ etcd:
       - etcd
     - require:
       - file: /etc/zypp/repos.d/containers.repo
-  iptables.append:
+  caasp_retriable.retry:
+    - name: iptables-etcd
+    - target: iptables.append
+    - retry:
+        attempts: 2
     - table: filter
     - family: ipv4
     - chain: INPUT
@@ -41,7 +45,7 @@ etcd:
     - require:
       - sls: ca-cert
       - pkg: etcd
-      - iptables: etcd
+      - caasp_retriable: iptables-etcd
     - watch:
       - {{ pillar['ssl']['crt_file'] }}
       - {{ pillar['ssl']['key_file'] }}

--- a/salt/flannel/init.sls
+++ b/salt/flannel/init.sls
@@ -9,7 +9,11 @@ flannel:
       - flannel
     - require:
       - file: /etc/zypp/repos.d/containers.repo
-  iptables.append:
+  caasp_retriable.retry:
+    - name: iptables-flannel
+    - target: iptables.append
+    - retry:
+        attempts: 2
     - table: filter
     - family: ipv4
     - chain: INPUT
@@ -36,7 +40,7 @@ flannel:
     - enable: True
     - require:
       - pkg: flannel
-      - iptables: flannel
+      - caasp_retriable: iptables-flannel
     - watch:
       - etcd  # this will be removed when CNI is in
       - file: /etc/sysconfig/flanneld

--- a/salt/haproxy/init.sls
+++ b/salt/haproxy/init.sls
@@ -18,11 +18,15 @@ haproxy:
     - mode: 644
     - makedirs: True
     - dir_mode: 755
+  caasp_retriable.retry:
+    - name: iptables-haproxy
 {% if "kube-master" in salt['grains.get']('roles', []) %}
-  iptables.append:
+    - target: iptables.append
 {% else %}
-  iptables.delete:
+    - target: iptables.delete
 {% endif %}
+    - retry:
+        attempts: 2
     - table:      filter
     - family:     ipv4
     - chain:      INPUT

--- a/salt/kube-apiserver/init.sls
+++ b/salt/kube-apiserver/init.sls
@@ -21,7 +21,11 @@ kube-apiserver:
       - kubernetes-master
     - require:
       - file: /etc/zypp/repos.d/containers.repo
-  iptables.append:
+  caasp_retriable.retry:
+    - name: iptables-kube-apiserver
+    - target: iptables.append
+    - retry:
+        attempts: 2
     - table:      filter
     - family:     ipv4
     - chain:      INPUT
@@ -40,7 +44,7 @@ kube-apiserver:
   service.running:
     - enable:     True
     - require:
-      - iptables: kube-apiserver
+      - caasp_retriable: iptables-kube-apiserver
       - sls:      ca-cert
       - x509:     {{ pillar['ssl']['kube_apiserver_crt'] }}
       - x509:     {{ pillar['paths']['service_account_key'] }}

--- a/salt/kubelet/init.sls
+++ b/salt/kubelet/init.sls
@@ -94,7 +94,11 @@ kubelet:
       - file:   /etc/kubernetes/manifests
       - file:   /etc/kubernetes/kubelet-initial
       - kubelet-config
-  iptables.append:
+  caasp_retriable.retry:
+    - name: iptables-kubelet
+    - target: iptables.append
+    - retry:
+        attempts: 2
     - table:     filter
     - family:    ipv4
     - chain:     INPUT


### PR DESCRIPTION
This is an attempt to fix bsc#1064186 by executing the iptables statements more than once.

This PR introcuces also `caasp_retriable.retry` state that allows to retry any kind of salt state. Once merged we could get rid of the `caasp_cmd`.