### PR TITLE
Include `Internal Dashboard FQDN/IP` value in the LDAP certificate

### DIFF
--- a/pillar/certificates.sls
+++ b/pillar/certificates.sls
@@ -27,6 +27,9 @@ ssl:
   velum_key: '/etc/pki/private/velum.key'
   velum_crt: '/etc/pki/velum.crt'
 
+  ldap_key: '/etc/pki/private/ldap.key'
+  ldap_crt: '/etc/pki/ldap.crt'
+
   dex_key: '/etc/pki/dex.key'
   dex_crt: '/etc/pki/dex.crt'
 

--- a/salt/ldap/init.sls
+++ b/salt/ldap/init.sls
@@ -1,0 +1,31 @@
+include:
+  - ca-cert
+  - cert
+
+{% set names = [] %}
+{% set ips = [] %}
+
+{% set dashboard = salt['pillar.get']('dashboard', '') %}
+{% if salt['caasp_filters.is_ip'](dashboard) %}
+  {% do ips.append(dashboard) %}
+{% else %}
+  {% do names.append(dashboard) %}
+{% endif %}
+
+{% from '_macros/certs.jinja' import extra_names, certs with context %}
+{{ certs("ldap:" + grains['caasp_fqdn'],
+         pillar['ssl']['ldap_crt'],
+         pillar['ssl']['ldap_key'],
+         cn = grains['caasp_fqdn'],
+         extra = extra_names(names, ips)) }}
+
+openldap_restart:
+  cmd.run:
+    - name: |-
+        openldap_id=$(docker ps | grep "openldap" | awk '{print $1}')
+        if [ -n "$openldap_id" ]; then
+            docker restart $openldap_id
+        fi
+    - onchanges:
+      - x509: {{ pillar['ssl']['ldap_key'] }}
+      - x509: {{ pillar['ssl']['ldap_crt'] }}

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -13,6 +13,7 @@ base:
   'roles:admin':
     - match: grain
     - velum
+    - ldap
   'roles:kube-(master|minion)':
     - match: grain_pcre
     - ca-cert


### PR DESCRIPTION
Since Dex will connect to LDAP using this FQDN/IP, make sure that the
TLS handshake will succeed by regenerating the certificate early in
the orchestration, so it includes this FQDN/IP in the SAN extensions
of the LDAP certificate.

Fixes: bsc#1069175