### PR TITLE
Assign the etcd role to current members before starting the update orchestration

### DIFF
--- a/salt/etcd/update-pre-orchestration.sls
+++ b/salt/etcd/update-pre-orchestration.sls
@@ -1,0 +1,24 @@
+{% set roles = salt['grains.get']('roles', []) %}
+{% set has_etcd_role = ("etcd" in roles) %}
+
+{% set is_etcd_member = salt['file.directory_exists' ]('/var/lib/etcd/member') and
+                    not salt['file.directory_exists' ]('/var/lib/etcd/proxy') %}
+
+{%- if is_etcd_member and not has_etcd_role -%}
+  # this is really running a member of the etcd cluster but it doesn't
+  # have the 'etcd' role: set the 'etcd' role so we are sure it will be
+  # running etcd after the update
+
+add-etcd-role:
+  grains.append:
+    - name: roles
+    - value: etcd
+
+{%- else %}
+
+{# See https://github.com/saltstack/salt/issues/14553 #}
+dummy_step:
+  cmd.run:
+    - name: "echo saltstack bug 14553"
+
+{%- endif %}

--- a/salt/etcd/update-pre-reboot.sls
+++ b/salt/etcd/update-pre-reboot.sls
@@ -1,20 +1,7 @@
 {% set roles = salt['grains.get']('roles', []) %}
 {% set has_etcd_role = ("etcd" in roles) %}
 
-{% set is_etcd_member = salt['file.directory_exists' ]('/var/lib/etcd/member') and
-                    not salt['file.directory_exists' ]('/var/lib/etcd/proxy') %}
-
-{%- if is_etcd_member and not has_etcd_role -%}
-  # this is really running a member of the etcd cluster but it doesn't
-  # have the 'etcd' role: set the 'etcd' role so we are sure it will be
-  # running etcd after the update
-
-add-etcd-role:
-  grains.append:
-    - name: roles
-    - value: etcd
-
-{% elif not has_etcd_role %}
+{% if not has_etcd_role %}
   # make sure there is nothing left in /var/lib/etcd
 
 cleanup-old-etcd-stuff:

--- a/salt/orch/update.sls
+++ b/salt/orch/update.sls
@@ -63,6 +63,7 @@ pre-orchestration-migration:
     - sls:
       - cni.update-pre-orchestration
       - kubelet.update-pre-orchestration
+      - etcd.update-pre-orchestration
     - require:
       - update-modules
 


### PR DESCRIPTION
... otherwise we can have some problems is nodes are rebooted in the wrong order.