### PR TITLE
Make kubelet rename migration idempotent.

### DIFF
--- a/salt/kubelet/update-pre-orchestration.sh
+++ b/salt/kubelet/update-pre-orchestration.sh
@@ -43,6 +43,7 @@ trap "exit_handler" INT TERM EXIT
 
 log "migrating $OLD_NODE_NAME to $NEW_NODE_NAME"
 
+kubectl get node $NEW_NODE_NAME && exit_changes "no" "$NEW_NODE_NAME already exists, nothing to migrate"
 kubectl get node $OLD_NODE_NAME || exit_changes "no" "$OLD_NODE_NAME does not exist, nothing to migrate"
 
 cat << EOF > /tmp/k8s-node-migration.yaml


### PR DESCRIPTION
If the new name already exists, also do nothing. A faulty update could
make this script fail over and over again because of its `set -e` and
the `kubectl create -f` command failing as the new node name already
exists.