### PR TITLE
Update dex binary name to caasp-dex

### DIFF
--- a/salt/dex/dex.yaml
+++ b/salt/dex/dex.yaml
@@ -101,7 +101,7 @@ spec:
       containers:
       - image: sles12/caasp-dex:2.7.1
         name: dex
-        command: ["/usr/bin/dex", "serve", "/etc/dex/cfg/config.yaml"]
+        command: ["/usr/bin/caasp-dex", "serve", "/etc/dex/cfg/config.yaml"]
 
         ports:
         - name: https


### PR DESCRIPTION
See https://build.suse.de/request/show/153621 and https://build.opensuse.org/package/rdiff/devel:CaaSP:Head:ControllerNode/caasp-dex?linkrev=base&rev=7