### PR TITLE
Minor cleanups in orchestrations

### DIFF
--- a/salt/cni/update-pre-reboot.sls
+++ b/salt/cni/update-pre-reboot.sls
@@ -6,3 +6,11 @@ uninstall-flannel:
   # make sure that the service is disabled
   service.disabled:
     - name: flanneld
+
+remove-flannel-unit:
+  file.absent:
+    - name: /usr/lib/systemd/system/docker.service.d/flannel.conf
+
+remove-flannel-subnets:
+  file.absent:
+    - name: /var/run/flannel


### PR DESCRIPTION
Use the same code convention for ids in the orchestration as all the other ids.
Cleanup some files when updating CNI.