### PR TITLE
Remove discovered IP addresses from certs

### DIFF
--- a/salt/_macros/certs.jinja
+++ b/salt/_macros/certs.jinja
@@ -2,11 +2,6 @@
 {% macro alt_names(lst=[]) -%}
   {#- add all the names and IPs we know about -#}
   {%- set altNames = ["DNS: " + grains['caasp_fqdn'] ] -%}
-  {%- for _, interface_addresses in grains['ip4_interfaces'].items() -%}
-    {%- for interface_address in interface_addresses -%}
-      {%- do altNames.append("IP: " + interface_address) -%}
-    {%- endfor -%}
-  {%- endfor -%}
   {#- append all the names/IPs provided (if not empty) -#}
   {%- for name in lst -%}
     {%- if name and name|length > 0 -%}


### PR DESCRIPTION
As the discovered IP addresses are not static, that we don't maintain that
the certs are updated+services are reloaded upon IP change, that we're
including all IPs - even 127.0.0.1 - in this list, and that we don't make use
of any of these SAN's, we should remove them.