### PR TITLE
Retry certificate generation

### DIFF
--- a/salt/_macros/certs.jinja
+++ b/salt/_macros/certs.jinja
@@ -65,7 +65,8 @@
       - file: /etc/pki
 
 {{ crt }}:
-  x509.certificate_managed:
+  caasp_retriable.retry:
+    - target: x509.certificate_managed
     - ca_server: {{ salt['mine.get']('roles:ca', 'ca.crt', expr_form='grain').keys()[0] }}
     - signing_policy: minion
     - public_key: {{ key }}
@@ -98,6 +99,8 @@
     - user: root
     - group: root
     - mode: 644
+    - retry:
+        attempts: 5
     - require:
       - sls: crypto
       - x509: {{ key }}
@@ -115,7 +118,7 @@
         certificate: {{ crt }}
         key:         {{ key }}
     - onchanges:
-        - x509: {{ crt }}
+        - caasp_retriable: {{ crt }}
         - x509: {{ key }}
 
 {%- endmacro %}

--- a/salt/dex/init.sls
+++ b/salt/dex/init.sls
@@ -24,7 +24,7 @@ include:
     - group: root
     - mode: 644
     - require:
-      - x509: /etc/pki/dex.crt
+      - caasp_retriable: /etc/pki/dex.crt
 
 /root/roles.yaml:
   file.managed:
@@ -47,7 +47,7 @@ dex_secrets:
       - KUBECONFIG: {{ pillar['paths']['kubeconfig'] }}
     - require:
       - kube-apiserver
-      - x509: /etc/pki/dex.crt
+      - caasp_retriable: /etc/pki/dex.crt
       - {{ pillar['paths']['kubeconfig'] }}
 
 dex_instance:

--- a/salt/kube-apiserver/init.sls
+++ b/salt/kube-apiserver/init.sls
@@ -44,15 +44,15 @@ kube-apiserver:
     - enable:     True
     - require:
       - caasp_retriable: iptables-kube-apiserver
-      - sls:      ca-cert
-      - {{ pillar['ssl']['kube_apiserver_crt'] }}
-      - x509:     {{ pillar['paths']['service_account_key'] }}
+      - sls:             ca-cert
+      - caasp_retriable: {{ pillar['ssl']['kube_apiserver_crt'] }}
+      - x509:            {{ pillar['paths']['service_account_key'] }}
     - watch:
-      - sls:      kubernetes-common
-      - file:     kube-apiserver
-      - sls:      ca-cert
-      - {{ pillar['ssl']['kube_apiserver_crt'] }}
-      - x509:     {{ pillar['paths']['service_account_key'] }}
+      - sls:             kubernetes-common
+      - file:            kube-apiserver
+      - sls:             ca-cert
+      - caasp_retriable: {{ pillar['ssl']['kube_apiserver_crt'] }}
+      - x509:            {{ pillar['paths']['service_account_key'] }}
   # wait until the API server is actually up and running
   http.wait_for_successful_query:
     {% set api_server = "api." + pillar['internal_infra_domain']  -%}

--- a/salt/kube-controller-manager/init.sls
+++ b/salt/kube-controller-manager/init.sls
@@ -25,7 +25,7 @@ kube-controller-manager:
       - x509:     {{ pillar['paths']['service_account_key'] }}
 
 {{ pillar['ssl']['kube_controller_mgr_key'] }}:
-  x509.private_key_managed:    
+  x509.private_key_managed:
     - bits: 4096
     - user: root
     - group: root
@@ -35,7 +35,8 @@ kube-controller-manager:
       - file: /etc/pki
 
 {{ pillar['ssl']['kube_controller_mgr_crt'] }}:
-  x509.certificate_managed:
+  caasp_retriable.retry:
+    - target: x509.certificate_managed
     - ca_server: {{ salt['mine.get']('roles:ca', 'ca.crt', expr_form='grain').keys()[0] }}
     - signing_policy: minion
     - public_key: {{ pillar['ssl']['kube_controller_mgr_key'] }}
@@ -57,6 +58,8 @@ kube-controller-manager:
     - user: root
     - group: root
     - mode: 644
+    - retry:
+        attempts: 5
     - require:
       - sls:  crypto
       - {{ pillar['ssl']['kube_controller_mgr_key'] }}

--- a/salt/kube-scheduler/init.sls
+++ b/salt/kube-scheduler/init.sls
@@ -23,7 +23,7 @@ kube-scheduler:
       - kube-scheduler-config
 
 {{ pillar['ssl']['kube_scheduler_key'] }}:
-  x509.private_key_managed:    
+  x509.private_key_managed:
     - bits: 4096
     - user: root
     - group: root
@@ -33,7 +33,8 @@ kube-scheduler:
       - file: /etc/pki
 
 {{ pillar['ssl']['kube_scheduler_crt'] }}:
-  x509.certificate_managed:
+  caasp_retriable.retry:
+    - target: x509.certificate_managed
     - ca_server: {{ salt['mine.get']('roles:ca', 'ca.crt', expr_form='grain').keys()[0] }}
     - signing_policy: minion
     - public_key: {{ pillar['ssl']['kube_scheduler_key'] }}
@@ -55,6 +56,8 @@ kube-scheduler:
     - user: root
     - group: root
     - mode: 644
+    - retry:
+        attempts: 5
     - require:
       - sls:  crypto
       - {{ pillar['ssl']['kube_scheduler_key'] }}

--- a/salt/ldap/init.sls
+++ b/salt/ldap/init.sls
@@ -19,4 +19,4 @@ openldap_restart:
             docker restart $openldap_id
         fi
     - onchanges:
-      - x509: {{ pillar['ssl']['ldap_crt'] }}
+      - caasp_retriable: {{ pillar['ssl']['ldap_crt'] }}

--- a/salt/velum/init.sls
+++ b/salt/velum/init.sls
@@ -27,6 +27,6 @@ velum_restart:
         fi
     - onchanges:
       - x509: {{ pillar['ssl']['velum_key'] }}
-      - x509: {{ pillar['ssl']['velum_crt'] }}
+      - caasp_retriable: {{ pillar['ssl']['velum_crt'] }}
     - onchanges_in:
       - cmd: update-velum-hosts


### PR DESCRIPTION
This will make the certificate request to the CA more resilient to
transient errors, in case of overload or any other reasons that make
the CA slow when creating new requested certificates.

Fixes CI.

Fixes: bsc#1070989

Backport of https://github.com/kubic-project/salt/pull/359