### PR TITLE
Fix certificates (bsc#1069205)

### DIFF
--- a/salt/_macros/certs.jinja
+++ b/salt/_macros/certs.jinja
@@ -1,51 +1,58 @@
 
-{% macro extra_names(names=[], ips=[]) -%}
+{% macro alt_names(lst=[]) -%}
   {#- add all the names and IPs we know about -#}
-  {%- set extra = ["DNS: " + grains['caasp_fqdn'] ] -%}
+  {%- set altNames = ["DNS: " + grains['caasp_fqdn'] ] -%}
   {%- for _, interface_addresses in grains['ip4_interfaces'].items() -%}
     {%- for interface_address in interface_addresses -%}
-      {%- do extra.append("IP: " + interface_address) -%}
+      {%- do altNames.append("IP: " + interface_address) -%}
     {%- endfor -%}
   {%- endfor -%}
   {#- append all the names/IPs provided (if not empty) -#}
-  {%- for name in names -%}
+  {%- for name in lst -%}
     {%- if name|length > 0 -%}
-      {%- do extra.append("DNS: " + name) -%}
+      {%- if salt['caasp_filters.is_ip'](name) -%}
+        {%- do altNames.append("IP: " + name) -%}
+      {%- else -%}
+        {%- do altNames.append("DNS: " + name) -%}
+      {%- endif -%}
     {%- endif -%}
   {%- endfor -%}
-  {%- for ip in ips -%}
-    {%- if ip|length > 0 -%}
-      {%- do extra.append("IP: " + ip) -%}
-    {%- endif -%}
-  {%- endfor -%}
-  {{ ", ".join(extra) }}
+  {{ ", ".join(altNames) }}
 {%- endmacro %}
 
 #####################################################################
 
-# a list of extra names for a kubernetes master
-{% macro extra_master_names(names=[], ips=[]) -%}
+# a list of alternative names for a kubernetes master
+{% macro alt_master_names(lst=[]) -%}
   {%- set names_lst = ["kubernetes",
-                      "kubernetes.default",
-                      "kubernetes.default.svc",
-                      "api",
-                      "api." + pillar['internal_infra_domain'],
-                      salt['pillar.get']('api:server:external_fqdn', '')] +
-                      salt['pillar.get']('api:server:extra_names', []) +
-                      names -%}
-  {%- set ips_lst   = [pillar['api']['cluster_ip']] +
-                      salt['pillar.get']('api:server:extra_ips', []) +
-                      ips -%}
+                       "kubernetes.default",
+                       "kubernetes.default.svc",
+                       "api",
+                       "api." + pillar['internal_infra_domain'],
+                       salt['pillar.get']('api:server:external_fqdn', ''),
+                       salt['pillar.get']('api:cluster_ip', '')] +
+                       salt['pillar.get']('api:server:extra_names', []) +
+                       salt['pillar.get']('api:server:extra_ips', []) +
+                       lst -%}
   {#- add some standard extra names from the DNS domain -#}
   {%- if salt['pillar.get']('dns:domain') -%}
     {%- do names_lst.append("kubernetes.default.svc." + pillar['dns']['domain']) -%}
   {%- endif -%}
-  {{ extra_names(names_lst, ips_lst) }}
+  {{ alt_names(names_lst) }}
 {%- endmacro %}
 
 #####################################################################
 
-{% macro certs(name, crt, key, cn='', o='', extra=[]) -%}
+{% macro certs(name, crt, key, cn='', o='', extra_alt_names=None) -%}
+
+{%- if extra_alt_names == None -%}
+  {#- calculate automatically the altNames depending on the role -#}
+  {%- if "kube-master" in salt['grains.get']('roles', []) -%}
+    {%- set extra_alt_names = alt_master_names() -%}
+  {%- else -%}
+    {%- set extra_alt_names = alt_names() -%}
+  {%- endif -%}
+{%- endif -%}
 
 {{ key }}:
   x509.private_key_managed:
@@ -82,8 +89,8 @@
     - ST: {{ pillar['certificate_information']['subject_properties']['ST']|yaml_dquote }}
     - basicConstraints: "critical CA:false"
     - keyUsage: nonRepudiation, digitalSignature, keyEncipherment
-  {%- if extra|length > 0 %}
-    - subjectAltName: {{ extra|yaml_dquote }}
+  {%- if extra_alt_names|length > 0 %}
+    - subjectAltName: {{ extra_alt_names|yaml_dquote }}
   {%- endif %}
     - days_valid: {{ pillar['certificate_information']['days_valid']['certificate'] }}
     - days_remaining: {{ pillar['certificate_information']['days_remaining']['certificate'] }}

--- a/salt/cert/init.sls
+++ b/salt/cert/init.sls
@@ -1,15 +1,9 @@
 include:
   - crypto
 
-{% from '_macros/certs.jinja' import extra_names, extra_master_names, certs with context %}
-
-{% set extra = extra_names() %}
-{% if "kube-master" in salt['grains.get']('roles', []) %}
-  {% set extra = extra_master_names() %}
-{% endif %}
+{% from '_macros/certs.jinja' import certs with context %}
 
 {{ certs("node:" + grains['caasp_fqdn'],
          pillar['ssl']['crt_file'],
          pillar['ssl']['key_file'],
-         o = pillar['certificate_information']['subject_properties']['O'],
-         extra = extra) }}
+         o = pillar['certificate_information']['subject_properties']['O']) }}

--- a/salt/dex/init.sls
+++ b/salt/dex/init.sls
@@ -4,18 +4,18 @@ include:
   - kubectl-config
   - kube-apiserver
 
-{% from '_macros/certs.jinja' import extra_master_names, certs with context %}
+{% from '_macros/certs.jinja' import alt_master_names, certs with context %}
 {% from '_macros/kubectl.jinja' import kubectl, kubectl_apply_template with context %}
 
-{% set dex_extra_names =["DNS: dex",
-                         "DNS: dex.kube-system",
-                         "DNS: dex.kube-system.svc",
-                         "DNS: dex.kube-system.svc." + pillar['internal_infra_domain']] %}
+{% set dex_alt_names = ["dex",
+                        "dex.kube-system",
+                        "dex.kube-system.svc",
+                        "dex.kube-system.svc." + pillar['internal_infra_domain']] %}
 {{ certs('dex',
          pillar['ssl']['dex_crt'],
          pillar['ssl']['dex_key'],
          cn = 'Dex',
-         extra = extra_master_names(names=dex_extra_names)) }}
+         extra_alt_names = alt_master_names(dex_alt_names)) }}
 
 {{ kubectl("dex_secrets",
            "create secret generic dex-tls --namespace=kube-system --from-file=/etc/pki/dex.crt --from-file=/etc/pki/dex.key",
@@ -30,4 +30,3 @@ include:
 {{ kubectl_apply_template("salt://dex/roles.yaml",
                           "/root/roles.yaml",
                           watch=["dex_secrets", "/root/dex.yaml"]) }}
-

--- a/salt/kube-apiserver/init.sls
+++ b/salt/kube-apiserver/init.sls
@@ -6,13 +6,12 @@ include:
   - kubernetes-common
   - kubernetes-common.serviceaccount-key
 
-{% from '_macros/certs.jinja' import extra_master_names, certs with context %}
+{% from '_macros/certs.jinja' import certs with context %}
 {{ certs("kube-apiserver",
          pillar['ssl']['kube_apiserver_crt'],
          pillar['ssl']['kube_apiserver_key'],
          cn = grains['caasp_fqdn'],
-         o = pillar['certificate_information']['subject_properties']['O'],
-         extra = extra_master_names()) }}
+         o = pillar['certificate_information']['subject_properties']['O']) }}
 
 kube-apiserver:
   pkg.installed:

--- a/salt/kube-proxy/init.sls
+++ b/salt/kube-proxy/init.sls
@@ -2,12 +2,11 @@ include:
   - repositories
   - kubernetes-common
 
-{% from '_macros/certs.jinja' import extra_names, certs with context %}
+{% from '_macros/certs.jinja' import certs with context %}
 {{ certs('kube-proxy',
          pillar['ssl']['kube_proxy_crt'],
          pillar['ssl']['kube_proxy_key'],
-         o = 'system:nodes',
-         extra = extra_names()) }}
+         o = 'system:nodes') }}
 
 {{ pillar['paths']['kube_proxy_config'] }}:
   file.managed:

--- a/salt/kubectl-config/init.sls
+++ b/salt/kubectl-config/init.sls
@@ -2,13 +2,12 @@ include:
   - crypto
   - kubernetes-common
 
-{% from '_macros/certs.jinja' import extra_names, certs with context %}
+{% from '_macros/certs.jinja' import certs with context %}
 {{ certs('kubectl',
          pillar['ssl']['kubectl_crt'],
          pillar['ssl']['kubectl_key'],
          cn = 'cluster-admin',
-         o = 'system:masters',
-         extra = extra_names()) }}
+         o = 'system:masters') }}
 
 {{ pillar['paths']['kubeconfig'] }}:
 # this kubeconfig file is used by kubectl for administrative functions

--- a/salt/kubelet/init.sls
+++ b/salt/kubelet/init.sls
@@ -17,12 +17,11 @@ include:
       schedulable: "false"
 {% endif %}
 
-{% from '_macros/certs.jinja' import extra_names, certs with context %}
+{% from '_macros/certs.jinja' import certs with context %}
 {{ certs('node:' + grains['caasp_fqdn'],
          pillar['ssl']['kubelet_crt'],
          pillar['ssl']['kubelet_key'],
-         o = 'system:nodes',
-         extra = extra_names()) }}
+         o = 'system:nodes') }}
 
 kubelet-config:
   file.managed:

--- a/salt/velum/init.sls
+++ b/salt/velum/init.sls
@@ -3,19 +3,12 @@ include:
   - ca-cert
   - cert
 
-{% set names = [salt['pillar.get']('dashboard_external_fqdn', '')] %}
-{% set ips = [] %}
+{% set names = [salt['pillar.get']('dashboard_external_fqdn', ''),
+                salt['pillar.get']('dashboard', '')] %}
 
-{% set dashboard = salt['pillar.get']('dashboard', '') %}
-{% if salt['caasp_filters.is_ip'](dashboard) %}
-  {% do ips.append(dashboard) %}
-{% else %}
-  {% do names.append(dashboard) %}
-{% endif %}
-
-{% from '_macros/certs.jinja' import extra_names, certs with context %}
+{% from '_macros/certs.jinja' import alt_names, certs with context %}
 {{ certs("velum:" + grains['caasp_fqdn'],
          pillar['ssl']['velum_crt'],
          pillar['ssl']['velum_key'],
          cn = grains['caasp_fqdn'],
-         extra = extra_names(names, ips)) }}
+         extra_alt_names = alt_names(names)) }}


### PR DESCRIPTION
In the certs macros, do not assume _"names"_ are always names and _"ips"_ are always IPs: just filter with the `is_ip()` filter and act accordingly.
Fix certifcates for dex: there were entries like `DNS:DNS:dex`
Minor shortcuts in the arguments.

Fixes: bsc#1069205