### PR TITLE
Explicitly pass the kubeconfig file to kubectl

### DIFF
--- a/salt/_macros/kubectl.jinja
+++ b/salt/_macros/kubectl.jinja
@@ -13,12 +13,10 @@
 
 {% macro _kubectl_run(args) -%}
   caasp_cmd.run:
-    - name: kubectl {{ args }}
+    - name: kubectl --kubeconfig={{ pillar['paths']['kubeconfig'] }} {{ args }}
     - retry:
         attempts: 10
         interval: 1
-    - env:
-      - KUBECONFIG: {{ pillar['paths']['kubeconfig'] }}
     - require:
       - kube-apiserver
       - {{ pillar['paths']['kubeconfig'] }}

--- a/salt/kubelet/init.sls
+++ b/salt/kubelet/init.sls
@@ -4,6 +4,7 @@ include:
   - cert
   - etcd
   - kubernetes-common
+  - kubectl-config
 
 /etc/kubernetes/kubelet-initial:
   file.managed:
@@ -91,14 +92,12 @@ kubelet:
     - name: |
         kubectl uncordon {{ grains['caasp_fqdn'] }}
     - onlyif:
-        test "$(kubectl get nodes {{ grains['caasp_fqdn'] }} -o=jsonpath="{.spec.unschedulable}" 2>/dev/null)" = "true"
+        test "$(kubectl --kubeconfig={{ pillar['paths']['kubeconfig'] }} get nodes {{ grains['caasp_fqdn'] }} -o=jsonpath='{.spec.unschedulable}' 2>/dev/null)" = "true"
     - retry:
         attempts: 10
         interval: 3
         until: |
-          test "$(kubectl get nodes {{ grains['caasp_fqdn'] }} -o=jsonpath="{.spec.unschedulable}" 2>/dev/null)" != "true"
-    - env:
-      - KUBECONFIG: {{ pillar['paths']['kubeconfig'] }}
+          test "$(kubectl --kubeconfig={{ pillar['paths']['kubeconfig'] }} get nodes {{ grains['caasp_fqdn'] }} -o=jsonpath='{.spec.unschedulable}' 2>/dev/null)" != "true"
     - require:
       - file: {{ pillar['paths']['kubeconfig'] }}
 {% endif %}

--- a/salt/kubelet/stop.sls
+++ b/salt/kubelet/stop.sls
@@ -8,9 +8,7 @@ include:
 drain-kubelet:
   cmd.run:
     - name: |
-        kubectl drain {{ grains['caasp_fqdn'] }} --ignore-daemonsets --grace-period=300 --timeout=340s
-    - env:
-      - KUBECONFIG: {{ pillar['paths']['kubeconfig'] }}
+        kubectl --kubeconfig={{ pillar['paths']['kubeconfig'] }} drain {{ grains['caasp_fqdn'] }} --ignore-daemonsets --grace-period=300 --timeout=340s
     - check_cmd:
       - /bin/true
     - require:


### PR DESCRIPTION
Do not try to pass the kubeconfig in the `KUBECONFIG` env var: it can be problematic. Just use the `--kubeconfig` argument of `kubectl`