### PR TITLE
Add PodSecurityPolicy Support

### DIFF
--- a/pillar/params.sls
+++ b/pillar/params.sls
@@ -67,6 +67,7 @@ kube_log_level:   '2'
 
 # install the addons (ie, DNS)
 addons:
+  psp:    'true'
   dns:    'true'
   tiller: 'false'
 

--- a/salt/addons/dex/manifests/10-clusterrolebinding.yaml
+++ b/salt/addons/dex/manifests/10-clusterrolebinding.yaml
@@ -26,3 +26,18 @@ subjects:
 - kind: Group
   name: "{{ pillar['ldap']['admin_group_name'] }}"
   apiGroup: rbac.authorization.k8s.io
+---
+# Allow Dex to use the suse:caasp:psp:privileged
+# PodSecurityPolicy.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: suse:caasp:psp:dex
+roleRef:
+  kind: ClusterRole
+  name: suse:caasp:psp:privileged
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: dex
+  namespace: kube-system

--- a/salt/addons/dex/manifests/20-deployment.yaml
+++ b/salt/addons/dex/manifests/20-deployment.yaml
@@ -26,6 +26,7 @@ spec:
         checksum/secret: {{ salt.hashutil.digest_file("/etc/kubernetes/addons/dex/15-secret.yaml", "sha256") }}
     spec:
       serviceAccountName: dex
+
       tolerations:
       - key: node-role.kubernetes.io/master
         operator: Exists
@@ -90,9 +91,11 @@ spec:
           items:
           - key: config.yaml
             path: config.yaml
+
       - name: tls
         secret:
           secretName: dex-tls
+
       - name: ca
         hostPath:
           path: {{ pillar['ssl']['ca_file'] }}

--- a/salt/addons/dns/init.sls
+++ b/salt/addons/dns/init.sls
@@ -1,4 +1,4 @@
-{% if salt.caasp_pillar.get('addons:dns', False) %}
+{% if salt.caasp_pillar.get('addons:dns', True) %}
 
 include:
   - kube-apiserver

--- a/salt/addons/dns/manifests/10-clusterrolebinding.yaml
+++ b/salt/addons/dns/manifests/10-clusterrolebinding.yaml
@@ -11,3 +11,18 @@ subjects:
 - kind: ServiceAccount
   name: kube-dns
   namespace: kube-system
+---
+# Allow Kube DNS to use the suse:caasp:psp:privileged
+# PodSecurityPolicy.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: suse:caasp:psp:kube-dns
+roleRef:
+  kind: ClusterRole
+  name: suse:caasp:psp:privileged
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: kube-dns
+  namespace: kube-system

--- a/salt/addons/psp/init.sls
+++ b/salt/addons/psp/init.sls
@@ -1,0 +1,18 @@
+{% if salt.caasp_pillar.get('addons:psp', True) %}
+
+include:
+  - kube-apiserver
+  - kubectl-config
+
+{% from '_macros/kubectl.jinja' import kubectl, kubectl_apply_template, kubectl_apply_dir_template with context %}
+
+{{ kubectl_apply_dir_template("salt://addons/psp/manifests/",
+                              "/etc/kubernetes/addons/psp/") }}
+
+{% else %}
+
+dummy:
+  cmd.run:
+    - name: echo "PSP addon not enabled in config"
+
+{% endif %}

--- a/salt/addons/psp/manifests/10-podsecuritypolicy-privileged.yaml
+++ b/salt/addons/psp/manifests/10-podsecuritypolicy-privileged.yaml
@@ -1,0 +1,77 @@
+# The privileged PodSecurityPolicy is intended to be given
+# only to trusted workloads. It provides for as few restrictions as possible
+# and should only be assigned to highly trusted users.
+---
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: suse.caasp.psp.privileged
+  annotations:
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: docker/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+spec:
+  # Privileged
+  privileged: true
+  # Volumes and File Systems
+  volumes:
+    # Kubernetes Pseudo Volume Types
+    - configMap
+    - secret
+    - emptyDir
+    - downwardAPI
+    - projected
+    - persistentVolumeClaim
+    # Kubernetes Host Volume Types
+    - hostPath
+    # Networked Storage
+    - nfs
+    - rbd
+    - cephFS
+    - glusterfs
+    - fc
+    - iscsi
+    # Cloud Volumes
+    - gcePersistentDisk
+    - awsElasticBlockStore
+    - azureDisk
+    - azureFile
+    - vsphereVolume
+  allowedFlexVolumes: []
+  #allowedHostPaths: []
+  readOnlyRootFilesystem: false
+  # Users and groups
+  runAsUser:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  # Privilege Escalation
+  allowPrivilegeEscalation: true
+  defaultAllowPrivilegeEscalation: true
+  # Capabilities
+  allowedCapabilities:
+    - '*'
+  defaultAddCapabilities: []
+  requiredDropCapabilities: []
+  # Host namespaces
+  hostPID: true
+  hostIPC: true
+  hostNetwork: true
+  hostPorts:
+  - min: 0
+    max: 65535
+  seLinux:
+    # SELinux is unsed in CaaSP
+    rule: 'RunAsAny'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: suse:caasp:psp:privileged
+rules:
+  - apiGroups: ['extensions']
+    resources: ['podsecuritypolicies']
+    verbs: ['use']
+    resourceNames: ['suse.caasp.psp.privileged']

--- a/salt/addons/psp/manifests/10-podsecuritypolicy-unprivileged.yaml
+++ b/salt/addons/psp/manifests/10-podsecuritypolicy-unprivileged.yaml
@@ -1,0 +1,82 @@
+# The unprivileged PodSecurityPolicy is intended to be a
+# reasonable compromise between the reality of Kubernetes workloads, and
+# suse:caasp:psp:privileged. By default, we'll grant this PSP to all
+# users and service accounts.
+---
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: suse.caasp.psp.unprivileged
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: docker/default
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: docker/default
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+spec:
+  # Privileged
+  privileged: false
+  # Volumes and File Systems
+  volumes:
+    # Kubernetes Pseudo Volume Types
+    - configMap
+    - secret
+    - emptyDir
+    - downwardAPI
+    - projected
+    - persistentVolumeClaim
+    # Networked Storage
+    - nfs
+    - rbd
+    - cephFS
+    - glusterfs
+    - fc
+    - iscsi
+    # Cloud Volumes
+    - gcePersistentDisk
+    - awsElasticBlockStore
+    - azureDisk
+    - azureFile
+    - vsphereVolume
+  allowedFlexVolumes: []
+  allowedHostPaths:
+    # Note: We don't allow hostPath volumes above, but set this to a path we
+    # control anyway as a belt+braces protection. /dev/null may be a better
+    # option, but the implications of pointing this towards a device are
+    # unclear.
+    - pathPrefix: /opt/kubernetes-hostpath-volumes
+  readOnlyRootFilesystem: false
+  # Users and groups
+  runAsUser:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  # Privilege Escalation
+  allowPrivilegeEscalation: false
+  defaultAllowPrivilegeEscalation: false
+  # Capabilities
+  allowedCapabilities: []
+  defaultAddCapabilities: []
+  requiredDropCapabilities: []
+  # Host namespaces
+  hostPID: false
+  hostIPC: false
+  hostNetwork: false
+  hostPorts:
+  - min: 0
+    max: 65535
+  # SELinux
+  seLinux:
+    # SELinux is unsed in CaaSP
+    rule: 'RunAsAny'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: suse:caasp:psp:unprivileged
+rules:
+  - apiGroups: ['extensions']
+    resources: ['podsecuritypolicies']
+    verbs: ['use']
+    resourceNames: ['suse.caasp.psp.unprivileged']

--- a/salt/addons/psp/manifests/20-clusterrolebinding.yaml
+++ b/salt/addons/psp/manifests/20-clusterrolebinding.yaml
@@ -1,0 +1,34 @@
+---
+# Allow all users and serviceaccounts to use the unprivileged
+# PodSecurityPolicy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: suse:caasp:psp:default
+roleRef:
+  kind: ClusterRole
+  name: suse:caasp:psp:unprivileged
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: Group
+  apiGroup: rbac.authorization.k8s.io
+  name: system:serviceaccounts
+- kind: Group
+  apiGroup: rbac.authorization.k8s.io
+  name: system:authenticated
+
+---
+# Allow CaaSP nodes to use the privileged
+# PodSecurityPolicy.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: suse:caasp:psp:nodes
+roleRef:
+  kind: ClusterRole
+  name: suse:caasp:psp:privileged
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: Group
+  apiGroup: rbac.authorization.k8s.io
+  name: system:nodes

--- a/salt/cni/kube-flannel-rbac.yaml.jinja
+++ b/salt/cni/kube-flannel-rbac.yaml.jinja
@@ -1,11 +1,4 @@
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: flannel
-  namespace: kube-system
-
----
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -40,6 +33,22 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: suse:caasp:flannel
+subjects:
+- kind: ServiceAccount
+  name: flannel
+  namespace: kube-system
+
+---
+# Allow Flannel to use the suse:caasp:psp:privileged
+# PodSecurityPolicy.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: suse:caasp:psp:flannel
+roleRef:
+  kind: ClusterRole
+  name: suse:caasp:psp:privileged
+  apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
   name: flannel

--- a/salt/cni/kube-flannel.yaml.jinja
+++ b/salt/cni/kube-flannel.yaml.jinja
@@ -4,12 +4,13 @@ kind: ServiceAccount
 metadata:
   name: flannel
   namespace: kube-system
+
 ---
 kind: ConfigMap
 apiVersion: v1
 metadata:
   name: flannel-plugin-config-map
-  namespace: "kube-system"
+  namespace: kube-system
   labels:
     tier: node
     app: flannel
@@ -52,12 +53,13 @@ data:
         "Type": "{{ salt.caasp_pillar.get('flannel:backend') }}"
       }
     }
+
 ---
 apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:
   name: kube-flannel
-  namespace: "kube-system"
+  namespace: kube-system
   labels:
     tier: node
     k8s-app: flannel

--- a/salt/kube-apiserver/apiserver.jinja
+++ b/salt/kube-apiserver/apiserver.jinja
@@ -23,7 +23,7 @@ KUBE_ETCD_SERVERS="--etcd-cafile={{ pillar['ssl']['ca_file'] }} \
 KUBE_SERVICE_ADDRESSES="--service-cluster-ip-range={{ pillar['services_cidr'] }}"
 
 # default admission control policies
-KUBE_ADMISSION_CONTROL="--admission-control=Initializers,NamespaceLifecycle,LimitRanger,ServiceAccount,NodeRestriction,PersistentVolumeLabel,DefaultStorageClass,ResourceQuota,DefaultTolerationSeconds"
+KUBE_ADMISSION_CONTROL="--admission-control=Initializers,NamespaceLifecycle,LimitRanger,ServiceAccount,NodeRestriction,PodSecurityPolicy,PersistentVolumeLabel,DefaultStorageClass,ResourceQuota,DefaultTolerationSeconds"
 
 # Add your own!
 KUBE_API_ARGS="--advertise-address={{ salt.caasp_net.get_primary_ip() }} \

--- a/salt/orch/kubernetes.sls
+++ b/salt/orch/kubernetes.sls
@@ -185,29 +185,23 @@ kubelet-setup:
       - kube-master-setup
       - kube-minion-setup
 
-# we must start CNI right after the masters/minions reach highstate,
-# as nodes will be NotReady until the CNI DaemonSet is loaded and running...
-cni-setup:
-  salt.state:
-    - tgt: {{ super_master }}
-    - sls:
-      - cni
-    - require:
-      - kubelet-setup
-
 reboot-setup:
   salt.state:
     - tgt: {{ super_master }}
     - sls:
       - reboot
     - require:
-      - cni-setup
+      - kubelet-setup
 
+# we must start CNI before any other pods, as nodes will be NotReady until
+# the CNI DaemonSet is loaded and running...
 services-setup:
   salt.state:
     - tgt: {{ super_master }}
     - sls:
       - addons
+      - addons.psp
+      - cni
       - addons.dns
       - addons.tiller
       - addons.dex


### PR DESCRIPTION
Add support for PodSecurityPolicy's, allowing us to disable use of the
hostPath volume type.

This change adds 2 PSP's:

* unprivileged (Default assigned to all users)

The unprivileged PodSecurityPolicy is intended to be a
reasonable compromise between the reality of Kubernetes workloads, and
suse:caasp:psp:privileged. By default, we'll grant this PSP to all
users and service accounts.

* privileged

The privileged PodSecurityPolicy is intended to be given
only to trusted workloads. It provides for as few restrictions as possible
and should only be assigned to highly trusted users.

Fixes bsc#1047535
