### PR TITLE
[2.0]  Add beacon to notify network changes only on the default network interface

### DIFF
--- a/config/master.d/50-reactor.conf
+++ b/config/master.d/50-reactor.conf
@@ -2,7 +2,7 @@ reactor:
   - 'salt/presence/change':
     - /usr/share/salt/kubernetes/reactor/presence.sls
     - /usr/share/salt/kubernetes/reactor/etc-hosts.sls
-  - 'salt/beacon/*/network_settings/eth*':
+  - 'salt/beacon/*/default_network_interface_settings/*':
     - /usr/share/salt/kubernetes/reactor/etc-hosts.sls
   - 'salt/minion/*/start':
     - /usr/share/salt/kubernetes/reactor/etc-hosts.sls

--- a/pillar/beacons.sls
+++ b/pillar/beacons.sls
@@ -1,7 +1,5 @@
 beacons:
-  network_settings:
+  default_network_interface_settings:
     interval: 5
-    # monitorize any change in IP addresses in eth0
-    eth0:
+    watch:
       ipaddr:
-

--- a/salt/_beacons/default_network_interface_settings.py
+++ b/salt/_beacons/default_network_interface_settings.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+'''
+Beacon to monitor default network adapter setting changes on Linux
+'''
+
+from salt.beacons import network_settings
+
+import logging
+log = logging.getLogger(__name__)
+
+__virtual_name__ = 'default_network_interface_settings'
+
+def __virtual__():
+    if network_settings.__virtual__():
+        return __virtual_name__
+    return False
+
+def __validate__(config):
+    return network_settings.__validate__(config)
+
+def beacon(config):
+    '''
+    Watch for changes on network settings on the gateway interface.
+
+    By default, the beacon will emit when there is a value change on one of the
+    settings on watch. The config also support the onvalue parameter for each
+    setting, which instruct the beacon to only emit if the setting changed to the
+    value defined.
+
+    Example Config
+
+    .. code-block:: yaml
+
+        beacons:
+          default_network_interface_settings:
+            interval: 5
+            watch:
+              ipaddr:
+              promiscuity:
+                onvalue: 1
+    '''
+
+    default_interface = __salt__['network.default_route']()[0]['interface']
+
+    return network_settings.beacon({default_interface: config['watch']})


### PR DESCRIPTION
Fixes: bsc#1063709

Backport of https://github.com/kubic-project/salt/pull/331