### PR TITLE
Disable container-feeder before rebooting

### DIFF
--- a/salt/container-feeder/init.sls
+++ b/salt/container-feeder/init.sls
@@ -12,4 +12,5 @@ container-feeder:
     - reload: True
     - require:
       - cmd: docker
+    - watch:
       - service: docker

--- a/salt/container-feeder/stop.sls
+++ b/salt/container-feeder/stop.sls
@@ -1,0 +1,4 @@
+# Stop and disable container-feeder
+container-feeder:
+  service.dead:
+    - enable: False

--- a/salt/orch/update.sls
+++ b/salt/orch/update.sls
@@ -45,6 +45,7 @@ update_modules:
   salt.state:
     - tgt: {{ master_id }}
     - sls:
+      - container-feeder.stop
       - kube-apiserver.stop
       - kube-controller-manager.stop
       - kube-scheduler.stop
@@ -124,8 +125,9 @@ update_modules:
   salt.state:
     - tgt: {{ worker_id }}
     - sls:
+      - container-feeder.stop
       - kubelet.stop
-      - kube-proxy.stop      
+      - kube-proxy.stop
       - docker.stop
       - flannel.stop
       - etcd.stop


### PR DESCRIPTION
This will allow us to control when container-feeder starts to load new
images from the filesystem. Due to some possible docker configuration changes
it might be restarted while container-feeder is working (if we keep it
enabled). Force to disable the service before rebooting.

Fixes: bsc#1066653