### PR TITLE
Wipe out our /etc/hosts changes before reboot

### DIFF
--- a/salt/etc-hosts/init.sls
+++ b/salt/etc-hosts/init.sls
@@ -2,6 +2,7 @@
 {% if salt['grains.get']('virtual_subtype', None) != 'Docker' %}
 /etc/hosts:
   file.blockreplace:
+    # If markers are changed, also update etc-hosts/update-pre-reboot.sls
     - marker_start: "#-- start Salt-CaaSP managed hosts - DO NOT MODIFY --"
     - marker_end:   "#-- end Salt-CaaSP managed hosts --"
     - source:       salt://etc-hosts/hosts.jinja

--- a/salt/etc-hosts/update-post-reboot.sls
+++ b/salt/etc-hosts/update-post-reboot.sls
@@ -1,0 +1,2 @@
+include:
+  - etc-hosts

--- a/salt/etc-hosts/update-pre-reboot.sls
+++ b/salt/etc-hosts/update-pre-reboot.sls
@@ -1,0 +1,8 @@
+# Remove our /etc/hosts entries, so that Systemd/Wicked hostname
+# logic doesn't pick up out /etc/hosts entry names.
+/etc/hosts:
+  file.blockreplace:
+    # If markers are changed, also update etc-hosts/init.sls
+    - marker_start: "#-- start Salt-CaaSP managed hosts - DO NOT MODIFY --"
+    - marker_end:   "#-- end Salt-CaaSP managed hosts --"
+    - content:      ""

--- a/salt/orch/update.sls
+++ b/salt/orch/update.sls
@@ -132,6 +132,7 @@ etcd-setup:
   salt.state:
     - tgt: {{ master_id }}
     - sls:
+      - etc-hosts.update-pre-reboot
       - cni.update-pre-reboot
       - etcd.update-pre-reboot
     - require:
@@ -159,6 +160,16 @@ etcd-setup:
     - require:
       - {{ master_id }}-reboot
 
+# Perform any migratrions necessary before salt starts doing
+# "real work" again
+{{ master_id }}-post-reboot:
+  salt.state:
+    - tgt: {{ master_id }}
+    - sls:
+      - etc-hosts.update-post-reboot
+    - require:
+      - {{ master_id }}-wait-for-start
+
 # Early apply haproxy configuration
 {{ master_id }}-apply-haproxy:
   salt.state:
@@ -166,7 +177,7 @@ etcd-setup:
     - sls:
       - haproxy
     - require:
-      - {{ master_id }}-wait-for-start
+      - {{ master_id }}-post-reboot
 
 # Start services
 {{ master_id }}-start-services:
@@ -224,6 +235,7 @@ etcd-setup:
   salt.state:
     - tgt: {{ worker_id }}
     - sls:
+      - etc-hosts.update-pre-reboot
       - cni.update-pre-reboot
     - require:
       - {{ worker_id }}-clean-shutdown
@@ -250,6 +262,16 @@ etcd-setup:
     - require:
       - {{ worker_id }}-reboot
 
+# Perform any migratrions necessary before salt starts doing
+# "real work" again
+{{ worker_id }}-post-reboot:
+  salt.state:
+    - tgt: {{ worker_id }}
+    - sls:
+      - etc-hosts.update-post-reboot
+    - require:
+      - {{ worker_id }}-wait-for-start
+
 # Early apply haproxy configuration
 {{ worker_id }}-apply-haproxy:
   salt.state:
@@ -257,7 +279,7 @@ etcd-setup:
     - sls:
       - haproxy
     - require:
-      - {{ worker_id }}-wait-for-start
+      - {{ worker_id }}-post-reboot
 
 # Start services
 {{ worker_id }}-start-services:


### PR DESCRIPTION
This ensures the systemd/wicked logic is unaffected by our /etc/hosts
changes.
