### PR TITLE
[2.0] only set service entries for localhost on kube-master

### DIFF
--- a/salt/etc-hosts/hosts.jinja
+++ b/salt/etc-hosts/hosts.jinja
@@ -1,5 +1,11 @@
 ### service names ###
+# set the apiserver for 127.0.0.1 on all hosts as haproxy is listening on all nodes
+# and forwarding connections to the real master
+{% if "kube-master" in salt['grains.get']('roles', []) %}
 127.0.0.1 api api.{{ pillar['internal_infra_domain'] }} {{ pillar['api']['server']['external_fqdn'] }}
+{% else %}
+127.0.0.1 api api.{{ pillar['internal_infra_domain'] }}
+{% endif %}
 
 ### admin nodes ###
 {%- set admins = salt['mine.get']('roles:admin', 'network.ip_addrs', 'grain') %}


### PR DESCRIPTION
also explain in a comment why we need to set the apiserver for 127.0.0.1
on all hosts

(bsc#1067219)

Signed-off-by: Maximilian Meister <mmeister@suse.de>
(cherry picked from commit 610f65e57c7daa96d9f7ad51addcb0e919fba837)

Backport of https://github.com/kubic-project/salt/pull/302