### PR TITLE
No longer use machine-id's as node names

### DIFF
--- a/pillar/fqdn.sls
+++ b/pillar/fqdn.sls
@@ -1,7 +1,0 @@
-mine_functions:
-  fqdn:
-    - mine_function: grains.get
-    - fqdn
-  caasp_fqdn:
-    - mine_function: grains.get
-    - caasp_fqdn

--- a/pillar/mine.sls
+++ b/pillar/mine.sls
@@ -2,4 +2,9 @@ mine_functions:
   network.ip_addrs: []
   network.interfaces: []
   network.default_route: []
-
+  nodename:
+    - mine_function: grains.get
+    - nodename
+  host:
+    - mine_function: grains.get
+    - host

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -8,7 +8,6 @@ base:
     - mine
     - docker
     - registries
-    - fqdn
     - schedule
   'roles:ca':
     - match: grain

--- a/salt/_macros/certs.jinja
+++ b/salt/_macros/certs.jinja
@@ -1,7 +1,10 @@
 
 {% macro alt_names(lst=[]) -%}
   {#- add all the names and IPs we know about -#}
-  {%- set altNames = ["DNS: " + grains['caasp_fqdn'] ] -%}
+  {%- set altNames = [
+    "DNS: " + grains['nodename'], "DNS: " + grains['nodename'] + "." + pillar['internal_infra_domain'],
+    "DNS: " + grains['machine_id'], "DNS: " + grains['machine_id'] + "." + pillar['internal_infra_domain']
+  ] -%}
   {#- append all the names/IPs provided (if not empty) -#}
   {%- for name in lst -%}
     {%- if name and name|length > 0 -%}

--- a/salt/_modules/caasp_net.py
+++ b/salt/_modules/caasp_net.py
@@ -59,3 +59,9 @@ def get_primary_ips_for(compound, **kwargs):
     for host in _get_mine(compound, 'network.interfaces', expr_form='compound').keys():
         res.append(get_primary_ip(host=host, **kwargs))
     return res
+
+
+def get_nodename(**kwargs):
+    host = kwargs.pop('host', _get_local_id())
+    
+    return _get_mine(host, 'nodename')[host]

--- a/salt/cert/init.sls
+++ b/salt/cert/init.sls
@@ -3,7 +3,7 @@ include:
 
 {% from '_macros/certs.jinja' import certs with context %}
 
-{{ certs("node:" + grains['caasp_fqdn'],
+{{ certs("node:" + grains['nodename'],
          pillar['ssl']['crt_file'],
          pillar['ssl']['key_file'],
          o = pillar['certificate_information']['subject_properties']['O']) }}

--- a/salt/cni/update-pre-orchestration.sh
+++ b/salt/cni/update-pre-orchestration.sh
@@ -18,7 +18,7 @@ exit_changes() {
 }
 
 get_node_cidr() {
-	kubectl get no "$NODE_ID" --template="{{.spec.podCIDR}}"
+	kubectl get node "$NODE_ID" --template="{{.spec.podCIDR}}"
 }
 
 patch_node() {

--- a/salt/cni/update-pre-orchestration.sls
+++ b/salt/cni/update-pre-orchestration.sls
@@ -6,12 +6,12 @@ include:
  - kubectl-config
 
 # try to save the flannel subnet in the .spec.podCIDR (if not assigned yet)
-/tmp/update-pre-orchestration.sh:
+/tmp/cni-update-pre-orchestration.sh:
   file.managed:
     - source: salt://cni/update-pre-orchestration.sh
     - mode: 0755
   cmd.run:
-    - name: /tmp/update-pre-orchestration.sh {{ grains['caasp_fqdn'] }} {{ salt.caasp_net.get_primary_ip() }} {{ salt.caasp_pillar.get('flannel:backend', 'vxlan') }}
+    - name: /tmp/cni-update-pre-orchestration.sh {{ grains['machine_id'] + "." + pillar['internal_infra_domain'] }} {{ salt.caasp_net.get_primary_ip() }} {{ salt.caasp_pillar.get('flannel:backend', 'vxlan') }}
     - stateful: True
     - env:
       - KUBECONFIG: {{ pillar['paths']['kubeconfig'] }}

--- a/salt/etc-hosts/hosts.jinja
+++ b/salt/etc-hosts/hosts.jinja
@@ -12,17 +12,17 @@
 ### admin nodes ###
 {%- set admins = salt['mine.get']('roles:admin', 'network.interfaces', 'grain') %}
 {%- for admin_id, ifaces in admins.items() %}
-{{ salt.caasp_net.get_primary_ip(host=admin_id, ifaces=ifaces) }} {{ admin_id }} {{ admin_id }}.{{ pillar['internal_infra_domain'] }}
+{{ salt.caasp_net.get_primary_ip(host=admin_id, ifaces=ifaces) }} {{ salt.caasp_net.get_nodename(host=admin_id) }} {{ salt.caasp_net.get_nodename(host=admin_id) }}.{{ pillar['internal_infra_domain'] }} {{ admin_id }} {{ admin_id }}.{{ pillar['internal_infra_domain'] }}
 {%- endfor %}
 
 ### kubernetes masters ###
 {%- set masters = salt['mine.get']('roles:kube-master', 'network.interfaces', 'grain') %}
 {%- for master_id, ifaces in masters.items() %}
-{{ salt.caasp_net.get_primary_ip(host=master_id, ifaces=ifaces) }} {{ master_id }} {{ master_id }}.{{ pillar['internal_infra_domain'] }}
+{{ salt.caasp_net.get_primary_ip(host=master_id, ifaces=ifaces) }} {{ salt.caasp_net.get_nodename(host=master_id) }} {{ salt.caasp_net.get_nodename(host=master_id) }}.{{ pillar['internal_infra_domain'] }} {{ master_id }} {{ master_id }}.{{ pillar['internal_infra_domain'] }}
 {%- endfor %}
 
 ### kubernetes workers ###
 {%- set minions = salt['mine.get']('roles:kube-minion', 'network.interfaces', 'grain') %}
 {%- for minion_id, ifaces in minions.items() %}
-{{ salt.caasp_net.get_primary_ip(host=minion_id, ifaces=ifaces) }} {{ minion_id }} {{ minion_id }}.{{ pillar['internal_infra_domain'] }}
+{{ salt.caasp_net.get_primary_ip(host=minion_id, ifaces=ifaces) }} {{ salt.caasp_net.get_nodename(host=minion_id) }} {{ salt.caasp_net.get_nodename(host=minion_id) }}.{{ pillar['internal_infra_domain'] }} {{ minion_id }} {{ minion_id }}.{{ pillar['internal_infra_domain'] }}
 {%- endfor %}

--- a/salt/etcd/etcd.conf.jinja
+++ b/salt/etcd/etcd.conf.jinja
@@ -6,7 +6,7 @@ ETCD_NAME="{{ grains['id'] }}"
 
 ETCD_LISTEN_CLIENT_URLS="https://0.0.0.0:2379"
 ETCD_LISTEN_PEER_URLS="https://0.0.0.0:2380"
-ETCD_ADVERTISE_CLIENT_URLS="https://{{ grains['caasp_fqdn'] }}:2379"
+ETCD_ADVERTISE_CLIENT_URLS="https://{{ grains['nodename'] }}:2379"
 ETCD_CLIENT_CERT_AUTH="true"
 
 ETCD_CA_FILE={{ pillar['ssl']['ca_file'] }}
@@ -26,7 +26,7 @@ ETCD_DISCOVERY="http://{{ pillar['dashboard'] }}:{{ pillar['etcd']['disco']['por
 ETCD_DISCOVERY_FALLBACK="proxy"
 
 ETCD_INITIAL_CLUSTER_TOKEN="{{ pillar['etcd']['token'] }}"
-ETCD_INITIAL_ADVERTISE_PEER_URLS="https://{{ grains['caasp_fqdn'] }}:2380"
+ETCD_INITIAL_ADVERTISE_PEER_URLS="https://{{ grains['nodename'] }}:2380"
 ETCD_INITIAL_CLUSTER_STATE="new"
 
 # set log level

--- a/salt/etcd/etcdctl.conf.jinja
+++ b/salt/etcd/etcdctl.conf.jinja
@@ -6,7 +6,7 @@
 # etcdctl:
 # set -a; source /etc/sysconfig/etcdctl; set +a
 
-ETCDCTL_ENDPOINT="https://{{ grains['caasp_fqdn'] }}:2379"
+ETCDCTL_ENDPOINT="https://{{ grains['nodename'] }}:2379"
 
 # etcd v2 style flags
 ETCDCTL_CA_FILE={{ pillar['ssl']['ca_file'] }}

--- a/salt/etcd/init.sls
+++ b/salt/etcd/init.sls
@@ -58,7 +58,7 @@ etcd:
         etcdctl --key-file {{ pillar['ssl']['key_file'] }} \
                 --cert-file {{ pillar['ssl']['crt_file'] }} \
                 --ca-file {{ pillar['ssl']['ca_file'] }} \
-                --endpoints https://{{ grains['caasp_fqdn'] }}:2379 \
+                --endpoints https://{{ grains['nodename'] }}:2379 \
                 cluster-health | grep "cluster is healthy"
     - retry:
         attempts: 10

--- a/salt/haproxy/haproxy.cfg.jinja
+++ b/salt/haproxy/haproxy.cfg.jinja
@@ -25,8 +25,8 @@ listen kubernetes-master
         default-server inter 10s fall 3
         balance roundrobin
 
-{%- for minion_id, _ in salt['mine.get']('roles:kube-master', 'network.interfaces', 'grain').items() %}
-        server master-{{ minion_id }} {{ minion_id }}.{{ pillar['internal_infra_domain'] }}:{{ pillar['api']['int_ssl_port'] }} check
+{%- for minion_id, nodename in salt['mine.get']('roles:kube-master', 'nodename', 'grain').items() %}
+        server master-{{ minion_id }} {{ nodename }}:{{ pillar['api']['int_ssl_port'] }} check
 {% endfor -%}
 
 {%- if "admin" in salt['grains.get']('roles', []) %}
@@ -37,8 +37,8 @@ listen kubernetes-dex
         default-server inter 10s fall 3
         balance roundrobin
 
-{%- for minion_id, _ in salt['mine.get']('roles:kube-master', 'network.interfaces', 'grain').items() %}
-        server master-{{ minion_id }} {{ minion_id }}.{{ pillar['internal_infra_domain'] }}:32000 check
+{%- for minion_id, nodename in salt['mine.get']('roles:kube-master', 'nodename', 'grain').items() %}
+        server master-{{ minion_id }} {{ nodename }}:32000 check
 {% endfor %}
 
 listen velum

--- a/salt/hostname/init.sls
+++ b/salt/hostname/init.sls
@@ -1,3 +1,0 @@
-caasp_fqdn:
-  grains.present:
-    - value: {{ grains['id'] }}.{{ pillar['internal_infra_domain'] }}

--- a/salt/kube-apiserver/apiserver.jinja
+++ b/salt/kube-apiserver/apiserver.jinja
@@ -16,7 +16,7 @@ KUBE_API_PORT="--insecure-port=8080 --secure-port={{ pillar['api']['int_ssl_port
 KUBE_ETCD_SERVERS="--etcd-cafile={{ pillar['ssl']['ca_file'] }} \
                    --etcd-certfile={{ pillar['ssl']['kube_apiserver_crt'] }} \
                    --etcd-keyfile={{ pillar['ssl']['kube_apiserver_key'] }} \
-                   --etcd-servers=https://{{ grains['caasp_fqdn'] }}:2379"
+                   --etcd-servers=https://{{ grains['nodename'] }}:2379"
 
 # Address range to use for services
 # [alvaro] should not be in the same range as the flannel network (https://github.com/coreos/flannel/issues/232)
@@ -27,7 +27,7 @@ KUBE_ADMISSION_CONTROL="--admission-control=Initializers,NamespaceLifecycle,Limi
 
 # Add your own!
 KUBE_API_ARGS="--advertise-address={{ salt.caasp_net.get_primary_ip() }} \
-               --apiserver-count={{ salt['mine.get']('roles:kube-master', 'caasp_fqdn', expr_form='grain').values()|length }} \
+               --apiserver-count={{ salt['mine.get']('roles:kube-master', 'nodename', expr_form='grain').values()|length }} \
 {%- if cloud_provider %}
                --cloud-provider={{ pillar['cloud']['provider'] }} \
   {%- if cloud_provider == 'openstack' %}

--- a/salt/kube-apiserver/init.sls
+++ b/salt/kube-apiserver/init.sls
@@ -10,7 +10,7 @@ include:
 {{ certs("kube-apiserver",
          pillar['ssl']['kube_apiserver_crt'],
          pillar['ssl']['kube_apiserver_key'],
-         cn = grains['caasp_fqdn'],
+         cn = grains['nodename'],
          o = pillar['certificate_information']['subject_properties']['O']) }}
 
 kube-apiserver:

--- a/salt/kube-proxy/proxy.jinja
+++ b/salt/kube-proxy/proxy.jinja
@@ -6,7 +6,7 @@
 # Add your own!
 KUBE_PROXY_ARGS="\
     --cluster-cidr={{ pillar['cluster_cidr'] }} \
-    --hostname-override={{ grains['caasp_fqdn'] }} \
+    --hostname-override={{ grains['nodename'] }} \
     --kubeconfig={{ pillar['paths']['kube_proxy_config'] }} \
     --proxy-mode=iptables \
     {{ pillar['components']['proxy']['args'] }} \

--- a/salt/kubelet/init.sls
+++ b/salt/kubelet/init.sls
@@ -19,7 +19,7 @@ include:
 {% endif %}
 
 {% from '_macros/certs.jinja' import certs with context %}
-{{ certs('node:' + grains['caasp_fqdn'],
+{{ certs('node:' + grains['nodename'],
          pillar['ssl']['kubelet_crt'],
          pillar['ssl']['kubelet_key'],
          o = 'system:nodes') }}
@@ -101,12 +101,12 @@ kubelet:
 {% if not "kube-master" in salt['grains.get']('roles', []) and salt['grains.get']('kubelet:should_uncordon', false) %}
   caasp_cmd.run:
     - name: |
-        kubectl uncordon {{ grains['caasp_fqdn'] }}
+        kubectl uncordon {{ grains['nodename'] }}
     - retry:
         attempts: 10
         interval: 3
         until: |
-          test "$(kubectl --kubeconfig={{ pillar['paths']['kubeconfig'] }} get nodes {{ grains['caasp_fqdn'] }} -o=jsonpath='{.spec.unschedulable}' 2>/dev/null)" != "true"
+          test "$(kubectl --kubeconfig={{ pillar['paths']['kubeconfig'] }} get nodes {{ grains['nodename'] }} -o=jsonpath='{.spec.unschedulable}' 2>/dev/null)" != "true"
     - require:
       - file: {{ pillar['paths']['kubeconfig'] }}
 {% endif %}

--- a/salt/kubelet/kubelet.jinja
+++ b/salt/kubelet/kubelet.jinja
@@ -12,8 +12,8 @@ KUBELET_ADDRESS="--address=0.0.0.0"
 # The port for the info server to serve on
 KUBELET_PORT="--port={{ pillar['kubelet']['port'] }}"
 
-# Use <machine_id>.<internal_infra_domain> matching the SSL certificates
-KUBELET_HOSTNAME="--hostname-override={{ grains['caasp_fqdn'] }}"
+# Ensure we match the machine hostname
+KUBELET_HOSTNAME="--hostname-override={{ grains['nodename'] }}"
 
 # Add your own!
 KUBELET_ARGS="\

--- a/salt/kubelet/stop.sls
+++ b/salt/kubelet/stop.sls
@@ -4,13 +4,13 @@
 include:
   - kubectl-config
 
-{% set should_uncordon = salt['cmd.run']("kubectl --kubeconfig=" + pillar['paths']['kubeconfig'] + " get nodes " + grains['caasp_fqdn'] + " -o=jsonpath='{.spec.unschedulable}' 2>/dev/null") != "true" %}
+{% set should_uncordon = salt['cmd.run']("kubectl --kubeconfig=" + pillar['paths']['kubeconfig'] + " get nodes " + grains['nodename'] + " -o=jsonpath='{.spec.unschedulable}' 2>/dev/null") != "true" %}
 
 # If this fails we should ignore it and proceed anyway as Kubernetes will recover
 drain-kubelet:
   cmd.run:
     - name: |
-        kubectl --kubeconfig={{ pillar['paths']['kubeconfig'] }} drain {{ grains['caasp_fqdn'] }} --ignore-daemonsets --grace-period=300 --timeout=340s
+        kubectl --kubeconfig={{ pillar['paths']['kubeconfig'] }} drain {{ grains['nodename'] }} --ignore-daemonsets --grace-period=300 --timeout=340s
     - check_cmd:
       - /bin/true
     - require:

--- a/salt/kubelet/update-post-start-services.sls
+++ b/salt/kubelet/update-post-start-services.sls
@@ -1,0 +1,10 @@
+# invoked by the "update" orchestration after starting
+# all the services after rebooting
+
+remove-old-node-entry:
+  cmd.run:
+    - name: kubectl delete node {{ grains['machine_id'] + "." + pillar['internal_infra_domain'] }}
+    - check_cmd:
+      - /bin/true
+    - onlyif:
+      - kubectl get node {{ grains['machine_id'] + "." + pillar['internal_infra_domain'] }}

--- a/salt/kubelet/update-pre-orchestration.sh
+++ b/salt/kubelet/update-pre-orchestration.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Preseeds a node in Kubernetes with critical data migrated from
+# an old node.
+
+OLD_NODE_NAME="$1"
+NEW_NODE_NAME="$2"
+
+##########################################################
+
+log() { echo "[machine-id migration]: $1 " ; logger -t "machine-id-migration" "$1" ; }
+
+exit_changes() {
+	log "$2"
+	echo  # an empty line here so the next line will be the last.
+	echo "changed=$1 comment='"$2"'"
+	exit 0
+}
+
+get_node_data() {
+	local template="$1"
+	kubectl get node "$OLD_NODE_NAME" --template="{{$template}}"
+}
+
+##########################################################
+
+log "migrating $OLD_NODE_NAME to $NEW_NODE_NAME"
+
+kubectl get node $OLD_NODE_NAME || exit_changes "no" "$OLD_NODE_NAME does not exist, nothing to migrate"
+
+cat << EOF > /tmp/k8s-node-migration.yaml
+apiVersion: v1
+kind: Node
+metadata:
+  name: ${NEW_NODE_NAME}
+  annotations:
+    flannel.alpha.coreos.com/backend-data: '$(get_node_data 'index .metadata.annotations "flannel.alpha.coreos.com/backend-data"')'
+    flannel.alpha.coreos.com/backend-type: '$(get_node_data 'index .metadata.annotations "flannel.alpha.coreos.com/backend-type"')'
+    flannel.alpha.coreos.com/public-ip: $(get_node_data 'index .metadata.annotations "flannel.alpha.coreos.com/public-ip"')
+    flannel.alpha.coreos.com/kube-subnet-manager: "true"
+spec:
+  externalID: ${NEW_NODE_NAME}
+  podCIDR: $(get_node_data .spec.podCIDR)
+EOF
+
+kubectl create -f /tmp/k8s-node-migration.yaml 2>/dev/null
+
+rm /tmp/k8s-node-migration.yaml
+
+exit_changes "yes" "Node data migrated from $OLD_NODE_NAME to $NEW_NODE_NAME"

--- a/salt/kubelet/update-pre-orchestration.sls
+++ b/salt/kubelet/update-pre-orchestration.sls
@@ -1,0 +1,19 @@
+# invoked by the "update" orchestration right
+# before starting the real orchestration updating
+# and rebooting machines
+
+include:
+ - kubectl-config
+
+# Migrates critical data from the old K8S node, to a new one with updated names
+/tmp/kubelet-update-pre-orchestration.sh:
+  file.managed:
+    - source: salt://kubelet/update-pre-orchestration.sh
+    - mode: 0755
+  cmd.run:
+    - name: /tmp/kubelet-update-pre-orchestration.sh {{ grains['machine_id'] + "." + pillar['internal_infra_domain'] }} {{ grains['nodename'] }}
+    - stateful: True
+    - env:
+      - KUBECONFIG: {{ pillar['paths']['kubeconfig'] }}
+    - require:
+      - {{ pillar['paths']['kubeconfig'] }}

--- a/salt/ldap/init.sls
+++ b/salt/ldap/init.sls
@@ -5,10 +5,10 @@ include:
 {% set names = [salt.caasp_pillar.get('dashboard')] %}
 
 {% from '_macros/certs.jinja' import alt_names, certs with context %}
-{{ certs("ldap:" + grains['caasp_fqdn'],
+{{ certs("ldap:" + grains['nodename'],
          pillar['ssl']['ldap_crt'],
          pillar['ssl']['ldap_key'],
-         cn = grains['caasp_fqdn'],
+         cn = grains['nodename'],
          extra_alt_names = alt_names(names)) }}
 
 openldap_restart:

--- a/salt/motd/motd.jinja
+++ b/salt/motd/motd.jinja
@@ -1,7 +1,7 @@
 Welcome!
 
 Machine ID: {{ salt['grains.get']('machine_id', 'ERROR') }}
-Internal FQDN: {{ salt['grains.get']('caasp_fqdn', 'ERROR') }}
+Hostname: {{ salt['grains.get']('nodename', 'ERROR') }}
 
 The roles of this node are:
 {%- for role in salt['grains.get']('roles', []) %}

--- a/salt/orch/kubernetes.sls
+++ b/salt/orch/kubernetes.sls
@@ -27,26 +27,19 @@ disable_rebootmgr:
     - require:
       - salt: set_bootstrap_in_progress_flag
 
-hostname_setup:
-  salt.state:
-    - tgt: 'roles:(admin|kube-(master|minion))'
-    - tgt_type: grain_pcre
-    - sls:
-      - hostname
-
 update_pillar:
   salt.function:
     - tgt: '*'
     - name: saltutil.refresh_pillar
     - require:
-      - salt: hostname_setup
+      - salt: disable_rebootmgr
 
 update_grains:
   salt.function:
     - tgt: '*'
     - name: saltutil.refresh_grains
     - require:
-      - salt: hostname_setup
+      - salt: disable_rebootmgr
 
 update_mine:
   salt.function:

--- a/salt/orch/update-etc-hosts.sls
+++ b/salt/orch/update-etc-hosts.sls
@@ -1,6 +1,6 @@
 {%- set updates_all_target = 'P@roles:(admin|kube-(master|minion)) and G@bootstrap_complete:true and not G@bootstrap_in_progress:true and not G@update_in_progress:true' %}
 
-{%- if salt.saltutil.runner('mine.get', tgt=updates_all_target, fun='caasp_fqdn', tgt_type='compound')|length > 0 %}
+{%- if salt.saltutil.runner('mine.get', tgt=updates_all_target, fun='nodename', tgt_type='compound')|length > 0 %}
 update_pillar:
   salt.function:
     - tgt: {{ updates_all_target }}

--- a/salt/orch/update.sls
+++ b/salt/orch/update.sls
@@ -62,6 +62,7 @@ pre-orchestration-migration:
     - batch: 3
     - sls:
       - cni.update-pre-orchestration
+      - kubelet.update-pre-orchestration
     - require:
       - salt: update_modules
 
@@ -125,6 +126,7 @@ pre-orchestration-migration:
     - tgt: {{ master_id }}
     - sls:
       - cni.update-post-start-services
+      - kubelet.update-post-start-services
     - require:
       - salt: {{ master_id }}-start-services
 
@@ -206,6 +208,7 @@ pre-orchestration-migration:
     - tgt: {{ worker_id }}
     - sls:
       - cni.update-post-start-services
+      - kubelet.update-post-start-services
     - require:
       - salt: {{ worker_id }}-start-services
 
@@ -270,6 +273,18 @@ services_setup:
     - require:
       - cni_setup
 
+# Remove the now defuct caasp_fqdn grain (Remove for 4.0).
+remove-caasp-fqdn-grain:
+  salt.function:
+    - tgt: '*'
+    - name: grains.delval
+    - arg:
+      - caasp_fqdn
+    - kwarg:
+        destructive: True
+    - require:
+      - salt: services_setup
+
 masters-remove-update-grain:
   salt.function:
     - tgt: G@roles:kube-master and G@update_in_progress:true
@@ -280,4 +295,4 @@ masters-remove-update-grain:
     - kwarg:
         destructive: True
     - require:
-      - salt: services_setup
+      - salt: remove-caasp-fqdn-grain

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -4,7 +4,6 @@ base:
     - ca
   'roles:(admin|kube-(master|minion))':
     - match: grain_pcre
-    - hostname
     - swap
     - etc-hosts
     - proxy

--- a/salt/velum/init.sls
+++ b/salt/velum/init.sls
@@ -7,8 +7,8 @@ include:
                 salt.caasp_pillar.get('dashboard')] %}
 
 {% from '_macros/certs.jinja' import alt_names, certs with context %}
-{{ certs("velum:" + grains['caasp_fqdn'],
+{{ certs("velum:" + grains['nodename'],
          pillar['ssl']['velum_crt'],
          pillar['ssl']['velum_key'],
-         cn = grains['caasp_fqdn'],
+         cn = grains['nodename'],
          extra_alt_names = alt_names(names)) }}


### PR DESCRIPTION
With CaaSP 3.0, we're introducing a requirement for machines to have valid+unique hostnames in order to allow for the K8S CPIs to function correctly.

This means our generated hostname is no longer needed, as our environment requirements force operators to provision servers with unique hostnames.

TODO:

- [x] Test deploy on OpenStack
- [x] ~~Test deploy on Bare Metal~~ - getting an ISO built pre-merge is proving difficult at best, lets validate BM env's once merged.,
- [x] Make upgrade work
- [x] Test upgrades on OpenStack 
- [x] ~~Test upgrades on Bare Metal~~ - getting an ISO built pre-merge is proving difficult at best, lets validate BM env's once merged.,
- [x] ~~Ensure doc bug is filed for updated requirements~~ - The requirements for 2.0 already list this (despite this not being a 2.0 requirement)
- [ ] Ensure doc bug is filed for with release note material
- [x] ~~Update Velum to refuse to add/accept nodes who have a conflicting hostname (if possible)~~ moved to https://github.com/kubic-project/velum/pull/433
- [x] Update tests etc which reference machine-id names to use the hostnames...

Some decisions made:

1. Continue to use /etc/hosts - don't rely on external name servers. This can be revisited later, but keeps the change smaller and less likely to break
2. Prefer to use short-form hostnames rather than FQDNs.
3. Keep the machine-id /etc/hosts entries for now as I suspect this will ease rolling upgrade.
4. Keep the machine-id entries in certs for now as I suspect this will ease rolling upgrade.
5. Make the minimal changes needed for CPIs to work as a first step

Depends-On: https://github.com/kubic-project/automation/pull/213
  