### PR TITLE
Relax dex deployment anti-affinity.

### DIFF
--- a/salt/dex/dex.yaml
+++ b/salt/dex/dex.yaml
@@ -122,14 +122,16 @@ spec:
       # ensure dex pods are running on different hosts
       affinity:
         podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - dex
-            topologyKey: "kubernetes.io/hostname"
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - dex
+              topologyKey: "kubernetes.io/hostname"
 
       containers:
       - image: sles12/caasp-dex:2.7.1


### PR DESCRIPTION
This can't be met on a cluster of n+2 size (n masters, 2 workers), as we
are creating a deployment of 3.

Let's relax the scheduling from required to preferred.