### PR TITLE
helm should detect salt-installed tiller service

### DIFF
--- a/salt/_macros/kubectl.jinja
+++ b/salt/_macros/kubectl.jinja
@@ -39,6 +39,10 @@
     - check_cmd:
        - {{ kwargs['check_cmd'] }}
 {%- endif %}
+{%- if 'onlyif' in kwargs %}
+    - onlyif:
+       - {{ kwargs['onlyif'] }}
+{%- endif %}
 {%- endmacro %}
 
 #####################################################################

--- a/salt/addons/tiller/init.sls
+++ b/salt/addons/tiller/init.sls
@@ -16,6 +16,10 @@ include:
            check_cmd="kubectl get clusterrolebindings | grep tiller",
            watch=["/etc/kubernetes/addons/tiller.yaml"]) }}
 
+{{ kubectl("remove-old-tiller-deployment",
+           "delete deploy tiller -n kube-system",
+           onlyif="kubectl get deploy tiller -n kube-system") }}
+
 {% else %}
 
 dummy:

--- a/salt/addons/tiller/init.sls
+++ b/salt/addons/tiller/init.sls
@@ -8,7 +8,7 @@ include:
 
 {{ kubectl_apply_template("salt://addons/tiller/tiller.yaml.jinja",
                           "/etc/kubernetes/addons/tiller.yaml",
-                          check_cmd="kubectl get deploy tiller -n kube-system | grep tiller") }}
+                          check_cmd="kubectl get deploy tiller-deploy -n kube-system | grep tiller-deploy") }}
 
 {{ kubectl("create-tiller-clusterrolebinding",
            "create clusterrolebinding system:tiller --clusterrole=cluster-admin --serviceaccount=kube-system:tiller",

--- a/salt/addons/tiller/tiller.yaml.jinja
+++ b/salt/addons/tiller/tiller.yaml.jinja
@@ -6,7 +6,7 @@ metadata:
     app: helm
     name: tiller
     kubernetes.io/cluster-service: "true"
-  name: tiller
+  name: tiller-deploy
   namespace: kube-system
 spec:
   strategy: {}


### PR DESCRIPTION
The helm client looks for a tiller deployment called 'tiller-deploy' to
establish if tiller is already installed in the cluster, or not. Update
our salt install of tiller to use a deployment with the same name so
that it will be recognized by the helm client as already being
installed.

Fixes: bsc#1066201