### PR TITLE
Add a suse:caasp:tiller-user ClusterRole

### DIFF
--- a/salt/addons/tiller/tiller.yaml.jinja
+++ b/salt/addons/tiller/tiller.yaml.jinja
@@ -22,6 +22,25 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 
 ---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: suse:caasp:tiller-user
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods/portforward
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+
+---
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:


### PR DESCRIPTION
This role represents the minimum RBAC requirements needed to make use of
Helm's Tiller service.

Users granted this role on the `kube-system` namespace, or cluster-wide, will be able to use the Tiller service deployed as part of CaaSP.