### PR TITLE
Minor certificates optimizations

### DIFF
--- a/salt/_macros/certs.jinja
+++ b/salt/_macros/certs.jinja
@@ -49,6 +49,7 @@
 
 {{ crt }}:
   x509.certificate_managed:
+    - overwrite: False
     - ca_server: {{ salt['mine.get']('roles:ca', 'ca.crt', expr_form='grain').keys()[0] }}
     - signing_policy: minion
   {%- if cn|length > 0 %}
@@ -81,11 +82,11 @@
     - group: root
     - mode: 644
     - managed_private_key:
-      - name: {{ key }}
-      - bits: 4096
-      - user: root
-      - group: root
-      - mode: 444
+        name: {{ key }}
+        bits: 4096
+        user: root
+        group: root
+        mode: 444
     - require:
       - sls: crypto
       - file: /etc/pki

--- a/salt/_macros/certs.jinja
+++ b/salt/_macros/certs.jinja
@@ -47,21 +47,10 @@
 
 {% macro certs(name, crt, key, cn='', o='', extra=[]) -%}
 
-{{ key }}:
-  x509.private_key_managed:
-    - bits: 4096
-    - user: root
-    - group: root
-    - mode: 444
-    - require:
-      - sls:  crypto
-      - file: /etc/pki
-
 {{ crt }}:
   x509.certificate_managed:
     - ca_server: {{ salt['mine.get']('roles:ca', 'ca.crt', expr_form='grain').keys()[0] }}
     - signing_policy: minion
-    - public_key: {{ key }}
   {%- if cn|length > 0 %}
     - CN: {{ cn|yaml_dquote }}
   {%- else %}
@@ -91,9 +80,15 @@
     - user: root
     - group: root
     - mode: 644
+    - managed_private_key:
+      - name: {{ key }}
+      - bits: 4096
+      - user: root
+      - group: root
+      - mode: 444
     - require:
       - sls: crypto
-      - x509: {{ key }}
+      - file: /etc/pki
 
 {{ crt }}-bundle:
   file.managed:

--- a/salt/_macros/certs.jinja
+++ b/salt/_macros/certs.jinja
@@ -47,6 +47,16 @@
 
 {% macro certs(name, crt, key, cn='', o='', extra=[]) -%}
 
+{% if salt['file.file_exists'](crt) and
+      not salt['x509.expired'](crt)['expired'] %}
+
+{{ crt }}:
+  file.exists:
+    - require:
+      - {{ pillar['ssl']['ca_file'] }}
+
+{% else %}
+
 {{ crt }}:
   x509.certificate_managed:
     - overwrite: False
@@ -90,6 +100,9 @@
     - require:
       - sls: crypto
       - file: /etc/pki
+      - {{ pillar['ssl']['ca_file'] }}
+
+{% endif %}
 
 {{ crt }}-bundle:
   file.managed:

--- a/salt/kube-apiserver/init.sls
+++ b/salt/kube-apiserver/init.sls
@@ -45,15 +45,15 @@ kube-apiserver:
     - enable:     True
     - require:
       - caasp_retriable: iptables-kube-apiserver
-      - sls:      ca-cert
-      - x509:     {{ pillar['ssl']['kube_apiserver_crt'] }}
-      - x509:     {{ pillar['paths']['service_account_key'] }}
+      - {{ pillar['ssl']['ca_file'] }}
+      - {{ pillar['ssl']['kube_apiserver_crt'] }}
+      - {{ pillar['paths']['service_account_key'] }}
     - watch:
       - sls:      kubernetes-common
       - file:     kube-apiserver
-      - sls:      ca-cert
-      - x509:     {{ pillar['ssl']['kube_apiserver_crt'] }}
-      - x509:     {{ pillar['paths']['service_account_key'] }}
+      - {{ pillar['ssl']['ca_file'] }}
+      - {{ pillar['ssl']['kube_apiserver_crt'] }}
+      - {{ pillar['paths']['service_account_key'] }}
   # wait until the API server is actually up and running
   http.wait_for_successful_query:
     {% set api_server = "api." + pillar['internal_infra_domain']  -%}

--- a/salt/kube-controller-manager/init.sls
+++ b/salt/kube-controller-manager/init.sls
@@ -19,10 +19,10 @@ kube-controller-manager:
       - sls:      kubernetes-common
       - file:     kube-controller-manager
       - kube-controller-mgr-config
-      - x509:     {{ pillar['paths']['service_account_key'] }}
+      - {{ pillar['paths']['service_account_key'] }}
     - require:
       - kube-controller-mgr-config
-      - x509:     {{ pillar['paths']['service_account_key'] }}
+      - {{ pillar['paths']['service_account_key'] }}
 
 {% from '_macros/certs.jinja' import certs with context %}
 {{ certs("kube-controller-manager", pillar['ssl']['kube_controller_mgr_crt'], pillar['ssl']['kube_controller_mgr_key']) }}

--- a/salt/velum/init.sls
+++ b/salt/velum/init.sls
@@ -18,4 +18,25 @@ include:
          pillar['ssl']['velum_crt'],
          pillar['ssl']['velum_key'],
          cn = grains['caasp_fqdn'],
+<<<<<<< HEAD
          extra = extra_names(names, ips)) }}
+=======
+         extra = extra_names(names, ips)) }}
+
+# TODO: We should not restart the Velum container, but this is required for the new certificates to
+#       be loaded. Soon, we should stop serving content directly with Puma and it should be done
+#       by web servers instead of application servers (apache, nginx...).
+# bsc#1062728: Add onchanges_in cmd: update-velum-hosts. After velum restart /etc/hosts will be recreated,
+#       we have to sync this file again with Admin node.
+velum_restart:
+  cmd.run:
+    - name: |-
+        velum_id=$(docker ps | grep "velum-dashboard" | awk '{print $1}')
+        if [ -n "$velum_id" ]; then
+            docker restart $velum_id
+        fi
+    - onchanges:
+      - x509: {{ pillar['ssl']['velum_crt'] }}
+    - onchanges_in:
+      - cmd: update-velum-hosts
+>>>>>>> Reduce the number of x509.sign_remote_certificate

--- a/salt/velum/init.sls
+++ b/salt/velum/init.sls
@@ -18,25 +18,4 @@ include:
          pillar['ssl']['velum_crt'],
          pillar['ssl']['velum_key'],
          cn = grains['caasp_fqdn'],
-<<<<<<< HEAD
          extra = extra_names(names, ips)) }}
-=======
-         extra = extra_names(names, ips)) }}
-
-# TODO: We should not restart the Velum container, but this is required for the new certificates to
-#       be loaded. Soon, we should stop serving content directly with Puma and it should be done
-#       by web servers instead of application servers (apache, nginx...).
-# bsc#1062728: Add onchanges_in cmd: update-velum-hosts. After velum restart /etc/hosts will be recreated,
-#       we have to sync this file again with Admin node.
-velum_restart:
-  cmd.run:
-    - name: |-
-        velum_id=$(docker ps | grep "velum-dashboard" | awk '{print $1}')
-        if [ -n "$velum_id" ]; then
-            docker restart $velum_id
-        fi
-    - onchanges:
-      - x509: {{ pillar['ssl']['velum_crt'] }}
-    - onchanges_in:
-      - cmd: update-velum-hosts
->>>>>>> Reduce the number of x509.sign_remote_certificate


### PR DESCRIPTION
By embedding the private key in the `certificate_managed` Salt can skip some certificate regenerations.

We are trying to reduce the number of `x509.sign_remote_certificate` events in the master: this reduced the number from 45 to 32 in a cluster with 1 admin, 1 master and 1 node, but it is still too high...