### PR TITLE
Move haproxy config to /etc/caasp/haproxy

### DIFF
--- a/salt/haproxy/haproxy.yaml.jinja
+++ b/salt/haproxy/haproxy.yaml.jinja
@@ -43,7 +43,7 @@ spec:
   volumes:
     - name: haproxy-cfg
       hostPath:
-        path: /etc/haproxy
+        path: /etc/caasp/haproxy
 {% if "admin" in salt['grains.get']('roles', []) %}
     - name: etc-hosts
       hostPath:

--- a/salt/haproxy/init.sls
+++ b/salt/haproxy/init.sls
@@ -1,4 +1,12 @@
-/etc/haproxy/haproxy.cfg:
+/etc/caasp/haproxy:
+  file.directory:
+    - name: /etc/caasp/haproxy
+    - user:     root
+    - group:    root
+    - dir_mode: 755
+    - makedirs: True
+
+/etc/caasp/haproxy/haproxy.cfg:
   file.managed:
     - source: salt://haproxy/haproxy.cfg.jinja
     - template: jinja
@@ -48,4 +56,4 @@ haproxy_restart:
             docker kill -s HUP $haproxy_id
         fi
     - onchanges:
-      - file: /etc/haproxy/haproxy.cfg
+      - file: /etc/caasp/haproxy/haproxy.cfg


### PR DESCRIPTION
This avoids a conflict between the caasp-container-manifests package,
and the haproxy package.

Depends-On: https://github.com/kubic-project/caasp-container-manifests/pull/150