### PR TITLE
Dex pods: introduce anti-affinity rule

### DIFF
--- a/salt/dex/dex.yaml
+++ b/salt/dex/dex.yaml
@@ -118,6 +118,19 @@ spec:
       tolerations:
       - key: "CriticalAddonsOnly"
         operator: "Exists"
+
+      # ensure dex pods are running on different hosts
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - dex
+            topologyKey: "kubernetes.io/hostname"
+
       containers:
       - image: sles12/caasp-dex:2.7.1
         name: dex


### PR DESCRIPTION
Our dex deployment creates 3 pods running the dex service. There are really high chances (or even certainty in the case of clusters made by 1or 2 worker nodes) that all the dex pods end up running on the same node.

This is bad from a HA perspective, plus we end up taking away resources from small clusters.

With the following change we enforce the kubernetes scheduler to always spread the dex pods over different nodes.

On small clusters (1 or 2 nodes) the deployment will be running with a lower number of replicas until new nodes are added. This doesn't cause our orchestration to fail.

Adding new nodes at a later stage will allow the deployment to reach the desired replica size without any intervention from us or the user.