### PR TITLE
Namespace the roles and cluster roles we create

### DIFF
--- a/salt/addons/dns/init.sls
+++ b/salt/addons/dns/init.sls
@@ -10,11 +10,10 @@ include:
                           "/etc/kubernetes/addons/kubedns.yaml",
                           check_cmd="kubectl get deploy kube-dns -n kube-system | grep kube-dns") }}
 
-{{ kubectl("create-dns-clusterrolebinding",
-           "create clusterrolebinding system:kube-dns --clusterrole=cluster-admin --serviceaccount=kube-system:default",
-           unless="kubectl get clusterrolebindings | grep kube-dns",
-           check_cmd="kubectl get clusterrolebindings | grep kube-dns",
-           watch=["/etc/kubernetes/addons/kubedns.yaml"]) }}
+# TODO: Transitional code, remove for CaaSP v4
+{{ kubectl("remove-old-kube-dns-clusterrolebinding",
+           "delete clusterrolebinding system:kube-dns",
+           onlyif="kubectl get clusterrolebinding system:kube-dns") }}
 
 {% else %}
 

--- a/salt/addons/dns/kubedns.yaml.jinja
+++ b/salt/addons/dns/kubedns.yaml.jinja
@@ -1,3 +1,27 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-dns
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: suse:caasp:kube-dns
+subjects:
+- kind: ServiceAccount
+  name: kube-dns
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+
+---
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
@@ -174,12 +198,3 @@ kind: ConfigMap
 metadata:
   name: kube-dns
   namespace: kube-system
-
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: kube-dns
-  namespace: kube-system
-  labels:
-    kubernetes.io/cluster-service: "true"

--- a/salt/addons/tiller/init.sls
+++ b/salt/addons/tiller/init.sls
@@ -10,12 +10,12 @@ include:
                           "/etc/kubernetes/addons/tiller.yaml",
                           check_cmd="kubectl get deploy tiller-deploy -n kube-system | grep tiller-deploy") }}
 
-{{ kubectl("create-tiller-clusterrolebinding",
-           "create clusterrolebinding system:tiller --clusterrole=cluster-admin --serviceaccount=kube-system:tiller",
-           unless="kubectl get clusterrolebindings | grep tiller",
-           check_cmd="kubectl get clusterrolebindings | grep tiller",
-           watch=["/etc/kubernetes/addons/tiller.yaml"]) }}
+# TODO: Transitional code, remove for CaaSP v4
+{{ kubectl("remove-old-tiller-clusterrolebinding",
+           "delete clusterrolebinding system:tiller",
+           onlyif="kubectl get clusterrolebinding system:tiller") }}
 
+# TODO: Transitional code, remove for CaaSP v4
 {{ kubectl("remove-old-tiller-deployment",
            "delete deploy tiller -n kube-system",
            onlyif="kubectl get deploy tiller -n kube-system") }}

--- a/salt/addons/tiller/tiller.yaml.jinja
+++ b/salt/addons/tiller/tiller.yaml.jinja
@@ -1,3 +1,27 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tiller
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: suse:caasp:tiller
+subjects:
+- kind: ServiceAccount
+  name: tiller
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+
+---
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
@@ -77,12 +101,3 @@ spec:
   type: ClusterIP
 status:
   loadBalancer: {}
-
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: tiller
-  namespace: kube-system
-  labels:
-    kubernetes.io/cluster-service: "true"

--- a/salt/cni/init.sls
+++ b/salt/cni/init.sls
@@ -48,4 +48,3 @@ include:
       - file:      /etc/kubernetes/addons/kube-flannel-rbac.yaml
 
 {% endif %}
-

--- a/salt/cni/kube-flannel-rbac.yaml.jinja
+++ b/salt/cni/kube-flannel-rbac.yaml.jinja
@@ -3,12 +3,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: flannel
-  namespace: "kube-system"
+  namespace: kube-system
+
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: flannel
+  name: suse:caasp:flannel
 rules:
   - apiGroups:
       - ""
@@ -29,16 +30,17 @@ rules:
       - nodes/status
     verbs:
       - patch
+
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: flannel
+  name: suse:caasp:flannel
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: flannel
+  name: suse:caasp:flannel
 subjects:
 - kind: ServiceAccount
   name: flannel
-  namespace: "kube-system"
+  namespace: kube-system

--- a/salt/dex/dex.yaml
+++ b/salt/dex/dex.yaml
@@ -11,7 +11,7 @@ metadata:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: system:dex
+  name: suse:caasp:dex
 subjects:
 - kind: ServiceAccount
   name: dex

--- a/salt/dex/init.sls
+++ b/salt/dex/init.sls
@@ -31,6 +31,26 @@ include:
                           "/root/roles.yaml",
                           watch=["dex_secrets", "/root/dex.yaml"]) }}
 
+# TODO: Transitional code, remove for CaaSP v4
+{{ kubectl("remove-old-find-dex-role",
+           "delete role find-dex -n kube-system",
+           onlyif="kubectl get role find-dex -n kube-system") }}
+
+# TODO: Transitional code, remove for CaaSP v4
+{{ kubectl("remove-old-find-dex-rolebinding",
+           "delete rolebinding find-dex -n kube-system",
+           onlyif="kubectl get rolebinding find-dex -n kube-system") }}
+
+# TODO: Transitional code, remove for CaaSP v4
+{{ kubectl("remove-old-administrators-in-ldap-clusterrolebinding",
+           "delete clusterrolebinding administrators-in-ldap",
+           onlyif="kubectl get clusterrolebinding administrators-in-ldap") }}
+
+# TODO: Transitional code, remove for CaaSP v4
+{{ kubectl("remove-old-dex-clusterrolebinding",
+           "delete clusterrolebinding system:dex",
+           onlyif="kubectl get clusterrolebinding system:dex") }}
+
 ensure_dex_running:
   # Wait until the Dex API is actually up and running
   http.wait_for_successful_query:

--- a/salt/dex/roles.yaml
+++ b/salt/dex/roles.yaml
@@ -5,7 +5,7 @@
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: find-dex
+  name: suse:caasp:read-dex-service
   namespace: kube-system
 rules:
 - apiGroups: [""]
@@ -18,7 +18,7 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: find-dex
+  name: suse:caasp:read-dex-service
   namespace: kube-system
 subjects:
 - kind: Group
@@ -29,14 +29,14 @@ subjects:
   apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: Role
-  name: find-dex
+  name: suse:caasp:read-dex-service
   apiGroup: rbac.authorization.k8s.io
 ---
 # Map the LDAP Administrators role to the Kubernetes system:masters group
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: administrators-in-ldap
+  name: suse:caasp:ldap-administrators
 subjects:
 - kind: Group
   name: "{{ pillar['ldap']['admin_group_name'] }}"


### PR DESCRIPTION
When we create a role, rolebinding etc, we should namespace the names
in order to make it obvious these are deployed as part of CaaSP, as well
as to help ensure these are obviously part of CaaSP, not a stock part of
Kubernetes.

I've gone with a "suse:caasp:" prefix, which matches the "system:" prefix
for built in roles/rolebindings/etc.

Additionally, move a few "kubectl create clusterrolebinding" shell outs over
to the matching YAML files, keeping everything together.