### PR TITLE
Never write `None` if we get `null` on the pillar override

### DIFF
--- a/salt/docker/init.sls
+++ b/salt/docker/init.sls
@@ -16,8 +16,8 @@ include:
     - makedirs: True
     - contents: |
         [Service]
-        Environment="HTTP_PROXY={{ salt['pillar.get']('proxy:http', '') }}"
-        Environment="HTTPS_PROXY={{ salt['pillar.get']('proxy:https', '') }}"
+        Environment="HTTP_PROXY={{ salt['pillar.get']('proxy:http', '') or '' }}"
+        Environment="HTTPS_PROXY={{ salt['pillar.get']('proxy:https', '') or '' }}"
         Environment="NO_PROXY={{ no_proxy|join(',') }}"
   module.run:
     - name: service.systemctl_reload

--- a/salt/proxy/init.sls
+++ b/salt/proxy/init.sls
@@ -1,7 +1,7 @@
 {% if salt['pillar.get']('proxy:systemwide', '').lower() == 'true' %}
 
-{% set proxy_http  = salt['pillar.get']('proxy:http', '') %}
-{% set proxy_https = salt['pillar.get']('proxy:https', '') %}
+{% set proxy_http  = salt['pillar.get']('proxy:http', '') or '' %}
+{% set proxy_https = salt['pillar.get']('proxy:https', '') or '' %}
 
 {% set no_proxy = [pillar['dashboard'], '.infra.caasp.local', '.cluster.local'] %}
 {% if salt['pillar.get']('proxy:no_proxy') %}


### PR DESCRIPTION
Instead, we write an empty string, because we don't intend to write
`None` on the configuration file.