### PR TITLE
Remove `set -e` from the migration script, as it's too strict.

### DIFF
--- a/salt/kubelet/update-pre-orchestration.sh
+++ b/salt/kubelet/update-pre-orchestration.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euo pipefail
+set -uo pipefail
 
 # Preseeds a node in Kubernetes with critical data migrated from
 # an old node.


### PR DESCRIPTION
This can cause that this script early terminates, leaving the output
as something salt cannot interpret (we are using `stateful` from cmd.run
here). Example:

```
                            ID: /tmp/kubelet-update-pre-orchestration.sh
                      Function: cmd.run
                          Name: /tmp/kubelet-update-pre-orchestration.sh dbf5c05dc8c74fbb8df1fccb105fe3bc.infra.caasp.local caasp-worker-0
                        Result: False
                       Comment: Failed parsing script output! Stdout must be JSON or a line of name=value pairs.
                       Started: 11:31:39.772959
                      Duration: 3967.967 ms
                       Changes:
                                ----------
                                pid:
                                    6472
                                retcode:
                                    1
                                stderr:
                                stdout:
                                    [machine-id migration]: migrating dbf5c05dc8c74fbb8df1fccb105fe3bc.infra.caasp.local to caasp-worker-0
                                    NAME                                                 STATUS     ROLES     AGE       VERSION
                                    dbf5c05dc8c74fbb8df1fccb105fe3bc.infra.caasp.local   NotReady   <none>    2h        v1.8.7
```

This makes the orchestration fail.