### PR TITLE
Add liveness/readiness probes to Dex deployment

### DIFF
--- a/salt/dex/dex.yaml
+++ b/salt/dex/dex.yaml
@@ -145,6 +145,23 @@ spec:
         - name: https
           containerPort: 5556
 
+        readinessProbe:
+          # Give Dex a little time to startup
+          initialDelaySeconds: 30
+          failureThreshold: 5
+          successThreshold: 5
+          timeoutSeconds: 10
+          httpGet:
+            path: /healthz
+            port: https
+            scheme: HTTPS
+
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: https
+            scheme: HTTPS
+
         volumeMounts:
         - name: config
           mountPath: /etc/dex/cfg
@@ -181,7 +198,7 @@ spec:
   - name: dex
     port: 5556
     protocol: TCP
-    targetPort: 5556
+    targetPort: https
     nodePort: {{ pillar['dex']['node_port'] }}
   selector:
     app: dex


### PR DESCRIPTION
This will ensure Kubernetes waits for the pods to become ready before
starting to send them traffic, which should in turn prevent the orchestration
proceeding and bootstrap completing until we have at least one working Dex pod

Fixes bsc#1062542