### PR TITLE
[2.0] Mark the haproxy as critical pod

### DIFF
--- a/salt/haproxy/haproxy.manifest
+++ b/salt/haproxy/haproxy.manifest
@@ -6,6 +6,8 @@ metadata:
   namespace: kube-system
   labels:
     name: haproxy
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ''
 spec:
   restartPolicy: Always
   hostNetwork: true
@@ -13,6 +15,8 @@ spec:
     - key: node-role.kubernetes.io/master
       operator: Exists
       effect: NoSchedule
+    - key: "CriticalAddonsOnly"
+      operator: "Exists"
   containers:
     - name: haproxy
       image: sles12/haproxy:1.6.0


### PR DESCRIPTION
Flag the haproxy pods providing connectivity to the API server as critical ones.

This should force kubelet and the scheduler to never ever get rid of
them. If these pods are killed to make more space for other ones, the
node would not be able to talk with the API server making it useless.

More details inside upstream doc:
https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/

Signed-off-by: Flavio Castelli <fcastelli@suse.com>

Backport of https://github.com/kubic-project/salt/pull/381