### PR TITLE
Update our manifests to reflect kubernetes 1.8 changes

### DIFF
--- a/salt/addons/dns/kubedns.yaml.jinja
+++ b/salt/addons/dns/kubedns.yaml.jinja
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: kube-dns

--- a/salt/addons/tiller/tiller.yaml.jinja
+++ b/salt/addons/tiller/tiller.yaml.jinja
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   creationTimestamp: null
@@ -9,6 +9,10 @@ metadata:
   name: tiller
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      app: helm
+      name: tiller
   strategy: {}
   template:
     metadata:

--- a/salt/cni/kube-flannel-rbac.yaml.jinja
+++ b/salt/cni/kube-flannel-rbac.yaml.jinja
@@ -6,7 +6,7 @@ metadata:
   namespace: "kube-system"
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: flannel
 rules:
@@ -31,7 +31,7 @@ rules:
       - patch
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: flannel
 roleRef:

--- a/salt/cni/kube-flannel.yaml.jinja
+++ b/salt/cni/kube-flannel.yaml.jinja
@@ -50,7 +50,7 @@ data:
       }
     }
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:
   name: kube-flannel
@@ -59,6 +59,10 @@ metadata:
     tier: node
     k8s-app: flannel
 spec:
+  selector:
+    matchLabels:
+      tier: node
+      k8s-app: flannel
   template:
     metadata:
       labels:

--- a/salt/dex/dex.yaml
+++ b/salt/dex/dex.yaml
@@ -9,7 +9,7 @@ metadata:
 ---
 # Map the LDAP Administrators role to the Kubernetes system:masters group
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: system:dex
 subjects:
@@ -77,7 +77,7 @@ data:
       name: "CaaSP CLI"
       secret: "swac7qakes7AvucH8bRucucH"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   labels:
@@ -86,6 +86,9 @@ metadata:
   name: dex
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      app: dex
   replicas: 3
   template:
     metadata:

--- a/salt/dex/roles.yaml
+++ b/salt/dex/roles.yaml
@@ -3,7 +3,7 @@
 # any time. It will be in a different location in a
 # cloud provider environment.
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: find-dex
   namespace: kube-system
@@ -16,7 +16,7 @@ rules:
 # Allow any authenticated *or* unauthenticated
 # user to look up Dex's service entry
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: find-dex
   namespace: kube-system
@@ -34,7 +34,7 @@ roleRef:
 ---
 # Map the LDAP Administrators role to the Kubernetes system:masters group
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: administrators-in-ldap
 subjects:


### PR DESCRIPTION
* [rbac has been promoted to stable](https://v1-8.docs.kubernetes.io/docs/admin/authorization/rbac/)
* [deployment is now v1beta2](https://v1-8.docs.kubernetes.io/docs/concepts/workloads/controllers/deployment/)
* [deamonset is now v1beta2](https://v1-8.docs.kubernetes.io/docs/concepts/workloads/controllers/daemonset/)