### PR TITLE
Registries and mirrors (bsc#1039877)

### DIFF
--- a/pillar/args.sls
+++ b/pillar/args.sls
@@ -3,9 +3,6 @@ docker:
   # Extra arguments to be passed to the Docker daemon.
   args: '--iptables=false'
 
-  # Use a docker registry (it must be a http service)
-  registry: ''
-
   # Set the logging level for dockerd
   # ( debug, info, warn, error, fatal )
   log_level: 'warn'

--- a/pillar/args.sls
+++ b/pillar/args.sls
@@ -1,13 +1,3 @@
-# Docker-specific parameters.
-docker:
-  # Extra arguments to be passed to the Docker daemon.
-  args: '--iptables=false'
-
-  # Set the logging level for dockerd
-  # ( debug, info, warn, error, fatal )
-  log_level: 'warn'
-
-
 # Specific parameters for each Kubernetes component.
 components:
   apiserver:

--- a/pillar/docker.sls
+++ b/pillar/docker.sls
@@ -1,0 +1,6 @@
+docker:
+  pkg: 'docker_1_12_6'
+  daemon:
+    # this mirrors the structure in /etc/docker/daemon.json
+    iptables: 'false'
+    log_level: 'warn'

--- a/pillar/registries.sls
+++ b/pillar/registries.sls
@@ -1,0 +1,24 @@
+# we can add certificates for particular registries like this:
+#
+# registries:
+#   - url: http://my.reg.url
+#   - url: http://my.reg.url.port:5000
+#   - url: my.reg.port:5000
+#   - url: https://my.reg.port.cert:5000
+#     cert: |
+#         >> the certificate for "my.reg.port.cert:5000" <<
+#   - url: weird.port.cert:8888
+#     cert: |
+#         >> the certificate for "weird.port.cert:8888" <<
+#   - url: http://my.mirrored.registry:5000
+#     mirrors:
+#     - url: https://local.mirror.lan:5000
+#       cert: |
+#           >> the certificate for "local.mirror.lan:5000" <<
+#     - url: mirror.with.no.port
+#       cert: |
+#           >> the certificate for "mirror.with.no.port" <<
+#
+# NOTE: secure (https://) is the default, adding http:// to the name will mark it insecure
+#
+registries: []

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -5,6 +5,7 @@ base:
     - vars
     - certificates
     - mine
+    - docker
     - fqdn
     - schedule
   'roles:ca':

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -6,6 +6,7 @@ base:
     - certificates
     - mine
     - docker
+    - registries
     - fqdn
     - schedule
   'roles:ca':

--- a/salt/_modules/caasp_docker.py
+++ b/salt/_modules/caasp_docker.py
@@ -1,0 +1,83 @@
+from __future__ import absolute_import
+
+import logging
+from urlparse import urlparse
+
+LOG = logging.getLogger(__name__)
+
+
+def __virtual__():
+    return "caasp_docker"
+
+
+def _get_hostname_and_port(url, default_port=None):
+    parsed = urlparse(url)
+    if parsed.hostname:
+        hostname = parsed.hostname
+        port = parsed.port
+    else:
+        splitted_url = url.split(':')
+        hostname = splitted_url[0]
+        if len(splitted_url) > 1:
+            port = int(splitted_url[1])
+        else:
+            port = None
+
+    res = (hostname, port or default_port)
+    LOG.debug("%s parsed as %s", url, res)
+    return res
+
+
+def get_registries_certs(lst, default_port=5000):
+    '''
+    Given a list of "valid" items, return a dictionay of
+    "<HOST>[:<PORT>]" -> <CERT>
+    "valid" items must be get'able objects, with attributes
+    "url", "cert" and (optional) "mirrors"
+    "url"s can be [<PROTO>://]<HOST>[:<PORT>]
+    '''
+    certs = {}
+
+    LOG.debug('Finding certificates in: %s', lst)
+    for registry in lst:
+        url = registry.get('url')
+        cert = registry.get('cert', '')
+        if len(cert) > 0:
+
+            # parse the name as an URL or "host:port", and return <HOST>[:<PORT>]
+            hostname, port = _get_hostname_and_port(url)
+            host_port = hostname
+            if port:
+                host_port += ":" + str(port)
+
+            LOG.debug('Adding certificate for: %s', host_port)
+            certs[host_port] = cert
+
+            if port:
+                if port == default_port:
+                    # When using the standar port (5000), if the user introduces
+                    # "my-registry:5000" as a trusted registry, he/she will be able
+                    # to do "docker pull my-registry:5000/some/image" but not
+                    # "docker pull my-registry/some/image".
+                    # So we must also create the "ca.crt" for "my-registry"
+                    # as he/she could just access "docker pull my-registry/some/image",
+                    # and Docker would fail to find "my-registry/ca.crt"
+                    name = hostname
+                    LOG.debug(
+                        'Using default port: adding certificate for "%s" too', name)
+                    certs[name] = cert
+            else:
+                # the same happens if the user introduced a certificate for
+                # "my-registry": we must fix the "docker pull my-registry:5000/some/image" case...
+                name = hostname + ':' + str(default_port)
+                LOG.debug('Adding certificate for default port, "%s", too', name)
+                certs[name] = cert
+
+        mirrors = registry.get('mirrors', [])
+        if len(mirrors) > 0:
+            LOG.debug('Looking recursively for certificates in mirrors')
+            certs_mirrors = get_registries_certs(mirrors,
+                                                 default_port=default_port)
+            certs.update(certs_mirrors)
+
+    return certs

--- a/salt/docker/daemon.json.jinja
+++ b/salt/docker/daemon.json.jinja
@@ -1,0 +1,27 @@
+{%- set docker_daemon_config = salt.caasp_pillar.get('docker:daemon') -%}
+{%- set registries           = salt.caasp_pillar.get('registries') -%}
+
+{
+  {% if registries|length > 0 -%}
+  "registries": [
+  {%- for registry in registries %}
+    {
+      {%- set mirrors = registry.get('mirrors', []) -%}
+      {% if mirrors|length > 0 %}
+      "Mirrors": [
+        {%- for mirror in mirrors %}
+        {
+          "URL": "{{- mirror.get('url') -}}"
+        }{{- "," if not loop.last else ""}}
+        {%- endfor %}
+      ],
+      {%- endif %}
+      {#- prefix must be [http[s]://]<HOST>[:<PORT>][/<PATH>] #}
+      "Prefix": "{{- registry.get('url') -}}"
+    }{{- "," if not loop.last else ""}}
+  {%- endfor %}
+  ],
+  {%- endif %}
+  "iptables": {{- docker_daemon_config.get('iptables') -}},   {#- true/false (not quoted) #}
+  "log-level": "{{- docker_daemon_config.get('log_level') -}}"
+}

--- a/salt/docker/init.sls
+++ b/salt/docker/init.sls
@@ -3,6 +3,61 @@ include:
   - flannel
 
 ######################
+# additional ca.crt(s)
+#######################
+
+{% set registries = salt['pillar.get']('docker:registries', []) %}
+{% for registry in registries %}
+  {% set cert = registry.get("cert", "") %}
+  {% if cert|length > 0 -%}
+    {% set host_port = registry.get("name") %}
+
+/etc/docker/certs.d/{{ host_port }}/ca.crt:
+  file.managed:
+    - makedirs: True
+    - contents: |
+        {{ cert | indent(8) }}
+
+  # When using the standar port (443), Docker is not very smart:
+  # if the user introduces "my-registry:443" as a trusted registry,
+  # we must also create the "ca.crt" for "my-registry"
+  # as he/she could just access "docker pull my-registry/some/image",
+  # and Docker would fail to find "my-registry/ca.crt"
+    {% set host_port_lst = host_port.split(':') %}
+    {% if host_port_lst|length > 1 %}
+      {% set host = host_port_lst[0] %}
+      {% set port = host_port_lst[1] %}
+      {% if port == '443' %}
+/etc/docker/certs.d/{{ host }}/ca.crt:
+  file.symlink:
+    - target: /etc/docker/certs.d/{{ host_port }}/ca.crt
+    - force: True
+    - makedirs: True
+    - require:
+      - file: /etc/docker/certs.d/{{ host_port }}/ca.crt
+      {% endif %}
+    {% else %}
+  # the same happens if the user introduced a certificate for
+  # "my-registry": we must fix the "docker pull my-registry:443/some/image" case.
+/etc/docker/certs.d/{{ host_port }}:443/ca.crt:
+  file.symlink:
+    - target: /etc/docker/certs.d/{{ host_port }}/ca.crt
+    - force: True
+    - makedirs: True
+    - require:
+      - file: /etc/docker/certs.d/{{ host_port }}/ca.crt
+    {% endif %}
+  {% endif %}
+{% endfor %}
+
+# Notes:
+# - from https://docs.docker.com/registry/insecure/#using-self-signed-certificates
+#   we do not need to restart docker after adding/removing certificates
+# - after a certificate is removed from the pillar by the user, the certifcate
+#   will remain there. Maybe we should consider to wipe the certificates
+#   directory if we are the only ones managing them...
+
+######################
 # proxy for the daemon
 #######################
 
@@ -39,14 +94,18 @@ include:
 
 docker:
   pkg.installed:
-    - name: docker_1_12_6
+    - name: {{ salt.caasp_pillar.get('docker:pkg', 'docker') }}
     - install_recommends: False
     - require:
       - file: /etc/zypp/repos.d/containers.repo
   file.replace:
+    # remove any DOCKER_OPTS in the sysconfig file, as we will be
+    # using the "daemon.json". In fact, we don't want any DOCKER_OPS
+    # in this file, so it could be used, for example, in a systemd
+    #  drop-in unit and we wouldn't get into troubles because of precedences...
     - name: /etc/sysconfig/docker
     - pattern: '^DOCKER_OPTS.*$'
-    - repl: DOCKER_OPTS="{{ docker_opts }}"
+    - repl:
     - flags: ['IGNORECASE', 'MULTILINE']
     - append_if_not_found: True
     - require:

--- a/salt/docker/init.sls
+++ b/salt/docker/init.sls
@@ -6,56 +6,27 @@ include:
 # additional ca.crt(s)
 #######################
 
-{% set registries = salt['pillar.get']('docker:registries', []) %}
-{% for registry in registries %}
-  {% set cert = registry.get("cert", "") %}
-  {% if cert|length > 0 -%}
-    {% set host_port = registry.get("name") %}
-
-/etc/docker/certs.d/{{ host_port }}/ca.crt:
-  file.managed:
-    - makedirs: True
-    - contents: |
-        {{ cert | indent(8) }}
-
-  # When using the standar port (443), Docker is not very smart:
-  # if the user introduces "my-registry:443" as a trusted registry,
-  # we must also create the "ca.crt" for "my-registry"
-  # as he/she could just access "docker pull my-registry/some/image",
-  # and Docker would fail to find "my-registry/ca.crt"
-    {% set host_port_lst = host_port.split(':') %}
-    {% if host_port_lst|length > 1 %}
-      {% set host = host_port_lst[0] %}
-      {% set port = host_port_lst[1] %}
-      {% if port == '443' %}
-/etc/docker/certs.d/{{ host }}/ca.crt:
-  file.symlink:
-    - target: /etc/docker/certs.d/{{ host_port }}/ca.crt
-    - force: True
-    - makedirs: True
-    - require:
-      - file: /etc/docker/certs.d/{{ host_port }}/ca.crt
-      {% endif %}
-    {% else %}
-  # the same happens if the user introduced a certificate for
-  # "my-registry": we must fix the "docker pull my-registry:443/some/image" case.
-/etc/docker/certs.d/{{ host_port }}:443/ca.crt:
-  file.symlink:
-    - target: /etc/docker/certs.d/{{ host_port }}/ca.crt
-    - force: True
-    - makedirs: True
-    - require:
-      - file: /etc/docker/certs.d/{{ host_port }}/ca.crt
-    {% endif %}
-  {% endif %}
-{% endfor %}
-
+# collect all the certificates
 # Notes:
 # - from https://docs.docker.com/registry/insecure/#using-self-signed-certificates
 #   we do not need to restart docker after adding/removing certificates
 # - after a certificate is removed from the pillar by the user, the certifcate
 #   will remain there. Maybe we should consider to wipe the certificates
 #   directory if we are the only ones managing them...
+
+{% set certs = salt.caasp_docker.get_registries_certs(salt.caasp_pillar.get('registries', [])) %}
+{% for cert_tuple in certs.items() %}
+  {% set name, cert = cert_tuple %}
+
+/etc/docker/certs.d/{{ name }}/ca.crt:
+  file.managed:
+    - makedirs: True
+    - contents: |
+        {{ cert | indent(8) }}
+    - require_in:
+      - docker
+
+{% endfor %}
 
 ######################
 # proxy for the daemon
@@ -84,13 +55,11 @@ include:
 # docker daemon
 #######################
 
-{% set docker_args = salt.caasp_pillar.get('docker:args') %}
-{% set docker_logs = salt.caasp_pillar.get('docker:log_level') %}
-{% set docker_reg  = salt.caasp_pillar.get('docker:registry') %}
-{% set docker_opts = docker_args + " --log-level=" + docker_logs %}
-{% if docker_reg %}
-  {% set docker_opts = docker_opts + " --insecure-registry=" + docker_reg + " --registry-mirror=http://" + docker_reg  %}
-{% endif %}
+/etc/docker/daemon.json:
+  file.managed:
+    - source: salt://docker/daemon.json.jinja
+    - template: jinja
+    - makedirs: True
 
 docker:
   pkg.installed:
@@ -105,7 +74,7 @@ docker:
     #  drop-in unit and we wouldn't get into troubles because of precedences...
     - name: /etc/sysconfig/docker
     - pattern: '^DOCKER_OPTS.*$'
-    - repl:
+    - repl: 'DOCKER_OPTS=""'
     - flags: ['IGNORECASE', 'MULTILINE']
     - append_if_not_found: True
     - require:
@@ -115,8 +84,10 @@ docker:
     - onlyif: systemctl status docker.service
     - onchanges:
       - /etc/systemd/system/docker.service.d/proxy.conf
+      - /etc/docker/daemon.json
     - require:
       - file: /etc/sysconfig/docker
+      - file: /etc/docker/daemon.json
   service.running:
     - enable: True
     - watch:

--- a/salt/proxy/init.sls
+++ b/salt/proxy/init.sls
@@ -1,6 +1,4 @@
-{% set proxy_systemwide  = salt.caasp_pillar.get('proxy:systemwide', False) %}
-
-{% if proxy_systemwide %}
+{% if salt.caasp_pillar.get('proxy:systemwide') %}
   {% set proxy_http  = salt.caasp_pillar.get('proxy:http') %}
   {% set proxy_https = salt.caasp_pillar.get('proxy:https') %}
 


### PR DESCRIPTION
(This is basically #119 revamped, and prepared for insecure registries as implemented in #129)

A new pillar structure is introduced where registroes can be specified in the followig way:

```yaml
 registries:
     - url: my-reg1.com:5000
     - url: my-reg2.com:5000
       cert: |
           # some certificate         
     - url: some.registry.com:5000
       mirrors:
        - url: http://local.mirror.lan:5000
          cert: |
              # the certificate for the mirror
```

I've followed the instruction found [here](https://docs.docker.com/registry/insecure/#using-self-signed-certificates) for adding customers' certificates to Docker so they can pull from other registries.


## How to test this

* download [the caaspctl script](https://raw.githubusercontent.com/inercia/caasp-tf/master/resources/common/caaspctl) and copy it to `/root` in the Admin Node
* `ssh admin-node` and `./caaspctl registry certs` and `./caaspctl registry start`. That will generate the certificates in the `/root/certificates.local` and start the registry.
* Import the `alpine` image to the registry with `./caaspctl registry import alpine`
* edit the `/usr/share/salt/kubernetes/pillar/certificates.sls` in the Admin Node and add the `/root/certificates.local/ca.pem` certificate as:
    ```yaml
      registries:
          - url: dashboard:5000
            cert: |
                 ---- BEGIN CERTIFICATE -----
           ...
    ```
* orchestrate
* get the Admin Node's `IP` and `ssh node1` and `echo "IP dashboard" > /etc/hosts`
* try to pull the `alpine` image from the registry with `docker pull dashboard:5000/alpine`. After that, you should see the `dashboard:5000/alpine` image when doing `docker images`.

  
  
  
  
  