### PR TITLE
Retry certificate generation

### DIFF
--- a/salt/_macros/certs.jinja
+++ b/salt/_macros/certs.jinja
@@ -60,7 +60,8 @@
       - file: /etc/pki
 
 {{ crt }}:
-  x509.certificate_managed:
+  caasp_retriable.retry:
+    - target: x509.certificate_managed
     - ca_server: {{ salt['mine.get']('roles:ca', 'ca.crt', expr_form='grain').keys()[0] }}
     - signing_policy: minion
     - public_key: {{ key }}
@@ -93,6 +94,8 @@
     - user: root
     - group: root
     - mode: 644
+    - retry:
+        attempts: 5
     - require:
       - sls: crypto
       - x509: {{ key }}
@@ -110,7 +113,7 @@
         certificate: {{ crt }}
         key:         {{ key }}
     - onchanges:
-        - x509: {{ crt }}
+        - caasp_retriable: {{ crt }}
         - x509: {{ key }}
 
 {%- endmacro %}

--- a/salt/kube-apiserver/init.sls
+++ b/salt/kube-apiserver/init.sls
@@ -44,15 +44,15 @@ kube-apiserver:
     - enable:     True
     - require:
       - caasp_retriable: iptables-kube-apiserver
-      - sls:      ca-cert
-      - x509:     {{ pillar['ssl']['kube_apiserver_crt'] }}
-      - x509:     {{ pillar['paths']['service_account_key'] }}
+      - sls:             ca-cert
+      - caasp_retriable: {{ pillar['ssl']['kube_apiserver_crt'] }}
+      - x509:            {{ pillar['paths']['service_account_key'] }}
     - watch:
-      - sls:      kubernetes-common
-      - file:     kube-apiserver
-      - sls:      ca-cert
-      - x509:     {{ pillar['ssl']['kube_apiserver_crt'] }}
-      - x509:     {{ pillar['paths']['service_account_key'] }}
+      - sls:             kubernetes-common
+      - file:            kube-apiserver
+      - sls:             ca-cert
+      - caasp_retriable: {{ pillar['ssl']['kube_apiserver_crt'] }}
+      - x509:            {{ pillar['paths']['service_account_key'] }}
   # wait until the API server is actually up and running
   http.wait_for_successful_query:
     {% set api_server = "api." + pillar['internal_infra_domain']  -%}

--- a/salt/ldap/init.sls
+++ b/salt/ldap/init.sls
@@ -19,4 +19,4 @@ openldap_restart:
             docker restart $openldap_id
         fi
     - onchanges:
-      - x509: {{ pillar['ssl']['ldap_crt'] }}
+      - caasp_retriable: {{ pillar['ssl']['ldap_crt'] }}


### PR DESCRIPTION
This will make the certificate request to the CA more resilient to
transient errors, in case of overload or any other reasons that make
the CA slow when creating new requested certificates.

Fixes: bsc#1070989