### PR TITLE
Discover everything (_states, _modules...) when we update, not only modules

### DIFF
--- a/salt/kubelet/init.sls
+++ b/salt/kubelet/init.sls
@@ -111,8 +111,6 @@ uncordon-node:
           test "$(kubectl --kubeconfig={{ pillar['paths']['kubeconfig'] }} get nodes {{ grains['nodename'] }} -o=jsonpath='{.spec.unschedulable}' 2>/dev/null)" != "true"
     - require:
       - file: {{ pillar['paths']['kubeconfig'] }}
-
-remove-should-uncordon-grain:
   grains.absent:
     - name: kubelet:should_uncordon
     - destructive: True

--- a/salt/orch/update.sls
+++ b/salt/orch/update.sls
@@ -61,7 +61,7 @@ update-mine:
 
 update-modules:
   salt.function:
-    - name: saltutil.sync_modules
+    - name: saltutil.sync_all
     - tgt: '*'
     - kwarg:
         refresh: True


### PR DESCRIPTION
When we update from 2.0 to 3.0, not only `_modules` have changed, but for example,
`caasp_cmd` has been introduced in `_states`. This can make the orchestration fail:

```
              ID: uncordon-node
        Function: caasp_cmd.run
            Name: kubectl uncordon caasp-worker-0

          Result: False
         Comment: State 'caasp_cmd.run' was not found in SLS 'kubelet'
                  Reason: 'caasp_cmd.run' is not available.
         Changes:
```

So, make sure that we run `sync_all` on the update process too, and we discover all
the new modules in general, not only `_modules`. After forcefully running `sync_all`
some minions discovered new states.

```
dbf5c05dc8c74fbb8df1fccb105fe3bc:
    ----------
    beacons:
    engines:
    grains:
    log_handlers:
    modules:
    output:
    proxymodules:
    renderers:
    returners:
    sdb:
    states:
        - states.caasp_cmd
        - states.caasp_service
    utils:
```