### PR TITLE
When upgrading, make sure to refresh the grains before attempting a highstate

### DIFF
--- a/salt/orch/update.sls
+++ b/salt/orch/update.sls
@@ -159,6 +159,15 @@ etcd-setup:
     - require:
       - {{ master_id }}-reboot
 
+# After an update, critical grains like `nodename` could need to be refreshed, make sure we do so
+# before attempting to highstate the node.
+{{ master_id }}-refresh-grains:
+  salt.function:
+    - tgt: {{ master_id }}
+    - name: saltutil.refresh_grains
+    - require:
+      - {{ master_id }}-wait-for-start
+
 # Early apply haproxy configuration
 {{ master_id }}-apply-haproxy:
   salt.state:
@@ -166,7 +175,7 @@ etcd-setup:
     - sls:
       - haproxy
     - require:
-      - {{ master_id }}-wait-for-start
+      - {{ master_id }}-refresh-grains
 
 # Start services
 {{ master_id }}-start-services:
@@ -250,6 +259,15 @@ etcd-setup:
     - require:
       - {{ worker_id }}-reboot
 
+# After an update, critical grains like `nodename` could need to be refreshed, make sure we do so
+# before attempting to highstate the node.
+{{ worker_id }}-refresh-grains:
+  salt.function:
+    - tgt: {{ worker_id }}
+    - name: saltutil.refresh_grains
+    - require:
+      - {{ worker_id }}-wait-for-start
+
 # Early apply haproxy configuration
 {{ worker_id }}-apply-haproxy:
   salt.state:
@@ -257,7 +275,7 @@ etcd-setup:
     - sls:
       - haproxy
     - require:
-      - {{ worker_id }}-wait-for-start
+      - {{ worker_id }}-refresh-grains
 
 # Start services
 {{ worker_id }}-start-services:


### PR DESCRIPTION
During an upgrade process, some important grains (like `nodename` during certain
upgrades, others in the future could also apply) might be outdated when we
highstate the node. Usually the salt-minion does this automatically, but QA has
found some cases in which this doesn't happen.

This is an attempt to fix that issue, despite hardly reproducible.