### PR TITLE
Velum Dash and API both attempt to bind to the same port

### DIFF
--- a/config/master.d/50-master.conf
+++ b/config/master.d/50-master.conf
@@ -37,5 +37,5 @@ module_dirs:
 
 ext_pillar:
   - velum:
-      url: https://localhost/internal-api/v1/pillar.json
+      url: https://localhost:444/internal-api/v1/pillar.json
       ca_bundle: /etc/pki/ca.crt

--- a/salt/haproxy/haproxy.cfg.jinja
+++ b/salt/haproxy/haproxy.cfg.jinja
@@ -57,7 +57,7 @@ listen velum
         server velum unix@/var/run/puma/dashboard.sock
 
 listen velum-api
-        bind 127.0.0.1:443 ssl crt /etc/pki/velum.pem ca-file /etc/pki/ca.crt
+        bind 127.0.0.1:444 ssl crt /etc/pki/velum.pem ca-file /etc/pki/ca.crt
         mode http
         option forwardfor
         http-request set-header X-Forwarded-Proto https


### PR DESCRIPTION
It's not possible to reliably bind to 0.0.0.0:443 for one service,
and 127.0.0.1:443 for another service.

As such, we'll move velum-api over to 127.0.0.1:444

Depends-On: https://github.com/kubic-project/caasp-container-manifests/pull/155