### PR TITLE
Only remove the `kubelet:should_uncordon` grain when we actually uncordon the node.

### DIFF
--- a/salt/kubelet/init.sls
+++ b/salt/kubelet/init.sls
@@ -100,6 +100,7 @@ kubelet:
       - service: kubelet
 
 {% if salt['grains.get']('kubelet:should_uncordon', false) %}
+uncordon-node:
   caasp_cmd.run:
     - name: |
         kubectl uncordon {{ grains['nodename'] }}
@@ -110,12 +111,14 @@ kubelet:
           test "$(kubectl --kubeconfig={{ pillar['paths']['kubeconfig'] }} get nodes {{ grains['nodename'] }} -o=jsonpath='{.spec.unschedulable}' 2>/dev/null)" != "true"
     - require:
       - file: {{ pillar['paths']['kubeconfig'] }}
-{% endif %}
 
 remove-should-uncordon-grain:
   grains.absent:
     - name: kubelet:should_uncordon
     - destructive: True
+    - require:
+      - caasp_cmd: uncordon-node
+{% endif %}
 
 #######################
 # config files


### PR DESCRIPTION
As part of the update process, we are cordoning the nodes, so they don't get new jobs when
we are planning to reboot them. If an update fails for whatever reason, it might happen that
we didn't uncordon the node, but removed the `kubelet:should_uncordon` grain. This would
cause that subsequent retries will never uncordon the worker node again, because without this
grain we'll think that this node was cordoned by the user and will not take any action.