### PR TITLE
Use complete host references on haproxy configuration

### DIFF
--- a/salt/haproxy/haproxy.cfg.jinja
+++ b/salt/haproxy/haproxy.cfg.jinja
@@ -27,7 +27,7 @@ listen kubernetes-master
         option httpchk GET /healthz
 
 {%- for minion_id, nodename in salt['mine.get']('roles:kube-master', 'nodename', 'grain').items() %}
-        server master-{{ minion_id }} {{ nodename }}:{{ pillar['api']['int_ssl_port'] }} check check-ssl port {{ pillar['api']['int_ssl_port'] }} verify none
+        server master-{{ nodename }} {{ nodename }}.{{ pillar['internal_infra_domain'] }}:{{ pillar['api']['int_ssl_port'] }} check check-ssl port {{ pillar['api']['int_ssl_port'] }} verify none
 {% endfor -%}
 
 {%- if "admin" in salt['grains.get']('roles', []) %}
@@ -40,7 +40,7 @@ listen kubernetes-dex
         option redispatch
 
 {%- for minion_id, nodename in salt['mine.get']('roles:kube-master', 'nodename', 'grain').items() %}
-        server master-{{ minion_id }} {{ nodename }}:32000 check
+        server master-{{ nodename }} {{ nodename }}.{{ pillar['internal_infra_domain'] }}:32000 check
 {% endfor %}
 
 listen velum


### PR DESCRIPTION
This avoids an incompatibility on the admin node in which if the external
fqdn field matched any of the master nodes host, haproxy would be checking
127.0.0.1:6444 for the apiserver for healthchecks.

Now, we are using the internal infra domain suffix so we are sure we are
referring to the real /etc/hosts entry with the ip address of the target
machines.