### PR TITLE
When executing a highstate of `apiserver` make sure that we check the local `apiserver` instance

### DIFF
--- a/salt/haproxy/haproxy.cfg.jinja
+++ b/salt/haproxy/haproxy.cfg.jinja
@@ -22,11 +22,13 @@ defaults
 listen kubernetes-master
         bind {{ bind_ip }}:{{ pillar['api']['ssl_port'] }}
         mode tcp
-        default-server inter 10s fall 3
+        default-server inter 10s fall 2
         balance roundrobin
+        option redispatch
+        option httpchk GET /healthz
 
 {%- for minion_id, nodename in salt['mine.get']('roles:kube-master', 'nodename', 'grain').items() %}
-        server master-{{ minion_id }} {{ nodename }}:{{ pillar['api']['int_ssl_port'] }} check
+        server master-{{ minion_id }} {{ nodename }}:{{ pillar['api']['int_ssl_port'] }} check check-ssl port {{ pillar['api']['int_ssl_port'] }} verify none
 {% endfor -%}
 
 {%- if "admin" in salt['grains.get']('roles', []) %}
@@ -34,8 +36,9 @@ listen kubernetes-master
 listen kubernetes-dex
         bind {{ bind_ip }}:32000
         mode tcp
-        default-server inter 10s fall 3
+        default-server inter 10s fall 2
         balance roundrobin
+        option redispatch
 
 {%- for minion_id, nodename in salt['mine.get']('roles:kube-master', 'nodename', 'grain').items() %}
         server master-{{ minion_id }} {{ nodename }}:32000 check


### PR DESCRIPTION
When executing the highstate make sure the `apiserver` we are checking
is the local one, not *any* master through haproxy.

Fixes: bsc#1079460