### PR TITLE
Resist 'None' certs in pillars

### DIFF
--- a/salt/_modules/caasp_docker.py
+++ b/salt/_modules/caasp_docker.py
@@ -40,44 +40,53 @@ def get_registries_certs(lst, default_port=5000):
 
     LOG.debug('Finding certificates in: %s', lst)
     for registry in lst:
-        url = registry.get('url')
-        cert = registry.get('cert', '')
-        if len(cert) > 0:
+        try:
+            url = registry.get('url')
 
-            # parse the name as an URL or "host:port", and return <HOST>[:<PORT>]
-            hostname, port = _get_hostname_and_port(url)
-            host_port = hostname
-            if port:
-                host_port += ":" + str(port)
+            cert = registry.get('cert', '')
+            if cert:
 
-            LOG.debug('Adding certificate for: %s', host_port)
-            certs[host_port] = cert
+                # parse the name as an URL or "host:port", and return <HOST>[:<PORT>]
+                hostname, port = _get_hostname_and_port(url)
+                host_port = hostname
+                if port:
+                    host_port += ":" + str(port)
 
-            if port:
-                if port == default_port:
-                    # When using the standar port (5000), if the user introduces
-                    # "my-registry:5000" as a trusted registry, he/she will be able
-                    # to do "docker pull my-registry:5000/some/image" but not
-                    # "docker pull my-registry/some/image".
-                    # So we must also create the "ca.crt" for "my-registry"
-                    # as he/she could just access "docker pull my-registry/some/image",
-                    # and Docker would fail to find "my-registry/ca.crt"
-                    name = hostname
+                LOG.debug('Adding certificate for: %s', host_port)
+                certs[host_port] = cert
+
+                if port:
+                    if port == default_port:
+                        # When using the standar port (5000), if the user introduces
+                        # "my-registry:5000" as a trusted registry, he/she will be able
+                        # to do "docker pull my-registry:5000/some/image" but not
+                        # "docker pull my-registry/some/image".
+                        # So we must also create the "ca.crt" for "my-registry"
+                        # as he/she could just access "docker pull my-registry/some/image",
+                        # and Docker would fail to find "my-registry/ca.crt"
+                        name = hostname
+                        LOG.debug(
+                            'Using default port: adding certificate for "%s" too', name)
+                        certs[name] = cert
+                else:
+                    # the same happens if the user introduced a certificate for
+                    # "my-registry": we must fix the "docker pull my-registry:5000/some/image" case...
+                    name = hostname + ':' + str(default_port)
                     LOG.debug(
-                        'Using default port: adding certificate for "%s" too', name)
+                        'Adding certificate for default port, "%s", too', name)
                     certs[name] = cert
-            else:
-                # the same happens if the user introduced a certificate for
-                # "my-registry": we must fix the "docker pull my-registry:5000/some/image" case...
-                name = hostname + ':' + str(default_port)
-                LOG.debug('Adding certificate for default port, "%s", too', name)
-                certs[name] = cert
 
-        mirrors = registry.get('mirrors', [])
-        if len(mirrors) > 0:
-            LOG.debug('Looking recursively for certificates in mirrors')
-            certs_mirrors = get_registries_certs(mirrors,
-                                                 default_port=default_port)
-            certs.update(certs_mirrors)
+        except Exception as e:
+            LOG.error('Could not parse certificate: %s', e)
+
+        try:
+            mirrors = registry.get('mirrors', [])
+            if mirrors:
+                LOG.debug('Looking recursively for certificates in mirrors')
+                certs_mirrors = get_registries_certs(mirrors,
+                                                     default_port=default_port)
+                certs.update(certs_mirrors)
+        except Exception as e:
+            LOG.error('Could not parse mirrors: %s', e)
 
     return certs


### PR DESCRIPTION
Make sure we do not crash on pillars that are not properly formatted by surrounding the code with some `try..except` blocks.