### PR TITLE
When we explicitly run `haproxy` sls in the update, run `etc-hosts` too.

### DIFF
--- a/salt/orch/update.sls
+++ b/salt/orch/update.sls
@@ -4,6 +4,7 @@ admin-apply-haproxy:
     - tgt_type: grain
     - batch: 1
     - sls:
+      - etc-hosts
       - haproxy
 
 # Ensure all nodes with updates are marked as upgrading. This will reduce the time window in which


### PR DESCRIPTION
* During a rename, it might happen that `haproxy` refuses to start because it cannot
resolve the new names `nodename.infra.caasp.local` in the configuration because its
`/etc/hosts` file hasn't been updated yet.

* Refresh modules before we call to any `sls`, they might use undiscovered modules.