### PR TITLE
[2.0] Fix certificates

### DIFF
--- a/pillar/params.sls
+++ b/pillar/params.sls
@@ -73,6 +73,12 @@ ssl:
   ldap_key: '/etc/pki/private/ldap.key'
   ldap_crt: '/etc/pki/ldap.crt'
 
+  dex_key: '/etc/pki/dex.key'
+  dex_crt: '/etc/pki/dex.crt'
+
+  kubectl_key: '/etc/pki/kubectl-client-cert.key'
+  kubectl_crt: '/etc/pki/kubectl-client-cert.crt'
+
   kube_apiserver_key: '/etc/pki/kube-apiserver.key'
   kube_apiserver_crt: '/etc/pki/kube-apiserver.crt'
 

--- a/salt/_macros/certs.jinja
+++ b/salt/_macros/certs.jinja
@@ -1,0 +1,121 @@
+
+{% macro alt_names(lst=[]) -%}
+  {#- add all the names and IPs we know about -#}
+  {%- set altNames = ["DNS: " + grains['caasp_fqdn'] ] -%}
+  {%- for _, interface_addresses in grains['ip4_interfaces'].items() -%}
+    {%- for interface_address in interface_addresses -%}
+      {%- do altNames.append("IP: " + interface_address) -%}
+    {%- endfor -%}
+  {%- endfor -%}
+  {#- append all the names/IPs provided (if not empty) -#}
+  {%- for name in lst -%}
+    {%- if name and name|length > 0 -%}
+      {%- if salt['caasp_filters.is_ip'](name) -%}
+        {%- do altNames.append("IP: " + name) -%}
+      {%- else -%}
+        {%- do altNames.append("DNS: " + name) -%}
+      {%- endif -%}
+    {%- endif -%}
+  {%- endfor -%}
+  {{ ", ".join(altNames) }}
+{%- endmacro %}
+
+#####################################################################
+
+# a list of alternative names for a kubernetes master
+{% macro alt_master_names(lst=[]) -%}
+  {%- set names_lst = ["kubernetes",
+                       "kubernetes.default",
+                       "kubernetes.default.svc",
+                       "api",
+                       "api." + pillar['internal_infra_domain'],
+                       salt['pillar.get']('api:server:external_fqdn', ''),
+                       salt['pillar.get']('api:cluster_ip', '')] +
+                       salt['pillar.get']('api:server:extra_names', []) +
+                       salt['pillar.get']('api:server:extra_ips', []) +
+                       lst -%}
+  {#- add some standard extra names from the DNS domain -#}
+  {%- if salt['pillar.get']('dns:domain') -%}
+    {%- do names_lst.append("kubernetes.default.svc." + pillar['dns']['domain']) -%}
+  {%- endif -%}
+  {{ alt_names(names_lst) }}
+{%- endmacro %}
+
+#####################################################################
+
+{% macro certs(name, crt, key, cn='', o='', extra_alt_names=None) -%}
+
+{%- if extra_alt_names == None -%}
+  {#- calculate automatically the altNames depending on the role -#}
+  {%- if "kube-master" in salt['grains.get']('roles', []) -%}
+    {%- set extra_alt_names = alt_master_names() -%}
+  {%- else -%}
+    {%- set extra_alt_names = alt_names() -%}
+  {%- endif -%}
+{%- endif -%}
+
+{{ key }}:
+  x509.private_key_managed:
+    - bits: 4096
+    - user: root
+    - group: root
+    - mode: 444
+    - require:
+      - sls:  crypto
+      - file: /etc/pki
+
+{{ crt }}:
+  x509.certificate_managed:
+    - ca_server: {{ salt['mine.get']('roles:ca', 'ca.crt', expr_form='grain').keys()[0] }}
+    - signing_policy: minion
+    - public_key: {{ key }}
+  {%- if cn|length > 0 %}
+    - CN: {{ cn|yaml_dquote }}
+  {%- else %}
+    - CN: {{ ("system:" + name)|yaml_dquote }}
+  {%- endif %}
+    - C: {{ pillar['certificate_information']['subject_properties']['C']|yaml_dquote }}
+    - Email: {{ pillar['certificate_information']['subject_properties']['Email']|yaml_dquote }}
+    - GN: {{ pillar['certificate_information']['subject_properties']['GN']|yaml_dquote }}
+    - L: {{ pillar['certificate_information']['subject_properties']['L']|yaml_dquote }}
+    {# "system:{{ name }}" is a kubernetes specific role identifying a {{ name }} in th system #}
+  {%- if o|length > 0 %}
+    - O: {{ o|yaml_dquote }}
+  {%- else -%}
+    - O: {{ ("system:" + name)|yaml_dquote }}
+  {%- endif %}
+    - OU: {{ pillar['certificate_information']['subject_properties']['OU']|yaml_dquote }}
+    - SN: {{ pillar['certificate_information']['subject_properties']['SN']|yaml_dquote }}
+    - ST: {{ pillar['certificate_information']['subject_properties']['ST']|yaml_dquote }}
+    - basicConstraints: "critical CA:false"
+    - keyUsage: nonRepudiation, digitalSignature, keyEncipherment
+  {%- if extra_alt_names|length > 0 %}
+    - subjectAltName: {{ extra_alt_names|yaml_dquote }}
+  {%- endif %}
+    - days_valid: {{ pillar['certificate_information']['days_valid']['certificate'] }}
+    - days_remaining: {{ pillar['certificate_information']['days_remaining']['certificate'] }}
+    - backup: True
+    - user: root
+    - group: root
+    - mode: 644
+    - require:
+      - sls: crypto
+      - x509: {{ key }}
+
+{{ crt }}-bundle:
+  file.managed:
+    - name: /etc/pki/private/{{ name }}-bundle.pem
+    - source: salt://cert/cert-bundle.jinja
+    - template: jinja
+    - user: root
+    - group: root
+    - mode: 600
+    - makedirs: True
+    - context:
+        certificate: {{ crt }}
+        key:         {{ key }}
+    - onchanges:
+        - x509: {{ crt }}
+        - x509: {{ key }}
+
+{%- endmacro %}

--- a/salt/cert/cert-bundle.jinja
+++ b/salt/cert/cert-bundle.jinja
@@ -1,0 +1,5 @@
+
+{%- import_text certificate as certificate -%}
+{%- import_text key as key -%}
+{{ certificate }}
+{{ key }}

--- a/salt/cert/init.sls
+++ b/salt/cert/init.sls
@@ -1,77 +1,9 @@
 include:
   - crypto
 
-{% set ip_addresses = [] -%}
-{% set extra_names = ["DNS: " + grains['caasp_fqdn'] ] -%}
+{% from '_macros/certs.jinja' import certs with context %}
 
-{% if "kube-master" in salt['grains.get']('roles', []) %}
-  {% do ip_addresses.append("IP: " + pillar['api']['cluster_ip']) %}
-  {% for _, interface_addresses in grains['ip4_interfaces'].items() %}
-    {% for interface_address in interface_addresses %}
-      {% do ip_addresses.append("IP: " + interface_address) %}
-    {% endfor %}
-  {% endfor %}
-  {% for extra_ip in pillar['api']['server']['extra_ips'] %}
-    {% do ip_addresses.append("IP: " + extra_ip) %}
-  {% endfor %}
-
-  # add some extra names the API server could have
-  {% set extra_names = extra_names + ["DNS: kubernetes",
-                                      "DNS: kubernetes.default",
-                                      "DNS: kubernetes.default.svc",
-                                      "DNS: api",
-                                      "DNS: api." + pillar['internal_infra_domain']] %}
-  {% for extra_name in pillar['api']['server']['extra_names'] %}
-    {% do extra_names.append("DNS: " + extra_name) %}
-  {% endfor %}
-
-  # add the fqdn provided by the user
-  # this will be the name used by the kubeconfig generated file
-  {% if salt['pillar.get']('api:server:external_fqdn') %}
-    {% do extra_names.append("DNS: " + pillar['api']['server']['external_fqdn']) %}
-  {% endif %}
-
-  # add some standard extra names from the DNS domain
-  {% if salt['pillar.get']('dns:domain') %}
-    {% do extra_names.append("DNS: kubernetes.default.svc." + pillar['dns']['domain']) %}
-  {% endif %}
-{% endif %}
-
-{{ pillar['ssl']['key_file'] }}:
-  x509.private_key_managed:
-    - bits: 4096
-    - user: root
-    - group: root
-    - mode: 444
-    - require:
-      - sls:  crypto
-      - file: /etc/pki
-
-{{ pillar['ssl']['crt_file'] }}:
-  x509.certificate_managed:
-    - ca_server: {{ salt['mine.get']('roles:ca', 'ca.crt', expr_form='grain').keys()[0] }}
-    - signing_policy: minion
-    - public_key: {{ pillar['ssl']['key_file'] }}
-    - CN: system:node:{{ grains['caasp_fqdn'] }}
-    - C: {{ pillar['certificate_information']['subject_properties']['C']|yaml_dquote }}
-    - Email: {{ pillar['certificate_information']['subject_properties']['Email']|yaml_dquote }}
-    - GN: {{ pillar['certificate_information']['subject_properties']['GN']|yaml_dquote }}
-    - L: {{ pillar['certificate_information']['subject_properties']['L']|yaml_dquote }}
-    - O: {{ pillar['certificate_information']['subject_properties']['O']|yaml_dquote }}
-    - OU: {{ pillar['certificate_information']['subject_properties']['OU']|yaml_dquote }}
-    - SN: {{ pillar['certificate_information']['subject_properties']['SN']|yaml_dquote }}
-    - ST: {{ pillar['certificate_information']['subject_properties']['ST']|yaml_dquote }}
-    - basicConstraints: "critical CA:false"
-    - keyUsage: nonRepudiation, digitalSignature, keyEncipherment
-    {% if (ip_addresses|length > 0) or (extra_names|length > 0) %}
-    - subjectAltName: "{{ ", ".join(extra_names + ip_addresses) }}"
-    {% endif %}
-    - days_valid: {{ pillar['certificate_information']['days_valid']['certificate'] }}
-    - days_remaining: {{ pillar['certificate_information']['days_remaining']['certificate'] }}
-    - backup: True
-    - user: root
-    - group: root
-    - mode: 644
-    - require:
-      - sls:  crypto
-      - x509: {{ pillar['ssl']['key_file'] }}
+{{ certs("node:" + grains['caasp_fqdn'],
+         pillar['ssl']['crt_file'],
+         pillar['ssl']['key_file'],
+         o = pillar['certificate_information']['subject_properties']['O']) }}

--- a/salt/kube-apiserver/init.sls
+++ b/salt/kube-apiserver/init.sls
@@ -6,78 +6,12 @@ include:
   - kubernetes-common
   - kubernetes-common.serviceaccount-key
 
-{% set ip_addresses = [] -%}
-{% set extra_names = ["DNS: " + grains['caasp_fqdn'] ] -%}
-
-{% do ip_addresses.append("IP: " + pillar['api']['cluster_ip']) %}
-{% for _, interface_addresses in grains['ip4_interfaces'].items() %}
-  {% for interface_address in interface_addresses %}
-    {% do ip_addresses.append("IP: " + interface_address) %}
-  {% endfor %}
-{% endfor %}
-{% for extra_ip in pillar['api']['server']['extra_ips'] %}
-  {% do ip_addresses.append("IP: " + extra_ip) %}
-{% endfor %}
-
-# add some extra names the API server could have
-{% set extra_names = extra_names + ["DNS: kubernetes",
-                                    "DNS: kubernetes.default",
-                                    "DNS: kubernetes.default.svc",
-                                    "DNS: api",
-                                    "DNS: api." + pillar['internal_infra_domain']] %}
-{% for extra_name in pillar['api']['server']['extra_names'] %}
-  {% do extra_names.append("DNS: " + extra_name) %}
-{% endfor %}
-
-# add the fqdn provided by the user
-# this will be the name used by the kubeconfig generated file
-{% if salt['pillar.get']('api:server:external_fqdn') %}
-  {% do extra_names.append("DNS: " + pillar['api']['server']['external_fqdn']) %}
-{% endif %}
-
-# add some standard extra names from the DNS domain
-{% if salt['pillar.get']('dns:domain') %}
-  {% do extra_names.append("DNS: kubernetes.default.svc." + pillar['dns']['domain']) %}
-{% endif %}
-
-{{ pillar['ssl']['kube_apiserver_key'] }}:
-  x509.private_key_managed:
-    - bits: 4096
-    - user: root
-    - group: root
-    - mode: 444
-    - require:
-      - sls:  crypto
-      - file: /etc/pki
-
-{{ pillar['ssl']['kube_apiserver_crt'] }}:
-  x509.certificate_managed:
-    - ca_server: {{ salt['mine.get']('roles:ca', 'ca.crt', expr_form='grain').keys()[0] }}
-    - signing_policy: minion
-    - public_key: {{ pillar['ssl']['kube_apiserver_key'] }}
-    - CN: {{ grains['caasp_fqdn'] }}
-    - C: {{ pillar['certificate_information']['subject_properties']['C']|yaml_dquote }}
-    - Email: {{ pillar['certificate_information']['subject_properties']['Email']|yaml_dquote }}
-    - GN: {{ pillar['certificate_information']['subject_properties']['GN']|yaml_dquote }}
-    - L: {{ pillar['certificate_information']['subject_properties']['L']|yaml_dquote }}
-    - O: {{ pillar['certificate_information']['subject_properties']['O']|yaml_dquote }}
-    - OU: {{ pillar['certificate_information']['subject_properties']['OU']|yaml_dquote }}
-    - SN: {{ pillar['certificate_information']['subject_properties']['SN']|yaml_dquote }}
-    - ST: {{ pillar['certificate_information']['subject_properties']['ST']|yaml_dquote }}
-    - basicConstraints: "critical CA:false"
-    - keyUsage: nonRepudiation, digitalSignature, keyEncipherment
-    {% if (ip_addresses|length > 0) or (extra_names|length > 0) %}
-    - subjectAltName: "{{ ", ".join(extra_names + ip_addresses) }}"
-    {% endif %}
-    - days_valid: {{ pillar['certificate_information']['days_valid']['certificate'] }}
-    - days_remaining: {{ pillar['certificate_information']['days_remaining']['certificate'] }}
-    - backup: True
-    - user: root
-    - group: root
-    - mode: 644
-    - require:
-      - sls:  crypto
-      - {{ pillar['ssl']['kube_apiserver_key'] }}
+{% from '_macros/certs.jinja' import certs with context %}
+{{ certs("kube-apiserver",
+         pillar['ssl']['kube_apiserver_crt'],
+         pillar['ssl']['kube_apiserver_key'],
+         cn = grains['caasp_fqdn'],
+         o = pillar['certificate_information']['subject_properties']['O']) }}
 
 kube-apiserver:
   pkg.installed:

--- a/salt/kube-proxy/init.sls
+++ b/salt/kube-proxy/init.sls
@@ -2,6 +2,25 @@ include:
   - repositories
   - kubernetes-common
 
+{% from '_macros/certs.jinja' import certs with context %}
+{{ certs('kube-proxy',
+         pillar['ssl']['kube_proxy_crt'],
+         pillar['ssl']['kube_proxy_key'],
+         o = 'system:nodes') }}
+
+kube-proxy-config:
+  file.managed:
+    - name: {{ pillar['paths']['kube_proxy_config'] }}
+    - source: salt://kubeconfig/kubeconfig.jinja
+    - template: jinja
+    - require:
+      - pkg: kubernetes-common
+      - {{ pillar['ssl']['kube_proxy_crt'] }}
+    - defaults:
+        user: 'default-admin'
+        client_certificate: {{ pillar['ssl']['kube_proxy_crt'] }}
+        client_key: {{ pillar['ssl']['kube_proxy_key'] }}
+
 kube-proxy:
   pkg.installed:
     - pkgs:
@@ -20,55 +39,3 @@ kube-proxy:
       - kube-proxy-config
       - file: kube-proxy
       - sls: kubernetes-common
-    - require:
-      - kube-proxy-config
-
-{{ pillar['ssl']['kube_proxy_key'] }}:
-  x509.private_key_managed:    
-    - bits: 4096
-    - user: root
-    - group: root
-    - mode: 444
-    - require:
-      - sls:  crypto
-      - file: /etc/pki
-
-{{ pillar['ssl']['kube_proxy_crt'] }}:
-  x509.certificate_managed:
-    - ca_server: {{ salt['mine.get']('roles:ca', 'ca.crt', expr_form='grain').keys()[0] }}
-    - signing_policy: minion
-    - public_key: {{ pillar['ssl']['kube_proxy_key'] }}
-    - CN: 'system:kube-proxy'
-    - C: {{ pillar['certificate_information']['subject_properties']['C']|yaml_dquote }}
-    - Email: {{ pillar['certificate_information']['subject_properties']['Email']|yaml_dquote }}
-    - GN: {{ pillar['certificate_information']['subject_properties']['GN']|yaml_dquote }}
-    - L: {{ pillar['certificate_information']['subject_properties']['L']|yaml_dquote }}
-    # system:node-proxier is a kubernetes specific role identifying a proxier in the system.
-    - O: 'system:nodes'
-    - OU: {{ pillar['certificate_information']['subject_properties']['OU']|yaml_dquote }}
-    - SN: {{ pillar['certificate_information']['subject_properties']['SN']|yaml_dquote }}
-    - ST: {{ pillar['certificate_information']['subject_properties']['ST']|yaml_dquote }}
-    - basicConstraints: "critical CA:false"
-    - keyUsage: nonRepudiation, digitalSignature, keyEncipherment
-    - days_valid: {{ pillar['certificate_information']['days_valid']['certificate'] }}
-    - days_remaining: {{ pillar['certificate_information']['days_remaining']['certificate'] }}
-    - backup: True
-    - user: root
-    - group: root
-    - mode: 644
-    - require:
-      - sls:  crypto
-      - {{ pillar['ssl']['kube_proxy_key'] }}
-
-kube-proxy-config:
-  file.managed:
-    - name: {{ pillar['paths']['kube_proxy_config'] }}
-    - source: salt://kubeconfig/kubeconfig.jinja
-    - template: jinja
-    - require:
-      - pkg: kubernetes-common
-      - {{ pillar['ssl']['kube_proxy_crt'] }}
-    - defaults:
-        user: 'default-admin'
-        client_certificate: {{ pillar['ssl']['kube_proxy_crt'] }}
-        client_key: {{ pillar['ssl']['kube_proxy_key'] }}

--- a/salt/kubectl-config/init.sls
+++ b/salt/kubectl-config/init.sls
@@ -2,33 +2,12 @@ include:
   - crypto
   - kubernetes-common
 
-/etc/pki/kubectl-client-cert.key:
-  x509.private_key_managed:
-    - bits: 4096
-    - user: root
-    - group: root
-    - mode: 444
-    - require:
-      - sls:  crypto
-      - file: /etc/pki
-
-/etc/pki/kubectl-client-cert.crt:
-  x509.certificate_managed:
-    - ca_server: {{ salt['mine.get']('roles:ca', 'ca.crt', expr_form='grain').keys()[0] }}
-    - signing_policy: minion
-    - public_key: /etc/pki/kubectl-client-cert.key
-    # proper username and group membership to allow kubectl unlimited rights from the nodes
-    - CN: cluster-admin
-    - O: system:masters
-    - days_valid: {{ pillar['certificate_information']['days_valid']['certificate'] }}
-    - days_remaining: {{ pillar['certificate_information']['days_remaining']['certificate'] }}
-    - backup: True
-    - user: root
-    - group: root
-    - mode: 644
-    - require:
-      - sls:  crypto
-      - x509: /etc/pki/kubectl-client-cert.key
+{% from '_macros/certs.jinja' import certs with context %}
+{{ certs('kubectl',
+         pillar['ssl']['kubectl_crt'],
+         pillar['ssl']['kubectl_key'],
+         cn = 'cluster-admin',
+         o = 'system:masters') }}
 
 {{ pillar['paths']['kubeconfig'] }}:
 # this kubeconfig file is used by kubectl for administrative functions

--- a/salt/ldap/init.sls
+++ b/salt/ldap/init.sls
@@ -2,54 +2,14 @@ include:
   - ca-cert
   - cert
 
-{% set ip_addresses = [] -%}
-{% set extra_names = ["DNS: " + grains['caasp_fqdn'], "DNS: " + pillar['dashboard_external_fqdn']] -%}
+{% set names = [salt['pillar.get']('dashboard', '')] %}
 
-{% set dashboard = salt['pillar.get']('dashboard', '') %}
-{% if salt['caasp_filters.is_ip'](dashboard) %}
-  {% do ip_addresses.append("IP: " + dashboard) %}
-{% else %}
-  {% do extra_names.append("DNS: " + dashboard) %}
-{% endif %}
-
-{{ pillar['ssl']['ldap_key'] }}:
-  x509.private_key_managed:
-    - bits: 4096
-    - user: root
-    - group: root
-    - mode: 444
-    - require:
-      - sls:  crypto
-      - file: /etc/pki
-
-{{ pillar['ssl']['ldap_crt'] }}:
-  x509.certificate_managed:
-    - ca_server: {{ salt['mine.get']('roles:ca', 'ca.crt', expr_form='grain').keys()[0] }}
-    - signing_policy: minion
-    - public_key: {{ pillar['ssl']['ldap_key'] }}
-    - CN: {{ grains['caasp_fqdn'] }}
-    - C: {{ pillar['certificate_information']['subject_properties']['C']|yaml_dquote }}
-    - Email: {{ pillar['certificate_information']['subject_properties']['Email']|yaml_dquote }}
-    - GN: {{ pillar['certificate_information']['subject_properties']['GN']|yaml_dquote }}
-    - L: {{ pillar['certificate_information']['subject_properties']['L']|yaml_dquote }}
-    - O: {{ pillar['certificate_information']['subject_properties']['O']|yaml_dquote }}
-    - OU: {{ pillar['certificate_information']['subject_properties']['OU']|yaml_dquote }}
-    - SN: {{ pillar['certificate_information']['subject_properties']['SN']|yaml_dquote }}
-    - ST: {{ pillar['certificate_information']['subject_properties']['ST']|yaml_dquote }}
-    - basicConstraints: "critical CA:false"
-    - keyUsage: nonRepudiation, digitalSignature, keyEncipherment
-    {% if (ip_addresses|length > 0) or (extra_names|length > 0) %}
-    - subjectAltName: "{{ ", ".join(extra_names + ip_addresses) }}"
-    {% endif %}
-    - days_valid: {{ pillar['certificate_information']['days_valid']['certificate'] }}
-    - days_remaining: {{ pillar['certificate_information']['days_remaining']['certificate'] }}
-    - backup: True
-    - user: root
-    - group: root
-    - mode: 644
-    - require:
-      - sls:  crypto
-      - {{ pillar['ssl']['ldap_key'] }}
+{% from '_macros/certs.jinja' import alt_names, certs with context %}
+{{ certs("ldap:" + grains['caasp_fqdn'],
+         pillar['ssl']['ldap_crt'],
+         pillar['ssl']['ldap_key'],
+         cn = grains['caasp_fqdn'],
+         extra_alt_names = alt_names(names)) }}
 
 openldap_restart:
   cmd.run:
@@ -59,5 +19,4 @@ openldap_restart:
             docker restart $openldap_id
         fi
     - onchanges:
-      - x509: {{ pillar['ssl']['ldap_key'] }}
       - x509: {{ pillar['ssl']['ldap_crt'] }}

--- a/salt/velum/init.sls
+++ b/salt/velum/init.sls
@@ -3,53 +3,15 @@ include:
   - ca-cert
   - cert
 
-{% set ip_addresses = [] -%}
-{% set extra_names = ["DNS: " + grains['caasp_fqdn'], "DNS: " + pillar['dashboard_external_fqdn']] -%}
+{% set names = [salt['pillar.get']('dashboard_external_fqdn', ''),
+                salt['pillar.get']('dashboard', '')] %}
 
-{% if salt['caasp_filters.is_ip'](pillar['dashboard']) %}
-{% do ip_addresses.append("IP: " + pillar['dashboard']) %}
-{% else %}
-{% do extra_names.append("DNS: " + pillar['dashboard']) %}
-{% endif %}
-
-{{ pillar['ssl']['velum_key'] }}:
-  x509.private_key_managed:    
-    - bits: 4096
-    - user: root
-    - group: root
-    - mode: 444
-    - require:
-      - sls:  crypto
-      - file: /etc/pki
-
-{{ pillar['ssl']['velum_crt'] }}:
-  x509.certificate_managed:
-    - ca_server: {{ salt['mine.get']('roles:ca', 'ca.crt', expr_form='grain').keys()[0] }}
-    - signing_policy: minion
-    - public_key: {{ pillar['ssl']['velum_key'] }}
-    - CN: {{ grains['caasp_fqdn'] }}
-    - C: {{ pillar['certificate_information']['subject_properties']['C']|yaml_dquote }}
-    - Email: {{ pillar['certificate_information']['subject_properties']['Email']|yaml_dquote }}
-    - GN: {{ pillar['certificate_information']['subject_properties']['GN']|yaml_dquote }}
-    - L: {{ pillar['certificate_information']['subject_properties']['L']|yaml_dquote }}
-    - O: {{ pillar['certificate_information']['subject_properties']['O']|yaml_dquote }}
-    - OU: {{ pillar['certificate_information']['subject_properties']['OU']|yaml_dquote }}
-    - SN: {{ pillar['certificate_information']['subject_properties']['SN']|yaml_dquote }}
-    - ST: {{ pillar['certificate_information']['subject_properties']['ST']|yaml_dquote }}
-    - basicConstraints: "critical CA:false"
-    - keyUsage: nonRepudiation, digitalSignature, keyEncipherment
-    {% if (ip_addresses|length > 0) or (extra_names|length > 0) %}
-    - subjectAltName: "{{ ", ".join(extra_names + ip_addresses) }}"
-    {% endif %}
-    - days_valid: {{ pillar['certificate_information']['days_valid']['certificate'] }}
-    - days_remaining: {{ pillar['certificate_information']['days_remaining']['certificate'] }}
-    - backup: True
-    - user: root
-    - group: root
-    - mode: 644
-    - require:
-      - sls:  crypto
-      - {{ pillar['ssl']['velum_key'] }}
+{% from '_macros/certs.jinja' import alt_names, certs with context %}
+{{ certs("velum:" + grains['caasp_fqdn'],
+         pillar['ssl']['velum_crt'],
+         pillar['ssl']['velum_key'],
+         cn = grains['caasp_fqdn'],
+         extra_alt_names = alt_names(names)) }}
 
 # Send a USR2 to velum when the config changes
 # TODO: There should be a better way to handle this, but currently, there is not. See


### PR DESCRIPTION
In the certs macros, do not assume "names" are always names and "ips" are always IPs: just filter with the "is_ip" filter.
Minor shortcuts in the arguments.
    
Fixes: bsc#1069205
    
Backport to 2.0 of https://github.com/kubic-project/salt/pull/311
