### PR TITLE
Increase haproxy timeouts from 50sec, to 120sec

### DIFF
--- a/salt/haproxy/haproxy.cfg.jinja
+++ b/salt/haproxy/haproxy.cfg.jinja
@@ -14,8 +14,8 @@ defaults
         option  tcplog
         option  dontlognull
         timeout connect 5000
-        timeout client 50000
-        timeout server 50000
+        timeout client 120000
+        timeout server 120000
 
 # Listen on the standard Kube-API Public port, 6443 by default, and proxy to the masters on
 # the Kube-API internal port, 6444 by default.


### PR DESCRIPTION
Some components have a 60 second timeout for salt request timeouts, e.g the
salt-api server which is called by Velum. Increase this timeout to double
their timeouts to allow the real failures to be disclosed.

We'll likely want to rework how timeouts are handled soon accross all our
components.