### PR TITLE
Remove the TODO message for using the standard `/opt/cni/bin`.

### DIFF
--- a/pillar/cni.sls
+++ b/pillar/cni.sls
@@ -6,8 +6,8 @@ flannel:
 # log level for flanneld service
 # 0 - Generally useful for this to ALWAYS be visible to an operator.
 # 1 - A reasonable default log level if you don't want verbosity.
-# 2 - Useful steady state information about the service and important log 
-#     messages that may correlate to significant changes in the system. 
+# 2 - Useful steady state information about the service and important log
+#     messages that may correlate to significant changes in the system.
 #     This is the recommended default log level for most systems.
 # 3 - Extended information about changes.
 # 4 - Debug level verbosity.
@@ -20,7 +20,7 @@ flannel:
 cni:
   plugin:         'flannel'
   dirs:
-    #bin:          '/opt/cni/bin'
-    # TODO: use the standard directory
-    bin:          '/var/lib/kubelet/cni/bin'
-    conf:         '/etc/cni/net.d'
+    # We are not using the standard `/opt/cni/bin` directory as it's not allowed to install files
+    # in `/opt` in TW as well as on SLE.
+    bin:  '/var/lib/kubelet/cni/bin'
+    conf: '/etc/cni/net.d'


### PR DESCRIPTION
Internal constraints won't allow us to use `/opt`, so we'll stick
to `/var/lib/kubelet/cni/bin`.