### PR TITLE
Use separate Dex clients for each actual client

### DIFF
--- a/pillar/params.sls
+++ b/pillar/params.sls
@@ -155,6 +155,9 @@ transactional-update:
 
 dex:
   node_port: '32000'
+  client_secrets:
+    kubernetes: ''
+    velum: ''
 
 # configuration parameters for interacting with LDAP via Dex
 # these get filled in by velum during bootstrap. they're listed

--- a/salt/dex/dex.yaml
+++ b/salt/dex/dex.yaml
@@ -69,13 +69,30 @@ data:
       skipApprovalScreen: true
 
     staticClients:
+    - id: kubernetes
+      redirectURIs:
+      - 'urn:ietf:wg:oauth:2.0:oob'
+      name: "Kubernetes"
+      secret: "{{ pillar['dex']['client_secrets']['kubernetes'] }}"
+      trustedPeers:
+      - caasp-cli
+      - velum
+
     - id: caasp-cli
       redirectURIs:
+      - 'urn:ietf:wg:oauth:2.0:oob'
       - 'http://127.0.0.1'
-      - 'https://{{ pillar['dashboard'] }}/oidc/done'
-      - 'https://{{ pillar['dashboard_external_fqdn'] }}/oidc/done'
+      - 'http://localhost'
       name: "CaaSP CLI"
       secret: "swac7qakes7AvucH8bRucucH"
+      public: true
+
+    - id: velum
+      redirectURIs:
+      - 'https://{{ pillar['dashboard'] }}/oidc/done'
+      - 'https://{{ pillar['dashboard_external_fqdn'] }}/oidc/done'
+      name: "Velum"
+      secret: "{{ pillar['dex']['client_secrets']['velum'] }}"
 ---
 apiVersion: apps/v1beta2
 kind: Deployment

--- a/salt/kube-apiserver/apiserver.jinja
+++ b/salt/kube-apiserver/apiserver.jinja
@@ -47,7 +47,7 @@ KUBE_API_ARGS="--advertise-address={{ salt.caasp_net.get_primary_ip() }} \
                --runtime-config=admissionregistration.k8s.io/v1alpha1 \
                --authorization-mode=Node,RBAC \
                --oidc-issuer-url=https://{{ pillar['api']['server']['external_fqdn'] }}:{{ pillar['dex']['node_port'] }} \
-               --oidc-client-id=caasp-cli \
+               --oidc-client-id=kubernetes \
                --oidc-ca-file={{ pillar['ssl']['ca_file'] }} \
                --oidc-username-claim=email \
                --oidc-groups-claim=groups"


### PR DESCRIPTION
Previously Velum, CaaSP CLI, and Kubernetes all shared a single Dex
client. From a security perspective, this was far from ideal.

Update Dex with 3 clients, one for each actual client. Both the Velum
and CaaSP CLI clients are allowed to issue tokens for the Kubernetes
client.

Depends-On: https://github.com/kubic-project/velum/pull/439
Depends-On: https://github.com/kubic-project/caasp-cli/pull/9