### PR TITLE
Update salt to use 2.7.2 version of tiller

### DIFF
--- a/salt/addons/tiller/tiller.yaml.jinja
+++ b/salt/addons/tiller/tiller.yaml.jinja
@@ -26,7 +26,7 @@ spec:
       - env:
         - name: TILLER_NAMESPACE
           value: kube-system
-        image: sles12/tiller:2.5.1
+        image: sles12/tiller:2.7.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:


### PR DESCRIPTION
Update the salt template for the tiller deployment to install the
sles12/tiller:2.7.2 container image which is the latest version for
this image.