### PR TITLE
Catch any exceptions on `caasp_retriable` state, and treat it as a regular failure

### DIFF
--- a/salt/_states/caasp_retriable.py
+++ b/salt/_states/caasp_retriable.py
@@ -30,14 +30,17 @@ def retry(name, target, retry={}, **kwargs):
     ret = None
 
     for attempt in xrange(retry_['attempts']):
-        ret = __states__[target](name=name, **kwargs)
+        try:
+            ret = __states__[target](name=name, **kwargs)
+        except BaseException as e:
+            ret = {'result': False, 'changes': False, 'comment': 'Exception raised: {0}'.format(e)}
 
         if ret['result']:
             return {
                 'name': "caasp_retriable.{0}.{1}".format(name, target),
                 'changes': ret['changes'],
                 'result': True,
-                'comment': "Command executed succesfully after {0} retries. "
+                'comment': "Command executed succesfully after {0} attempts. "
                 "Last output: {1}".format(attempt + 1, ret['comment'])}
 
         if attempt + 1 == retry_['attempts']:
@@ -50,7 +53,7 @@ def retry(name, target, retry={}, **kwargs):
         'name': "caasp_retriable.{0}.{1}".format(name, target),
         'changes': ret['changes'],
         'result': False,
-        'comment': "Command failed after {0} retries. "
+        'comment': "Command failed after {0} attempts. "
                    "Last output: {1} "
                    "Params: {2}".format(
                        retry_['attempts'],

--- a/salt/kube-controller-manager/init.sls
+++ b/salt/kube-controller-manager/init.sls
@@ -34,7 +34,7 @@ kube-controller-mgr-config:
     - template: jinja
     - require:
       - pkg: kubernetes-common
-      - {{ pillar['ssl']['kube_controller_mgr_crt'] }}
+      - caasp_retriable: {{ pillar['ssl']['kube_controller_mgr_crt'] }}
     - defaults:
         user: 'default-admin'
         client_certificate: {{ pillar['ssl']['kube_controller_mgr_crt'] }}

--- a/salt/kube-proxy/init.sls
+++ b/salt/kube-proxy/init.sls
@@ -14,7 +14,7 @@ include:
     - template: jinja
     - require:
       - pkg: kubernetes-common
-      - {{ pillar['ssl']['kube_proxy_crt'] }}
+      - caasp_retriable: {{ pillar['ssl']['kube_proxy_crt'] }}
     - defaults:
         user: 'default-admin'
         client_certificate: {{ pillar['ssl']['kube_proxy_crt'] }}

--- a/salt/kube-scheduler/init.sls
+++ b/salt/kube-scheduler/init.sls
@@ -32,7 +32,7 @@ kube-scheduler-config:
     - template: jinja
     - require:
       - pkg: kubernetes-common
-      - {{ pillar['ssl']['kube_scheduler_crt'] }}
+      - caasp_retriable: {{ pillar['ssl']['kube_scheduler_crt'] }}
     - defaults:
         user: 'default-admin'
         client_certificate: {{ pillar['ssl']['kube_scheduler_crt'] }}

--- a/salt/kubelet/init.sls
+++ b/salt/kubelet/init.sls
@@ -31,7 +31,7 @@ kubelet-config:
     - template: jinja
     - require:
       - pkg: kubernetes-common
-      - {{ pillar['ssl']['kubelet_crt'] }}
+      - caasp_retriable: {{ pillar['ssl']['kubelet_crt'] }}
     - defaults:
         user: 'default-admin'
         client_certificate: {{ pillar['ssl']['kubelet_crt'] }}


### PR DESCRIPTION
Explicitly wait for `caasp_retriable` states.

Fixes: bsc#1070989