### PR TITLE
RFC: Remove iptables rules

### DIFF
--- a/salt/etcd/init.sls
+++ b/salt/etcd/init.sls
@@ -16,26 +16,10 @@ etcd:
       - group: etcd
   pkg.installed:
     - pkgs:
-      - iptables
       - etcdctl
       - etcd
     - require:
       - file: /etc/zypp/repos.d/containers.repo
-  caasp_retriable.retry:
-    - name: iptables-etcd
-    - target: iptables.append
-    - retry:
-        attempts: 2
-    - table: filter
-    - family: ipv4
-    - chain: INPUT
-    - jump: ACCEPT
-    - match: state
-    - connstate: NEW
-    # TODO: add "- source: <local-subnet>"
-    - dports:
-        - 2380
-    - proto: tcp
   caasp_service.running_stable:
     - name: etcd
     - successful_retries_in_a_row: 50
@@ -45,7 +29,6 @@ etcd:
     - require:
       - sls: ca-cert
       - pkg: etcd
-      - caasp_retriable: iptables-etcd
     - watch:
       - {{ pillar['ssl']['crt_file'] }}
       - {{ pillar['ssl']['key_file'] }}

--- a/salt/haproxy/init.sls
+++ b/salt/haproxy/init.sls
@@ -18,24 +18,6 @@ haproxy:
     - mode: 644
     - makedirs: True
     - dir_mode: 755
-  caasp_retriable.retry:
-    - name: iptables-haproxy
-{% if "kube-master" in salt['grains.get']('roles', []) %}
-    - target: iptables.append
-{% else %}
-    - target: iptables.delete
-{% endif %}
-    - retry:
-        attempts: 2
-    - table:      filter
-    - family:     ipv4
-    - chain:      INPUT
-    - jump:       ACCEPT
-    - match:      state
-    - connstate:  NEW
-    - dports:
-      - {{ pillar['api']['ssl_port'] }}
-    - proto:      tcp
 
 # Send a HUP to haproxy when the config changes
 # TODO: There should be a better way to handle this, but currently, there is not. See

--- a/salt/kube-apiserver/init.sls
+++ b/salt/kube-apiserver/init.sls
@@ -16,26 +16,9 @@ include:
 kube-apiserver:
   pkg.installed:
     - pkgs:
-      - iptables
       - kubernetes-master
     - require:
       - file: /etc/zypp/repos.d/containers.repo
-  caasp_retriable.retry:
-    - name: iptables-kube-apiserver
-    - target: iptables.append
-    - retry:
-        attempts: 2
-    - table:      filter
-    - family:     ipv4
-    - chain:      INPUT
-    - jump:       ACCEPT
-    - match:      state
-    - connstate:  NEW
-    - dports:
-      - {{ pillar['api']['int_ssl_port'] }}
-    - proto:      tcp
-    - require:
-      - sls:      kubernetes-common
   file.managed:
     - name:       /etc/kubernetes/apiserver
     - source:     salt://kube-apiserver/apiserver.jinja
@@ -43,7 +26,6 @@ kube-apiserver:
   service.running:
     - enable:     True
     - require:
-      - caasp_retriable: iptables-kube-apiserver
       - sls:             ca-cert
       - caasp_retriable: {{ pillar['ssl']['kube_apiserver_crt'] }}
       - x509:            {{ pillar['paths']['service_account_key'] }}

--- a/salt/kube-proxy/init.sls
+++ b/salt/kube-proxy/init.sls
@@ -23,7 +23,6 @@ include:
 kube-proxy:
   pkg.installed:
     - pkgs:
-      - iptables
       - conntrack-tools
       - kubernetes-node
     - require:

--- a/salt/kubelet/init.sls
+++ b/salt/kubelet/init.sls
@@ -55,7 +55,6 @@ kubelet-config:
 kubelet:
   pkg.installed:
     - pkgs:
-      - iptables
       - kubernetes-client
       - kubernetes-node
     - require:
@@ -81,22 +80,6 @@ kubelet:
       - file:   /etc/kubernetes/manifests
       - file:   /etc/kubernetes/kubelet-initial
       - kubelet-config
-  caasp_retriable.retry:
-    - name: iptables-kubelet
-    - target: iptables.append
-    - retry:
-        attempts: 2
-    - table:     filter
-    - family:    ipv4
-    - chain:     INPUT
-    - jump:      ACCEPT
-    - match:     state
-    - connstate: NEW
-    - dports:
-      - {{ pillar['kubelet']['port'] }}
-    - proto:     tcp
-    - require:
-      - service: kubelet
 
 {% if not "kube-master" in salt['grains.get']('roles', []) and salt['grains.get']('kubelet:should_uncordon', false) %}
   caasp_cmd.run:


### PR DESCRIPTION
The cluster seems to work fine without this rules, and also we are
not persisting them, so they are lost after a reboot.

Try to keep the deployment as simple as possible and only do the
actions we require to work.