### PR TITLE
Use a batch size for etcd setup equal to the number of etcd masters (bsc#1066695)

### DIFF
--- a/config/master.d/50-master.conf
+++ b/config/master.d/50-master.conf
@@ -22,6 +22,17 @@ pillar_roots:
   base:
     - /usr/share/salt/kubernetes/pillar
 
+# The mechanism that provides custom modules to the master
+# is different from that which serves them to the minions.
+# Whereas the second is the _modules directory in file_roots,
+# if you want to provide custom modules to the master you need
+# to use the `extension_modules` master config.
+# `module_dirs` is like `extension_modules`, but a list of
+# extra directories to search for Salt modules.
+module_dirs:
+  - /usr/share/salt/kubernetes/salt/_modules
+  - /usr/share/salt/kubernetes/salt/_pillar
+
 ext_pillar:
   - velum:
       url: https://localhost/internal-api/v1/pillar.json

--- a/salt/_modules/caasp_etcd.py
+++ b/salt/_modules/caasp_etcd.py
@@ -1,13 +1,47 @@
 from __future__ import absolute_import
+
 import logging
 
+log = logging.getLogger(__name__)
 
-LOG = logging.getLogger(__name__)
-DESIRED_MEMBER_COUNT = 3
+# minimum number of etcd masters we recommend
+MIN_RECOMMENDED_MEMBER_COUNT = 3
 
 
 def __virtual__():
     return "caasp_etcd"
+
+
+# Grain used for getting nodes
+# make sure 'network.interfaces' is in the pillar/mine.sls
+_GRAIN = 'network.interfaces'
+
+
+def _optimal_etcd_number(num_nodes):
+    if num_nodes >= 7:
+        return 7
+    elif num_nodes >= 5:
+        return 5
+    elif num_nodes >= 3:
+        return 3
+    else:
+        return 1
+
+
+def _get_num_kube(expr):
+    """
+    Get the number of kubernetes nodes that in the cluster that match "expr"
+    """
+    log.debug("Finding nodes that match '%s' in the cluster", expr)
+    nodes = __salt__['mine.get'](expr, _GRAIN, expr_form='grain').values()
+    # 'mine.get' is not available in the master, so it will return nothing
+    # in that case, we can try again with saltutil.runner... uh?
+    if not nodes:
+        log.debug("... using 'saltutil.runner' for getting the '%s' nodes", expr)
+        nodes = __salt__['saltutil.runner']('mine.get',
+                                            tgt=expr, fun=_GRAIN, tgt_type='grain').values()
+    return len(nodes)
+
 
 def get_cluster_size():
     """
@@ -19,37 +53,37 @@ def get_cluster_size():
     less than 3, it will bump it to 3 (or the number of nodes
     available if the number of nodes is less than 3).
     """
-    member_count = __pillar__["etcd"]["masters"]
+    member_count = __salt__['pillar.get']('etcd:masters', None)
 
-    if member_count is not None:
+    if not member_count:
+        # A value has not been set in the pillar, calculate a "good" number
+        # for the user.
+        num_masters = _get_num_kube("roles:kube-master")
+
+        member_count = _optimal_etcd_number(num_masters)
+        if member_count < MIN_RECOMMENDED_MEMBER_COUNT:
+            # Attempt to increase the number of etcd master to 3,
+            # however, if we don't have 3 nodes in total,
+            # then match the number of nodes we have.
+            increased_member_count = _get_num_kube("roles:kube-*")
+            increased_member_count = min(
+                MIN_RECOMMENDED_MEMBER_COUNT, increased_member_count)
+
+            # ... but make sure we are using an odd number
+            # (otherwise we could have some leader election problems)
+            member_count = _optimal_etcd_number(increased_member_count)
+
+            log.warning("etcd member count too low (%d), increasing to %d",
+                        num_masters, increased_member_count)
+    else:
         # A value has been set in the pillar, respect the users choice
         # even it's not a "good" number.
         member_count = int(member_count)
 
-        if member_count < DESIRED_MEMBER_COUNT:
-            LOG.warning("etcd member count too low (%d), consider increasing "
-                        "to %d", member_count, DESIRED_MEMBER_COUNT)
+        if member_count < MIN_RECOMMENDED_MEMBER_COUNT:
+            log.warning("etcd member count too low (%d), consider increasing "
+                        "to %d", member_count, MIN_RECOMMENDED_MEMBER_COUNT)
 
-            return member_count
-
-    else:
-        # A value has not been set in the pillar, calculate a "good" number
-        # for the user.
-        member_count = len(__salt__['mine.get'](
-            'roles:kube-master', 'caasp_fqdn', expr_form='grain').values())
-
-        if member_count >= DESIRED_MEMBER_COUNT:
-            # We have enough members, use this count.
-            return member_count
-        else:
-            # Attempt to increase the member count to 3, however, if we don't
-            # have 3 nodes in total, then match the number of nodes we have.
-            increased_member_count = len(__salt__['mine.get'](
-                'roles:kube-*', 'caasp_fqdn', expr_form='grain').values())
-            increased_member_count = min(
-                DESIRED_MEMBER_COUNT, increased_member_count)
-
-            LOG.warning("etcd member count too low (%d), increasing to %d",
-                        member_count, increased_member_count)
-
-            return increased_member_count
+    member_count = max(1, member_count)
+    log.debug("using member count = %d", member_count)
+    return member_count

--- a/salt/_modules/caasp_filters.py
+++ b/salt/_modules/caasp_filters.py
@@ -7,6 +7,8 @@ def is_ip(ip):
     '''
     Returns a bool telling if the passed IP is a valid IPv4 or IPv6 address.
     '''
+    # TODO: use the builtin filter (https://docs.saltstack.com/en/latest/topics/jinja/index.html#is-ip)
+    #       once we Salt>2017.7.0
     return is_ipv4(ip) or is_ipv6(ip)
 
 
@@ -14,6 +16,8 @@ def is_ipv4(ip):
     '''
     Returns a bool telling if the value passed to it was a valid IPv4 address
     '''
+    # TODO: use the builtin filter (https://docs.saltstack.com/en/latest/topics/jinja/index.html#is-ipv4)
+    #       once we Salt>2017.7.0
     try:
         return ipaddress.ip_address(ip).version == 4
     except ValueError:
@@ -24,7 +28,15 @@ def is_ipv6(ip):
     '''
     Returns a bool telling if the value passed to it was a valid IPv6 address
     '''
+    # TODO: use the builtin filter (https://docs.saltstack.com/en/latest/topics/jinja/index.html#is-ipv6)
+    #       once we Salt>2017.7.0
     try:
         return ipaddress.ip_address(ip).version == 6
     except ValueError:
         return False
+
+
+def get_max(seq):
+    # TODO: use the builtin filter (https://docs.saltstack.com/en/latest/topics/jinja/index.html#max)
+    #       once we Salt>2017.7.0
+    return max(seq)

--- a/salt/orch/kubernetes.sls
+++ b/salt/orch/kubernetes.sls
@@ -1,6 +1,10 @@
 {%- set masters = salt.saltutil.runner('mine.get', tgt='G@roles:kube-master', fun='network.interfaces', tgt_type='compound').keys() %}
 {%- set super_master = masters|first %}
 
+{%- set default_batch = 5 %}
+
+{%- set num_etcd_masters = salt.caasp_etcd.get_cluster_size() %}
+
 # Ensure the node is marked as bootstrapping
 set_bootstrap_in_progress_flag:
   salt.function:
@@ -56,7 +60,6 @@ update_modules:
   salt.function:
     - tgt: '*'
     - name: saltutil.sync_all
-    - batch: 3
     - kwarg:
         refresh: True
 
@@ -102,18 +105,14 @@ etcd_discovery_setup:
     - require:
       - salt: update_modules
 
+# setup {{ num_etcd_masters }} etcd masters
 etcd_setup:
   salt.state:
     - tgt: 'roles:kube-(master|minion)'
     - tgt_type: grain_pcre
     - sls:
       - etcd
-    # Currently, we never ask for more than 3 members. Setting this to 3 ensures
-    # we don't let more than 3 members attempt etcd discovery before a cluster
-    # has been fully formed. If we have less this 3, this will still succeed, as
-    # the exact number of members we expect will also end up attempting discovery
-    # at the same time.
-    - batch: 3
+    - batch: {{ num_etcd_masters }}
     - require:
       - salt: etcd_discovery_setup
 
@@ -130,7 +129,7 @@ admin_setup:
     - tgt: 'roles:admin'
     - tgt_type: grain
     - highstate: True
-    - batch: 5
+    - batch: {{ default_batch }}
     - require:
       - salt: flannel_setup
 
@@ -139,7 +138,7 @@ kube_master_setup:
     - tgt: 'roles:kube-master'
     - tgt_type: grain
     - highstate: True
-    - batch: 5
+    - batch: {{ default_batch }}
     - require:
       - salt: admin_setup
       - salt: generate_sa_key
@@ -150,7 +149,7 @@ kube_minion_setup:
     - tgt: 'roles:kube-minion'
     - tgt_type: grain
     - highstate: True
-    - batch: 5
+    - batch: {{ default_batch }}
     - require:
       - salt: flannel_setup
       - salt: kube_master_setup


### PR DESCRIPTION
Use a batch size for etcd setup equal to the number of etcd masters
Minor cleanups and a fix for a case where `caasp_etcd.py` could return 0.

See https://bugzilla.suse.com/show_bug.cgi?id=1066695

