### PR TITLE
Do not check if we need to uncordon this node depending on its state.

### DIFF
--- a/salt/kubelet/init.sls
+++ b/salt/kubelet/init.sls
@@ -81,18 +81,10 @@ kubelet:
     - require:
       - service: kubelet
 
-  # TODO: This needs to wait for the node to register, which takes a few seconds.
-  # Salt doesn't seem to have a retry mechanism in the version were using, so I'm
-  # doing a horrible hack right now.
-  # RAR: Increasing the timeout to 5 minutes, since this now occurs during the initial
-  # bootstrap - it takes more than 60 seconds before kube-apiserver is running.
-  # DO NOT uncordon the "master" nodes, this makes them schedulable.
 {% if not "kube-master" in salt['grains.get']('roles', []) %}
   caasp_cmd.run:
     - name: |
         kubectl uncordon {{ grains['caasp_fqdn'] }}
-    - onlyif:
-        test "$(kubectl --kubeconfig={{ pillar['paths']['kubeconfig'] }} get nodes {{ grains['caasp_fqdn'] }} -o=jsonpath='{.spec.unschedulable}' 2>/dev/null)" = "true"
     - retry:
         attempts: 10
         interval: 3


### PR DESCRIPTION
The `onlyif` section can fail its check (without retrial opportunity), making
the whole uncordon process to abort, when we really want to uncordon a node.

In the future, we need to keep track of cordoned nodes by the update so we
only uncordon those, leaving cordoned the nodes that were cordoned by the user.

In any case, for this issue, `kubectl` will be smart enough:

- For a cordoned node, uncordoning:

```
~ KUBECONFIG=~/Downloads/kubeconfig kubectl uncordon 7a4f4985eaed4f519e27900ece559b8e.infra.caasp.local
node "7a4f4985eaed4f519e27900ece559b8e.infra.caasp.local" uncordoned
~ echo $?
0
```

- For an uncordoned node, uncordoning again:

```
~ KUBECONFIG=~/Downloads/kubeconfig kubectl uncordon 7a4f4985eaed4f519e27900ece559b8e.infra.caasp.local
node "7a4f4985eaed4f519e27900ece559b8e.infra.caasp.local" already uncordoned
~ echo $?
0
```

We know we want to uncordon the node, let's do that directly, and it will just
succeed in any case (unless the process of uncordoning fails for some reason, and
in that case we have the `retries` in place).

Fixes: bsc#1073919
Fixes: #336