### PR TITLE
Fix use of no HTTP proxies with the new Pillar API

### DIFF
--- a/salt/docker/init.sls
+++ b/salt/docker/init.sls
@@ -6,7 +6,18 @@ include:
 # proxy for the daemon
 #######################
 
+{% set proxy_http = salt['pillar.get']('proxy:http', '') %}
+{% set proxy_https = salt['pillar.get']('proxy:https', '') %}
 {% set no_proxy = ['.infra.caasp.local', '.cluster.local'] %}
+
+{% if proxy_http is none %}
+  {% set proxy_http = '' %}
+{% endif %}
+
+{% if proxy_https is none %}
+  {% set proxy_https = '' %}
+{% endif %}
+
 {% if salt['pillar.get']('proxy:no_proxy') %}
   {% do no_proxy.append(pillar['proxy']['no_proxy']) %}
 {% endif %}

--- a/salt/proxy/init.sls
+++ b/salt/proxy/init.sls
@@ -2,8 +2,16 @@
 
 {% set proxy_http  = salt['pillar.get']('proxy:http', '') %}
 {% set proxy_https = salt['pillar.get']('proxy:https', '') %}
-
 {% set no_proxy = [pillar['dashboard'], '.infra.caasp.local', '.cluster.local'] %}
+
+{% if proxy_http is none %}
+  {% set proxy_http = '' %}
+{% endif %}
+
+{% if proxy_https is none %}
+  {% set proxy_https = '' %}
+{% endif %}
+
 {% if salt['pillar.get']('proxy:no_proxy') %}
   {% do no_proxy.append(pillar['proxy']['no_proxy']) %}
 {% endif %}


### PR DESCRIPTION
With the new Pillar API, velum always returns all pillar keys, so we can
no longer rely on the absence of a pillar key to disable proxies.