### PR TITLE
Early mark nodes requiring update reboot as update in progress.

### DIFF
--- a/salt/_states/caasp_retriable.py
+++ b/salt/_states/caasp_retriable.py
@@ -30,7 +30,10 @@ def retry(name, target, retry={}, **kwargs):
     ret = None
 
     for attempt in xrange(retry_['attempts']):
-        ret = __states__[target](name=name, **kwargs)
+        try:
+            ret = __states__[target](name=name, **kwargs)
+        except BaseException as e:
+            ret = {'result': False, 'changes': False, 'comment': 'Exception raised: {0}'.format(e)}
 
         if ret['result']:
             return {

--- a/salt/kube-controller-manager/init.sls
+++ b/salt/kube-controller-manager/init.sls
@@ -71,7 +71,7 @@ kube-controller-mgr-config:
     - template: jinja
     - require:
       - pkg: kubernetes-common
-      - {{ pillar['ssl']['kube_controller_mgr_crt'] }}
+      - caasp_retriable: {{ pillar['ssl']['kube_controller_mgr_crt'] }}
     - defaults:
         user: 'default-admin'
         client_certificate: {{ pillar['ssl']['kube_controller_mgr_crt'] }}

--- a/salt/kube-proxy/init.sls
+++ b/salt/kube-proxy/init.sls
@@ -15,7 +15,7 @@ kube-proxy-config:
     - template: jinja
     - require:
       - pkg: kubernetes-common
-      - {{ pillar['ssl']['kube_proxy_crt'] }}
+      - caasp_retriable: {{ pillar['ssl']['kube_proxy_crt'] }}
     - defaults:
         user: 'default-admin'
         client_certificate: {{ pillar['ssl']['kube_proxy_crt'] }}

--- a/salt/kube-scheduler/init.sls
+++ b/salt/kube-scheduler/init.sls
@@ -69,7 +69,7 @@ kube-scheduler-config:
     - template: jinja
     - require:
       - pkg: kubernetes-common
-      - {{ pillar['ssl']['kube_scheduler_crt'] }}
+      - caasp_retriable: {{ pillar['ssl']['kube_scheduler_crt'] }}
     - defaults:
         user: 'default-admin'
         client_certificate: {{ pillar['ssl']['kube_scheduler_crt'] }}

--- a/salt/kubelet/init.sls
+++ b/salt/kubelet/init.sls
@@ -30,7 +30,7 @@ kubelet-config:
     - template: jinja
     - require:
       - pkg: kubernetes-common
-      - {{ pillar['ssl']['kubelet_crt'] }}
+      - caasp_retriable: {{ pillar['ssl']['kubelet_crt'] }}
     - defaults:
         user: 'default-admin'
         client_certificate: {{ pillar['ssl']['kubelet_crt'] }}

--- a/salt/orch/update-etc-hosts.sls
+++ b/salt/orch/update-etc-hosts.sls
@@ -27,7 +27,6 @@ etc_hosts_setup:
   salt.state:
     - tgt: {{ updates_all_target }}
     - tgt_type: compound
-    - queue: True
     - sls:
       - etc-hosts
     - require:


### PR DESCRIPTION
This will allow us to reduce the timeframe in which the update-etc-hosts
orchestration can pop up, eventually running states on minions effectively
taking their lock and making this orchestration fail. We don't want the
update-etc-hosts orchestration to interfere with the main update
orchestration.

We'll release minion per minion grain when they are done, but let's
block all of them at the very beginning.

Fixes: bsc#1077086

Backport of https://github.com/kubic-project/salt/pull/354