### PR TITLE
Use a sanitized version of pillar.get

### DIFF
--- a/salt/_macros/certs.jinja
+++ b/salt/_macros/certs.jinja
@@ -29,13 +29,13 @@
                        "kubernetes.default.svc",
                        "api",
                        "api." + pillar['internal_infra_domain'],
-                       salt['pillar.get']('api:server:external_fqdn', ''),
-                       salt['pillar.get']('api:cluster_ip', '')] +
-                       salt['pillar.get']('api:server:extra_names', []) +
-                       salt['pillar.get']('api:server:extra_ips', []) +
+                       salt.caasp_pillar.get('api:server:external_fqdn'),
+                       salt.caasp_pillar.get('api:cluster_ip')] +
+                       salt.caasp_pillar.get('api:server:extra_names', []) +
+                       salt.caasp_pillar.get('api:server:extra_ips', []) +
                        lst -%}
   {#- add some standard extra names from the DNS domain -#}
-  {%- if salt['pillar.get']('dns:domain') -%}
+  {%- if salt.caasp_pillar.get('dns:domain') -%}
     {%- do names_lst.append("kubernetes.default.svc." + pillar['dns']['domain']) -%}
   {%- endif -%}
   {{ alt_names(names_lst) }}
@@ -69,7 +69,7 @@
     - ca_server: {{ salt['mine.get']('roles:ca', 'ca.crt', expr_form='grain').keys()[0] }}
     - signing_policy: minion
     - public_key: {{ key }}
-  {%- if cn|length > 0 %}
+  {%- if cn %}
     - CN: {{ cn|yaml_dquote }}
   {%- else %}
     - CN: {{ ("system:" + name)|yaml_dquote }}
@@ -79,7 +79,7 @@
     - GN: {{ pillar['certificate_information']['subject_properties']['GN']|yaml_dquote }}
     - L: {{ pillar['certificate_information']['subject_properties']['L']|yaml_dquote }}
     {# "system:{{ name }}" is a kubernetes specific role identifying a {{ name }} in th system #}
-  {%- if o|length > 0 %}
+  {%- if o %}
     - O: {{ o|yaml_dquote }}
   {%- else -%}
     - O: {{ ("system:" + name)|yaml_dquote }}
@@ -89,7 +89,7 @@
     - ST: {{ pillar['certificate_information']['subject_properties']['ST']|yaml_dquote }}
     - basicConstraints: "critical CA:false"
     - keyUsage: nonRepudiation, digitalSignature, keyEncipherment
-  {%- if extra_alt_names|length > 0 %}
+  {%- if extra_alt_names %}
     - subjectAltName: {{ extra_alt_names|yaml_dquote }}
   {%- endif %}
     - days_valid: {{ pillar['certificate_information']['days_valid']['certificate'] }}

--- a/salt/_modules/caasp_pillar.py
+++ b/salt/_modules/caasp_pillar.py
@@ -1,0 +1,28 @@
+from __future__ import absolute_import
+
+
+def __virtual__():
+    return "caasp_pillar"
+
+
+def get(name, default=''):
+    '''
+    A sanitized version of pillar.get() that
+
+    * will return `default` (or `''`) instead of `None` or `''`
+    * will return `True`/`False` instead of `"true"`/`"false"`
+
+    The rationale is that, if pillar[x] can return None,
+    we can get a nasty "None" when replacing {{pillar[x]}} in a
+    jinja template. In other words, `None`s are annoying when used
+    in Salt/Jinja...
+    '''
+    res = __salt__['pillar.get'](name, None)
+    if res is None:
+        res = default
+    if isinstance(res, basestring):
+        if res.lower() in ["true", "yes", "on"]:
+            return True
+        elif res.lower() in ["false", "no", "off"]:
+            return False
+    return res

--- a/salt/addons/dns/init.sls
+++ b/salt/addons/dns/init.sls
@@ -1,4 +1,4 @@
-{% if salt['pillar.get']('addons:dns', 'false').lower() == 'true' %}
+{% if salt.caasp_pillar.get('addons:dns', False) %}
 
 include:
   - kube-apiserver
@@ -23,4 +23,3 @@ dummy:
     - name: echo "DNS addon not enabled in config"
 
 {% endif %}
-

--- a/salt/addons/tiller/init.sls
+++ b/salt/addons/tiller/init.sls
@@ -1,4 +1,4 @@
-{% if salt['pillar.get']('addons:tiller', 'false').lower() == 'true' %}
+{% if salt.caasp_pillar.get('addons:tiller', False) %}
 
 include:
   - kube-apiserver

--- a/salt/docker/init.sls
+++ b/salt/docker/init.sls
@@ -7,8 +7,9 @@ include:
 #######################
 
 {% set no_proxy = ['.infra.caasp.local', '.cluster.local'] %}
-{% if salt['pillar.get']('proxy:no_proxy') %}
-  {% do no_proxy.append(pillar['proxy']['no_proxy']) %}
+{% set extra_no_proxy = salt.caasp_pillar.get('proxy:no_proxy') %}
+{% if extra_no_proxy %}
+  {% do no_proxy.append(extra_no_proxy) %}
 {% endif %}
 
 /etc/systemd/system/docker.service.d/proxy.conf:
@@ -16,8 +17,8 @@ include:
     - makedirs: True
     - contents: |
         [Service]
-        Environment="HTTP_PROXY={{ salt['pillar.get']('proxy:http', '') or '' }}"
-        Environment="HTTPS_PROXY={{ salt['pillar.get']('proxy:https', '') or '' }}"
+        Environment="HTTP_PROXY={{ salt.caasp_pillar.get('proxy:http') }}"
+        Environment="HTTPS_PROXY={{ salt.caasp_pillar.get('proxy:https') }}"
         Environment="NO_PROXY={{ no_proxy|join(',') }}"
   module.run:
     - name: service.systemctl_reload
@@ -28,11 +29,11 @@ include:
 # docker daemon
 #######################
 
-{% set docker_args = salt['pillar.get']('docker:args', '') %}
-{% set docker_logs = salt['pillar.get']('docker:log_level', '') %}
-{% set docker_reg  = salt['pillar.get']('docker:registry', '') %}
+{% set docker_args = salt.caasp_pillar.get('docker:args') %}
+{% set docker_logs = salt.caasp_pillar.get('docker:log_level') %}
+{% set docker_reg  = salt.caasp_pillar.get('docker:registry') %}
 {% set docker_opts = docker_args + " --log-level=" + docker_logs %}
-{% if docker_reg|length > 0 %}
+{% if docker_reg %}
   {% set docker_opts = docker_opts + " --insecure-registry=" + docker_reg + " --registry-mirror=http://" + docker_reg  %}
 {% endif %}
 

--- a/salt/etcd-discovery/init.sls
+++ b/salt/etcd-discovery/init.sls
@@ -1,7 +1,8 @@
-{% if salt['pillar.get']('etcd:disco:id', '')|length > 0 %}
+{% set disco = salt.caasp_pillar.get('etcd:disco:id') %}
+{% if disco %}
 
-{% set etcd_base = "http://" + pillar['dashboard'] + ":" + pillar['etcd']['disco']['port'] %}
-{% set etcd_size_uri = etcd_base + "/v2/keys/_etcd/registry/" + pillar['etcd']['disco']['id'] + "/_config/size" %}
+  {% set etcd_base = "http://" + pillar['dashboard'] + ":" + pillar['etcd']['disco']['port'] %}
+  {% set etcd_size_uri = etcd_base + "/v2/keys/_etcd/registry/" + pillar['etcd']['disco']['id'] + "/_config/size" %}
 
 # set the cluster size in the private Discovery registry
 etcd-discovery-setup:

--- a/salt/flannel-setup/config.json.jinja
+++ b/salt/flannel-setup/config.json.jinja
@@ -1,10 +1,10 @@
 {
-  "Network":   "{{ pillar['cluster_cidr'] }}",
-  "SubnetLen": {{ pillar['cluster_cidr_len'] }},
-  "SubnetMin": "{{ pillar['cluster_cidr_min'] }}",
-  "SubnetMax": "{{ pillar['cluster_cidr_max'] }}",
+  "Network":   "{{ salt.caasp_pillar.get('cluster_cidr') }}",
+  "SubnetLen": {{ salt.caasp_pillar.get('cluster_cidr_len') }},
+  "SubnetMin": "{{ salt.caasp_pillar.get('cluster_cidr_min') }}",
+  "SubnetMax": "{{ salt.caasp_pillar.get('cluster_cidr_max') }}",
   "Backend":
   {
-    "Type": "{{ pillar['flannel']['backend'] }}"
+    "Type": "{{ salt.caasp_pillar.get('flannel:backend') }}"
   }
 }

--- a/salt/kube-apiserver/apiserver.jinja
+++ b/salt/kube-apiserver/apiserver.jinja
@@ -6,6 +6,8 @@
 
 {% from '_macros/network.jinja' import get_primary_ip with context %}
 
+{% set cloud_provider = salt.caasp_pillar.get('cloud:provider') %}
+
 # The address on the local server to listen to.
 KUBE_API_ADDRESS="--insecure-bind-address=127.0.0.1 --bind-address=0.0.0.0"
 
@@ -28,9 +30,9 @@ KUBE_ADMISSION_CONTROL="--admission-control=Initializers,NamespaceLifecycle,Limi
 # Add your own!
 KUBE_API_ARGS="--advertise-address={{ get_primary_ip() }} \
                --apiserver-count={{ salt['mine.get']('roles:kube-master', 'caasp_fqdn', expr_form='grain').values()|length }} \
-{%- if salt['pillar.get']('cloud:provider', '') != '' %}
+{%- if cloud_provider %}
                --cloud-provider={{ pillar['cloud']['provider'] }} \
-  {%- if salt['pillar.get']('cloud:provider', '') == 'openstack' %}
+  {%- if cloud_provider == 'openstack' %}
                --cloud-config=/etc/kubernetes/openstack-config \
   {%- endif -%}
 {% endif %}
@@ -38,7 +40,7 @@ KUBE_API_ARGS="--advertise-address={{ get_primary_ip() }} \
                --tls-private-key-file={{ pillar['ssl']['kube_apiserver_key'] }} \
                --tls-ca-file={{ pillar['ssl']['ca_file'] }} \
                --cert-dir=/etc/pki \
-               {{ salt['pillar.get']('components:apiserver:args', '') }} \
+               {{ salt.caasp_pillar.get('components:apiserver:args') }} \
                --client-ca-file={{ pillar['ssl']['ca_file'] }} \
                --storage-backend={{ pillar['api']['etcd_version'] }} \
                --storage-media-type=application/json \

--- a/salt/kube-controller-manager/controller-manager.jinja
+++ b/salt/kube-controller-manager/controller-manager.jinja
@@ -3,6 +3,9 @@
 
 # defaults from config and apiserver should be adequate
 
+{%- set cloud_provider = salt.caasp_pillar.get('cloud:provider') -%}
+{%- set managr_args = salt.caasp_pillar.get('components:controller-manager:args') %}"
+
 # Add your own!
 KUBE_CONTROLLER_MANAGER_ARGS="\
     --kubeconfig={{ pillar['paths']['kube_controller_mgr_config'] }} \
@@ -12,10 +15,10 @@ KUBE_CONTROLLER_MANAGER_ARGS="\
     --cluster-cidr={{ pillar['cluster_cidr'] }} \
     --service-account-private-key-file={{ pillar['paths']['service_account_key'] }} \
     --root-ca-file={{ pillar['ssl']['ca_file'] }} \
-{% if salt['pillar.get']('cloud:provider', '') != '' -%}
-               --cloud-provider={{ pillar['cloud']['provider'] }} \
-  {% if salt['pillar.get']('cloud:provider', '') == 'openstack' -%}
+{% if cloud_provider -%}
+               --cloud-provider={{ cloud_provider }} \
+  {% if cloud_provider == 'openstack' -%}
                --cloud-config=/etc/kubernetes/openstack-config \
   {% endif -%}
 {% endif -%}
-    {{ salt['pillar.get']('components:controller-manager:args', '') }}"
+    {{ managr_args }}"

--- a/salt/kube-scheduler/scheduler.jinja
+++ b/salt/kube-scheduler/scheduler.jinja
@@ -7,4 +7,4 @@
 KUBE_SCHEDULER_ARGS="\
     --kubeconfig={{ pillar['paths']['kube_scheduler_config'] }} \
     --leader-elect=true \
-    {{ salt['pillar.get']('components:scheduler:args', '') }}"
+    {{ salt.caasp_pillar.get('components:scheduler:args') }}"

--- a/salt/kubelet/init.sls
+++ b/salt/kubelet/init.sls
@@ -56,7 +56,7 @@ kubelet:
       - file:   /etc/kubernetes/config
       - kubelet-config
       - file:   kubelet
-{% if pillar.get('cloud:provider', '') == 'openstack' %}
+{% if salt.caasp_pillar.get('cloud:provider') == 'openstack' %}
       - file:     /etc/kubernetes/openstack-config
 {% endif %}
     - require:
@@ -114,7 +114,7 @@ kubelet:
     - dir_mode: 755
     - makedirs: True
 
-{% if pillar.get('e2e', '').lower() == 'true' %}
+{% if salt.caasp_pillar.get('e2e', False) %}
 /etc/kubernetes/manifests/e2e-image-puller.manifest:
   file.managed:
     - source:    salt://kubelet/e2e-image-puller.manifest

--- a/salt/kubelet/kubelet.jinja
+++ b/salt/kubelet/kubelet.jinja
@@ -1,6 +1,7 @@
 {% set api_server = "api." + pillar['internal_infra_domain']  -%}
 {% set api_ssl_port = salt['pillar.get']('api:ssl_port', '6443') -%}
 {% set api_server_url = 'https://' + api_server + ':' + api_ssl_port -%}
+{% set cloud_provider = salt.caasp_pillar.get('cloud:provider') %}
 
 {% from '_macros/network.jinja' import get_primary_ip with context %}
 
@@ -25,9 +26,9 @@ KUBELET_ARGS="\
     --pod-manifest-path=/etc/kubernetes/manifests \
     --pod-infra-container-image={{ pillar['pod_infra_container_image'] }} \
 {% endif -%}
-{% if salt['pillar.get']('cloud:provider', '') != '' -%}
+{% if cloud_provider -%}
                --cloud-provider={{ pillar['cloud']['provider'] }} \
-  {% if salt['pillar.get']('cloud:provider', '') == 'openstack' -%}
+  {% if cloud_provider == 'openstack' -%}
                --cloud-config=/etc/kubernetes/openstack-config \
   {% endif -%}
 {% endif -%}

--- a/salt/ldap/init.sls
+++ b/salt/ldap/init.sls
@@ -2,7 +2,7 @@ include:
   - ca-cert
   - cert
 
-{% set names = [salt['pillar.get']('dashboard', '')] %}
+{% set names = [salt.caasp_pillar.get('dashboard')] %}
 
 {% from '_macros/certs.jinja' import alt_names, certs with context %}
 {{ certs("ldap:" + grains['caasp_fqdn'],

--- a/salt/proxy/init.sls
+++ b/salt/proxy/init.sls
@@ -1,12 +1,14 @@
-{% if salt['pillar.get']('proxy:systemwide', '').lower() == 'true' %}
+{% set proxy_systemwide  = salt.caasp_pillar.get('proxy:systemwide', False) %}
 
-{% set proxy_http  = salt['pillar.get']('proxy:http', '') or '' %}
-{% set proxy_https = salt['pillar.get']('proxy:https', '') or '' %}
+{% if proxy_systemwide %}
+  {% set proxy_http  = salt.caasp_pillar.get('proxy:http') %}
+  {% set proxy_https = salt.caasp_pillar.get('proxy:https') %}
 
-{% set no_proxy = [pillar['dashboard'], '.infra.caasp.local', '.cluster.local'] %}
-{% if salt['pillar.get']('proxy:no_proxy') %}
-  {% do no_proxy.append(pillar['proxy']['no_proxy']) %}
-{% endif %}
+  {% set no_proxy = [salt.caasp_pillar.get('dashboard'), '.infra.caasp.local', '.cluster.local'] %}
+  {% set extra_no_proxy = salt.caasp_pillar.get('proxy:no_proxy') %}
+  {% if extra_no_proxy %}
+    {% do no_proxy.append(extra_no_proxy) %}
+  {% endif %}
 
 /etc/sysconfig/proxy:
   file.managed:
@@ -17,13 +19,13 @@
         HTTPS_PROXY="{{ proxy_https }}"
         NO_PROXY="{{ no_proxy|join(',') }}"
 
-# curl does not like an empty --proxy in curlrc...
-{% if proxy_http|length > 0 %}
+  # curl does not like an empty --proxy in curlrc...
+  {% if proxy_http %}
 /root/.curlrc:
   file.managed:
     - contents: |
         --proxy "{{ proxy_http }}"
         --noproxy "{{ no_proxy|join(',') }}"
-{% endif %}
+  {% endif %}
 
 {% endif %}

--- a/salt/velum/init.sls
+++ b/salt/velum/init.sls
@@ -3,8 +3,8 @@ include:
   - ca-cert
   - cert
 
-{% set names = [salt['pillar.get']('dashboard_external_fqdn', ''),
-                salt['pillar.get']('dashboard', '')] %}
+{% set names = [salt.caasp_pillar.get('dashboard_external_fqdn'),
+                salt.caasp_pillar.get('dashboard')] %}
 
 {% from '_macros/certs.jinja' import alt_names, certs with context %}
 {{ certs("velum:" + grains['caasp_fqdn'],


### PR DESCRIPTION
if `pillar[x]` can return `None`, we can get a nasty `"None"` string when replacing `{{pillar[x]}}` in a Jinja template. And, in general, `None`s are rather annoying in Salt/Jinja...

So this PR implements our own version of `pillar.get` that sanitizes the output, never returning `None` and converting `"true"`/`"false"` to `True`/`False`.