### PR TITLE
Add pillar root for public cloud specific config

### DIFF
--- a/config/master.d/50-master.conf
+++ b/config/master.d/50-master.conf
@@ -21,6 +21,8 @@ file_roots:
 pillar_roots:
   base:
     - /usr/share/salt/kubernetes/pillar
+  prod:
+    - /srv/pillar
 
 # The mechanism that provides custom modules to the master
 # is different from that which serves them to the minions.


### PR DESCRIPTION
This adds a second pillar root for cloud specific configuration. See also [Add mount for public cloud pillar](https://github.com/kubic-project/caasp-container-manifests/pull/142) in caasp-container-manifests.