### PR TITLE
Do not remove flannel interface when updating 3.x

### DIFF
--- a/salt/cni/update-post-start-services.sls
+++ b/salt/cni/update-post-start-services.sls
@@ -8,9 +8,3 @@ remove-docker-iface:
     - check_cmd:
       - /bin/true
     # TODO: maybe we should restart dockerd...
-
-remove-flannel-iface:
-  cmd.run:
-    - name: ip link delete flannel.1
-    - check_cmd:
-      - /bin/true


### PR DESCRIPTION
Between minor updates on 3.x we can get a bad timing when removing the
flannel.1 interface as the DaemonSet will start right after the worker
reboot, and we could remove the interface when flannel thinks it exists
and it goes to add arp entries to it, leading to a failure and to an
invalid kubernetes networking status.