### PR TITLE
When populating the cache, don't fail if this fails for some reason.

### DIFF
--- a/salt/_pillar/velum.py
+++ b/salt/_pillar/velum.py
@@ -74,7 +74,10 @@ def ext_pillar(minion_id,
                                   decode_type='json')
 
     if 'dict' in data:
-        cache.store('caasp/pillar', minion_id, data['dict'])
+        try:
+            cache.store('caasp/pillar', minion_id, data['dict'])
+        except Exception as e:
+            log.warning('Error when populating the cache: {0}. Moving on, not critical'.format(e))
         return data['dict']
     elif cache.contains('caasp/pillar', minion_id):
         log.warning('Serving pillar from cache for minion {0}, since {1} was not available'.format(minion_id, url))


### PR DESCRIPTION
There's a race condition in which the cache directory does not exist, but
when tried to be created it has already been created by something else, and
an exception is raised, stopping the execution.

When populating the cache, we don't really care if it was correctly populated
or not in that *specific* call, so move on.

Fixes: bsc#1084441