### PR TITLE
Dex: Delay liveness probe in addition to readiness probe

### DIFF
--- a/salt/addons/dex/manifests/20-deployment.yaml
+++ b/salt/addons/dex/manifests/20-deployment.yaml
@@ -68,6 +68,8 @@ spec:
             scheme: HTTPS
 
         livenessProbe:
+          # Give Dex a little time to startup
+          initialDelaySeconds: 30
           httpGet:
             path: /healthz
             port: https


### PR DESCRIPTION
Delay the liveness probe by 30 seconds, matching the readiness
probe.