### PR TITLE
[Test CI] DO NOT MERGE - Set debug loglevel

### DIFF
--- a/config/master.d/50-master.conf
+++ b/config/master.d/50-master.conf
@@ -9,6 +9,9 @@ event_return: mysql
 presence_events: True
 timeout: 20
 
+log_level: debug
+log_level_logfile: debug
+
 # performance tunning
 # see https://docs.saltstack.com/en/latest/ref/configuration/master.html#master-large-scale-tuning-settings
 worker_threads: 20


### PR DESCRIPTION
This is to try to find the root cause of the only reason for flaky tests now: "Minion did not respond" error message.