### PR TITLE
Do not try to remove some file in a read-only dir

### DIFF
--- a/salt/cni/update-pre-reboot.sls
+++ b/salt/cni/update-pre-reboot.sls
@@ -7,10 +7,10 @@ uninstall-flannel:
   service.disabled:
     - name: flanneld
 
-remove-flannel-unit:
+remove-flannel-files-1:
   file.absent:
-    - name: /usr/lib/systemd/system/docker.service.d/flannel.conf
+    - name: /run/flannel/docker
 
-remove-flannel-subnets:
+remove-flannel-files-2:
   file.absent:
     - name: /var/run/flannel


### PR DESCRIPTION
When updating the cluster, do not try to remove some _flannel_ file that cannot be removed, and remove some other instead