### PR TITLE
Remove unnecessary check from rebootmgr state

### DIFF
--- a/salt/rebootmgr/init.sls
+++ b/salt/rebootmgr/init.sls
@@ -1,11 +1,3 @@
-{# In devenv, the rebootmgr service does not exist on admin #}
-{% if salt['grains.get']('virtual_subtype', None) != 'Docker' %}
 rebootmgr:
   service.dead:
     - enable: False
-{% else %}
-{# See https://github.com/saltstack/salt/issues/14553 #}
-rebootmgr_dummy_step:
-  cmd.run:
-    - name: "echo saltstack bug 14553"
-{% endif %}


### PR DESCRIPTION
DevEnv no longer runs this way, so the check was doing nothing of value.