### PR TITLE
Early mark nodes requiring update reboot as update in progress.

### DIFF
--- a/salt/orch/update-etc-hosts.sls
+++ b/salt/orch/update-etc-hosts.sls
@@ -26,7 +26,6 @@ etc_hosts_setup:
   salt.state:
     - tgt: {{ updates_all_target }}
     - tgt_type: compound
-    - queue: True
     - sls:
       - etc-hosts
     - require:


### PR DESCRIPTION
This will allow us to reduce the timeframe in which the update-etc-hosts
orchestration can pop up, eventually running states on minions effectively
taking their lock and making this orchestration fail. We don't want the
update-etc-hosts orchestration to interfere with the main update
orchestration.

We'll release minion per minion grain when they are done, but let's
block all of them at the very beginning.

Fixes: bsc#1077086