### PR TITLE
Only uncordon nodes that were cordoned because of our own processes

### DIFF
--- a/salt/kubelet/init.sls
+++ b/salt/kubelet/init.sls
@@ -86,7 +86,7 @@ kubelet:
   # RAR: Increasing the timeout to 5 minutes, since this now occurs during the initial
   # bootstrap - it takes more than 60 seconds before kube-apiserver is running.
   # DO NOT uncordon the "master" nodes, this makes them schedulable.
-{% if not "kube-master" in salt['grains.get']('roles', []) %}
+{% if not "kube-master" in salt['grains.get']('roles', []) and salt['grains.get']('kubelet:should_uncordon', false) %}
   cmd.run:
     - name: |
         ELAPSED=0
@@ -101,6 +101,11 @@ kubelet:
     - require:
       - file: {{ pillar['paths']['kubeconfig'] }}
 {% endif %}
+
+remove-should-uncordon-grain:
+  grains.absent:
+    - name: kubelet:should_uncordon
+    - destructive: True
 
 #######################
 # config files

--- a/salt/kubelet/stop.sls
+++ b/salt/kubelet/stop.sls
@@ -4,6 +4,8 @@
 include:
   - kubectl-config
 
+{% set should_uncordon = salt['cmd.run']("kubectl --kubeconfig=" + pillar['paths']['kubeconfig'] + " get nodes " + grains['caasp_fqdn'] + " -o=jsonpath='{.spec.unschedulable}' 2>/dev/null") != "true" %}
+
 # If this fails we should ignore it and proceed anyway as Kubernetes will recover
 drain-kubelet:
   cmd.run:
@@ -15,6 +17,10 @@ drain-kubelet:
       - /bin/true
     - require:
       - file: {{ pillar['paths']['kubeconfig'] }}
+  grains.present:
+    - name: kubelet:should_uncordon
+    - value: {{ should_uncordon }}
+    - force: True
 
 kubelet:
   service.dead:


### PR DESCRIPTION
Fix kubelet highstate to uncordon the node only if we did cordon it by
one of our processes (like an update).

Without this patch, adding new nodes or performing an update would
uncordon all nodes unconditionally, without taking into account if a
user had a node cordoned for some reason (e.g. hardware failures or
other reasons). Do not uncordon those nodes, keep them cordoned.

Fixes: bsc#1050017

Backport of https://github.com/kubic-project/salt/pull/338