### PR TITLE
Remove empty state from etc-hosts orch

### DIFF
--- a/salt/orch/update-etc-hosts.sls
+++ b/salt/orch/update-etc-hosts.sls
@@ -1,5 +1,4 @@
 {%- set updates_all_target = 'P@roles:(admin|kube-(master|minion)) and G@bootstrap_complete:true and not G@bootstrap_in_progress:true and not G@update_in_progress:true' %}
-{%- set updates_master_target = 'G@roles:kube-master and G@bootstrap_complete:true and not G@bootstrap_in_progress:true and not G@update_in_progress:true' %}
 
 {%- if salt.saltutil.runner('mine.get', tgt=updates_all_target, fun='caasp_fqdn', tgt_type='compound')|length > 0 %}
 update_pillar:
@@ -32,12 +31,4 @@ etc_hosts_setup:
       - etc-hosts
     - require:
       - salt: update_mine
-
-kube_master_setup:
-  salt.state:
-    - tgt: {{ updates_master_target }}
-    - tgt_type: compound
-    - queue: True
-    - require:
-      - salt: etc_hosts_setup
 {% endif %}


### PR DESCRIPTION
The final state in the etc-hosts orch was not actually calling
anything, and hasn't been for quite a while. Lets remove it, so
that the error it logs can be finally be gone!