### PR TITLE
Restart instead of reload container-feeder

### DIFF
--- a/salt/container-feeder/init.sls
+++ b/salt/container-feeder/init.sls
@@ -9,7 +9,6 @@ include:
 container-feeder:
   service.running:
     - enable: True
-    - reload: True
     - require:
       - cmd: docker
     - watch:


### PR DESCRIPTION
container-feeder is a oneshot service, where reload makes no sense
and in unsupported. If this triggers, we ended up getting:

	salt-minion[2454]: [ERROR   ] Command '['systemd-run', '--scope', 'systemctl', 'reload', 'container-feeder.service']' failed with return code: 3
	salt-minion[2454]: Failed to reload container-feeder.service: Job type reload is not applicable for unit container-feeder.service.