### PR TITLE
Node removal: refactorings and code cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea/
 Makefile
 *.tgz
+*.pyc
 
 # local config files
 config/master.d/99-local-*.conf

--- a/salt/_modules/caasp_grains.py
+++ b/salt/_modules/caasp_grains.py
@@ -1,0 +1,20 @@
+from __future__ import absolute_import
+
+
+def __virtual__():
+    return "caasp_grains"
+
+
+# default grain name, used for getting node IDs
+_GRAIN_NAME = 'nodename'
+
+
+def get(expr, grain=_GRAIN_NAME, type='compound'):
+    if __opts__['__role'] == 'master':
+        # 'mine.get' is not available in the master: it returns nothing
+        # in that case, we should use "saltutil.runner"... uh?
+        return __salt__['saltutil.runner']('mine.get',
+                                           tgt=expr,
+                                           fun=grain, tgt_type=type)
+    else:
+        return __salt__['mine.get'](expr, grain, expr_form=type)

--- a/salt/_modules/caasp_log.py
+++ b/salt/_modules/caasp_log.py
@@ -1,46 +1,54 @@
+# note: this module can be directly imported from other
+#       Salt modules. Do not do the same for other modules:
+#       use __salt__['caasp_module.function'](args)
+#
 from __future__ import absolute_import
 
 import logging
 
-log = logging.getLogger(__name__)
+from salt.exceptions import SaltException
+
+log = logging.getLogger('CaaS')
 
 
-class ExecutionAborted(Exception):
+_CAAS_PREFIX = '[CaaS]: '
+
+
+class ExecutionAborted(SaltException):
     pass
 
 
-def abort(*args, **kwargs):
+def abort(msg, *args, **kwargs):
     '''
     Abort the Salt execution with an error
     '''
-    # TODO: use the builtin function (https://docs.saltstack.com/en/latest/topics/jinja/index.html#logs)
-    #       once we Salt>2017.7.0
-    log.error(*args, **kwargs)
-    raise ExecutionAborted()
+    error(msg, *args, **kwargs)
+    raise ExecutionAborted(msg % args)
 
 
-def error(*args, **kwargs):
+def error(msg, *args, **kwargs):
     '''
     Log a error message
     '''
-    # TODO: use the builtin function (https://docs.saltstack.com/en/latest/topics/jinja/index.html#logs)
-    #       once we Salt>2017.7.0
-    log.error(*args, **kwargs)
+    log.error(_CAAS_PREFIX + msg % args, **kwargs)
 
 
-def warn(*args, **kwargs):
+def warn(msg, *args, **kwargs):
     '''
     Log a warning message
     '''
-    # TODO: use the builtin function (https://docs.saltstack.com/en/latest/topics/jinja/index.html#logs)
-    #       once we Salt>2017.7.0
-    log.warn(*args, **kwargs)
+    log.warn(_CAAS_PREFIX + msg % args, **kwargs)
 
 
-def debug(*args, **kwargs):
+def info(msg, *args, **kwargs):
+    '''
+    Log an info message
+    '''
+    log.info(_CAAS_PREFIX + msg % args, **kwargs)
+
+
+def debug(msg, *args, **kwargs):
     '''
     Log a debug message
     '''
-    # TODO: use the builtin function (https://docs.saltstack.com/en/latest/topics/jinja/index.html#logs)
-    #       once we Salt>2017.7.0
-    log.debug(*args, **kwargs)
+    log.debug(_CAAS_PREFIX + msg % args, **kwargs)

--- a/salt/_modules/caasp_net.py
+++ b/salt/_modules/caasp_net.py
@@ -5,10 +5,6 @@
 
 from __future__ import absolute_import
 
-import logging
-
-LOG = logging.getLogger(__name__)
-
 
 def __virtual__():
     return "caasp_net"
@@ -62,6 +58,13 @@ def get_primary_ips_for(compound, **kwargs):
 
 
 def get_nodename(**kwargs):
-    host = kwargs.pop('host', _get_local_id())
-    
-    return _get_mine(host, 'nodename')[host]
+    '''
+    (given some optional 'host')
+    return the hostname
+    '''
+    _not_provided = object()
+    host = kwargs.pop('host', _not_provided)
+    if host is _not_provided:
+        return __salt__['grains.get']('nodename')
+    else:
+        return _get_mine(host, 'nodename')[host]

--- a/salt/_modules/caasp_nodes.py
+++ b/salt/_modules/caasp_nodes.py
@@ -1,0 +1,495 @@
+from __future__ import absolute_import
+
+# note: do not import caasp modules other than caasp_log
+from caasp_log import abort, debug, error, info, warn
+
+# minimum number of nodes (per role) we can have after a removal
+_MIN_ETCD_MEMBERS_AFTER_REMOVAL = 1
+_MIN_MASTERS_AFTER_REMOVAL = 1
+_MIN_MINIONS_AFTER_REMOVAL = 1
+
+
+def _get_prio_etcd(unassigned=False):
+    '''
+    Get the priorities for choosing new nodes for running
+    new etcd members.
+
+    Optional arguments:
+
+      * `unassigned`: consider nodes with no roles assigned
+    '''
+    res = []
+
+    # etcd nodes that not been bootstrapped yet
+    # (ie, the role has been assigned in Velum)
+    res.append('G@roles:etcd and not G@bootstrap_complete:true')
+
+    if unassigned:
+        # has no role (prefering non-bootstrapped nodes)
+        res.append('not P@roles:(kube-master|kube-minion|etcd) and not G@bootstrap_complete:true')
+        res.append('not P@roles:(kube-master|kube-minion|etcd)')
+
+    # kubernetes masters (prefering non-bootstrapped nodes)
+    res.append('G@roles:kube-master and not G@bootstrap_complete:true')
+    res.append('G@roles:kube-master')
+
+    # kuberetes minions (prefering non-bootstrapped nodes)
+    res.append('G@roles:kube-minion and not G@bootstrap_complete:true')
+    res.append('G@roles:kube-minion')
+
+    return res
+
+
+def _get_prio_master(unassigned=False):
+    '''
+    Get the priorities for choosing new nodes for running
+    a new kubernetes master.
+
+    Optional arguments:
+
+      * `unassigned`: consider nodes with no roles assigned
+    '''
+    res = []
+
+    # kubernetes masters that not been bootstrapped yet
+    # (ie, the role has been assigned in Velum)
+    res.append('G@roles:kube-master and not G@bootstrap_complete:true')
+
+    if unassigned:
+        # nodes with no role (preferring non-bootstrapped nodes)
+        res.append('not P@roles:(kube-master|kube-minion|etcd) and not G@bootstrap_complete:true')
+        res.append('not P@roles:(kube-master|kube-minion|etcd)')
+
+    # etcd-only nodes (preferring non-bootstrapped nodes)
+    res.append('G@roles:etcd and not G@roles:kube-master and not G@bootstrap_complete:true')
+    res.append('G@roles:etcd and not G@roles:kube-master')
+    return res
+
+
+def _get_prio_minion(unassigned=False):
+    '''
+    Get the priorities for choosing new nodes for running
+    a new kubernetes minion.
+
+    Optional arguments:
+
+      * `unassigned`: consider nodes with no roles assigned
+    '''
+    res = []
+
+    # kubernetes minions that not been bootstrapped yet
+    # (ie, the role has been assigned in Velum)
+    res.append('G@roles:kube-minion and not G@bootstrap_complete:true')
+
+    if unassigned:
+        # nodes with no role (preferring non-bootstrapped nodes)
+        res.append('not P@roles:(kube-master|kube-minion|etcd) and not G@bootstrap_complete:true')
+        res.append('not P@roles:(kube-master|kube-minion|etcd)')
+
+    # etcd-only nodes (preferring non-bootstrapped nodes)
+    res.append('G@roles:etcd and not G@roles:kube-master and not G@bootstrap_complete:true')
+    res.append('G@roles:etcd and not G@roles:kube-master')
+
+    return res
+
+
+_PRIO_FUN = {
+    'etcd': _get_prio_etcd,
+    'kube-master': _get_prio_master,
+    'kube-minion': _get_prio_minion,
+}
+
+
+# filter out empty/None and sort a list
+def _sanitize_list(lst):
+    res = [x for x in lst if x]
+    res.sort()
+    return res
+
+
+def get_with_expr(expr, **kwargs):
+    '''
+    Get all the nodes that match some expression `expr`
+
+    Optional arguments:
+
+      * `booted`: exclude non-bootstrapped nodes
+      * `exclude_admin`: exclude the Admin and CA nodes
+      * `exclude_in_progress`: exclude any node with *_in_progress grains
+      * `excluded`: list of nodes to exclude
+      * `excluded_roles`: list of roles to exclude
+    '''
+    expr_items = [expr]
+
+    if kwargs.get('booted', False):
+        expr_items.append('G@bootstrap_complete:true')
+
+    if kwargs.get('exclude_admin', False):
+        expr_items.append('not P@roles:(admin|ca)')
+
+    if kwargs.get('exclude_in_progress', False):
+        expr_items.append('not G@bootstrap_in_progress:true')
+        expr_items.append('not G@update_in_progress:true')
+        expr_items.append('not G@removal_in_progress:true')
+        expr_items.append('not G@addition_in_progress:true')
+
+    excluded = _sanitize_list(kwargs.get('excluded', []))
+    if excluded:
+        expr_items.append('not L@' + '|'.join(excluded))
+
+    excluded_roles = _sanitize_list(kwargs.get('excluded_roles', []))
+    if excluded_roles:
+        expr_items.append('not P@roles:(' + '|'.join(excluded_roles) + ')')
+
+    return __salt__['caasp_grains.get'](' and '.join(expr_items)).keys()
+
+
+def get_from_args_or_with_expr(arg_name, args_dict, *args, **kwargs):
+    '''
+    Utility function for getting a list of nodes from either the kwargs
+    or from an expression.
+    '''
+    if arg_name in args_dict:
+        return _sanitize_list(args_dict[arg_name])
+    else:
+        return get_with_expr(*args, **kwargs)
+
+
+def get_with_prio(num, description, prio_rules, **kwargs):
+    '''
+    Get a list of `num` nodes that could be used for
+    running some role.
+
+    A valid node is a node that:
+
+      1) is not the `admin` or `ca`
+      2) dopes not currently have that role
+      2) is not being removed/added/updated
+    '''
+    new_nodes = []
+    remaining = num
+    for expr in prio_rules:
+        debug('trying to find candidates for %s with %s',
+              description, expr)
+        # get all the nodes matching the priority expression,
+        # but filtering out all the nodes we already have
+        candidates = get_with_expr(expr,
+                                   exclude_admin=True, exclude_in_progress=True,
+                                   **kwargs)
+        ids = [x for x in candidates if x not in new_nodes]
+        if len(ids) > 0:
+            new_ids = ids[:remaining]
+            new_nodes = new_nodes + new_ids
+            remaining -= len(new_ids)
+            debug('... %d new candidates (%s) for %s: %d remaining',
+                  len(ids), str(ids), description, remaining, )
+        else:
+            debug('... no candidates found with %s', expr)
+
+        if remaining <= 0:
+            break
+
+    info('we were looking for %d candidates for %s and %d found',
+         num, description, len(new_nodes))
+    return new_nodes[:num]
+
+
+def get_with_prio_for_role(num, role, **kwargs):
+    unassigned = kwargs.get('unassigned', False)
+    prio_rules = _PRIO_FUN[role](unassigned)
+    return get_with_prio(num, role, prio_rules, **kwargs)
+
+
+def _get_one_for_role(role, **kwargs):
+    res = get_with_prio_for_role(1, role, unassigned=True, **kwargs)
+    return res[0] if len(res) > 0 else ''
+
+
+def get_replacement_for(target, replacement='', **kwargs):
+    '''
+    When removing a node `target`, try to get a `replacement` (and the new roles that
+    must be assigned) for all the roles that were running there.
+
+    If the user provides an explicit `replacement`, verify that that replacement is valid.
+    In case the user-provided is not valid, raise an exception (aborting the execution).
+
+    If no replacement can be found, we are fine as long as we have a minimum number
+    of nodes with that role (ie, for masters, we are fine as long as we have at least one master).
+    '''
+    assert target
+
+    excluded = kwargs.get('excluded', [])
+
+    replacement_provided = (replacement != '')
+    replacement_roles = []
+
+    def warn_or_abort_on_replacement_provided(msg, *args):
+        if replacement_provided:
+            abort('the user provided replacement cannot be used: ' + msg, *args)
+        else:
+            warn(msg, *args)
+
+    # preparations
+
+    # check: we cannot try to remove some 'virtual' nodes
+    forbidden = get_from_args_or_with_expr(
+        'forbidden', kwargs, 'P@roles:(admin|ca)')
+    if target in forbidden:
+        abort('%s cannot be removed: it has a "ca" or "admin" role',
+              target)
+    elif replacement_provided and replacement in forbidden:
+        abort('%s cannot be replaced by %s: the replacement has a "ca" or "admin" role',
+              target, replacement)
+
+    masters = get_from_args_or_with_expr(
+        'masters', kwargs, 'G@roles:kube-master')
+    minions = get_from_args_or_with_expr(
+        'minions', kwargs, 'G@roles:kube-minion')
+    etcd_members = get_from_args_or_with_expr(
+        'etcd_members', kwargs, 'G@roles:etcd')
+
+    #
+    # replacement for etcd members
+    #
+    if target in etcd_members:
+        etcd_replacement = replacement
+        if not etcd_replacement:
+            debug('looking for replacement for etcd at %s', target)
+            # we must choose another node and promote it to be an etcd member
+            etcd_replacement = _get_one_for_role(
+                'etcd', excluded=excluded)
+
+        # check if the replacement provided is valid
+        if etcd_replacement:
+            bootstrapped_etcd_members = get_from_args_or_with_expr(
+                'booted_etcd_members', kwargs, 'G@roles:kube-master', booted=True)
+
+            if etcd_replacement in bootstrapped_etcd_members:
+                warn_or_abort_on_replacement_provided('the replacement for the etcd server %s cannot be %s: another etcd server is already running there',
+                                                      target, etcd_replacement)
+                etcd_replacement = ''
+            # the etcd replacement can be run in bootstrapped masters/minions,
+            # so we are done with the incompatibility checks...
+
+        if etcd_replacement:
+            debug('setting %s as the replacement for the etcd member %s',
+                  etcd_replacement, target)
+            replacement = etcd_replacement
+            replacement_roles.append('etcd')
+
+        if not 'etcd' in replacement_roles:
+            if len(etcd_members) <= _MIN_ETCD_MEMBERS_AFTER_REMOVAL:
+                # we need at least one etcd server
+                abort('cannot remove etcd member %s: too few etcd members, and no replacement found or provided',
+                      target)
+            else:
+                warn('number of etcd members will be reduced to %d, as no replacement for etcd server in %s has been found (or provided)',
+                     len(etcd_members), target)
+
+    #
+    # replacement for k8s masters
+    #
+    if target in masters:
+        master_replacement = replacement
+        if not master_replacement:
+            # NOTE: even if no `replacement` was provided in the pillar,
+            #       we probably have one at this point: if the master was
+            #       running etcd as well, we have already tried to find
+            #       a replacement in the previous step...
+            #       however, we must verify that the etcd replacement
+            #       is a valid k8s master replacement too.
+            #       (ideally we should find the union of etcd and
+            #       masters candidates)
+            debug('looking for replacement for kubernetes master at %s', target)
+            master_replacement = _get_one_for_role(
+                'kube-master', excluded=excluded)
+
+        # check if the replacement provided/found is valid
+        if master_replacement:
+            bootstrapped_masters = get_from_args_or_with_expr(
+                'booted_masters', kwargs, 'G@roles:kube-master', booted=True)
+            if master_replacement in bootstrapped_masters:
+                warn_or_abort_on_replacement_provided('will not replace the k8s master %s: the replacement %s is already running a k8s master',
+                                                      target, master_replacement)
+                master_replacement = ''
+            elif master_replacement in minions:
+                warn_or_abort_on_replacement_provided('will not replace the k8s master at %s: the replacement found/provided is the k8s minion %s',
+                                                      target, master_replacement)
+                master_replacement = ''
+
+        if master_replacement:
+            # so far we do not support having two replacements for two roles,
+            # so we check if the new replacement is compatible with any previous
+            # replacement found so far. If it is not, keep the previous one and
+            # warn the user
+            if not replacement:
+                replacement = master_replacement
+
+            assert len(replacement) > 0
+            if replacement == master_replacement:
+                debug('setting %s as replacement for the kubernetes master %s',
+                      replacement, target)
+                replacement_roles.append('kube-master')
+            else:
+                warn('the k8s master replacement (%s) is not the same as the current replacement (%s) ' +
+                     '(it will run %s) so we cannot use it for running the k8s master too',
+                     master_replacement, replacement, ','.join(replacement_roles))
+
+        if not 'kube-master' in replacement_roles:
+            # stability check: check if it is ok not to run the k8s master in the replacement
+            if len(masters) <= _MIN_MASTERS_AFTER_REMOVAL:
+                # we need at least one master (for runing the k8s API at all times)
+                abort('cannot remove k8s master %s: too few k8s masters, and no replacement found or provided',
+                      target)
+            else:
+                warn('number of k8s masters will be reduced to %d, as no replacement for the k8s master in %s has been found (or provided)',
+                     len(masters), target)
+
+    #
+    # replacement for k8s minions
+    #
+    if target in minions:
+        minion_replacement = replacement
+        if not minion_replacement:
+            debug('looking for replacement for kubernetes minion at %s', target)
+            minion_replacement = _get_one_for_role(
+                'kube-minion', excluded=excluded)
+
+        # check if the replacement provided/found is valid
+        # NOTE: maybe the new role has already been assigned in Velum...
+        if minion_replacement:
+            bootstrapped_minions = get_from_args_or_with_expr(
+                'booted_minions', kwargs, 'G@roles:kube-minion', booted=True)
+            if minion_replacement in bootstrapped_minions:
+                warn_or_abort_on_replacement_provided('will not replace minion %s: the replacement %s is already running a k8s minion',
+                                                      target, minion_replacement)
+                minion_replacement = ''
+
+            elif minion_replacement in masters:
+                warn_or_abort_on_replacement_provided('will not replace the k8s minion %s: the replacement %s is already a k8s master',
+                                                      target, minion_replacement)
+                minion_replacement = ''
+
+            elif 'kube-master' in replacement_roles:
+                warn_or_abort_on_replacement_provided('will not replace the k8s minion %s: the replacement found/provided, %s, is already scheduled for being a new k8s master',
+                                                      target, minion_replacement)
+                minion_replacement = ''
+
+        if minion_replacement:
+            # once again, check if the new replacement is compatible with any previous one
+            if not replacement:
+                replacement = minion_replacement
+
+            assert len(replacement) > 0
+            if replacement == minion_replacement:
+                debug('setting %s as replacement for the k8s minion %s',
+                      replacement, target)
+                replacement_roles.append('kube-minion')
+            else:
+                warn('the k8s minion replacement (%s) is not the same as the current replacement (%s) ' +
+                     '(it will run %s) so we cannot use it for running the k8s minion too',
+                     minion_replacement, replacement, ','.join(replacement_roles))
+
+        if not 'kube-minion' in replacement_roles:
+            # stability check: check if it is ok not to run the k8s minion in the replacement
+            if len(minions) <= _MIN_MINIONS_AFTER_REMOVAL:
+                # we need at least one minion (for running dex, kube-dns, etc..)
+                abort('cannot remove k8s minion %s: too few k8s minions, and no replacement found or provided',
+                      target)
+            else:
+                warn('number of k8s minions will be reduced to %d, as no replacement for the k8s minion in %s has been found (or provided)',
+                     len(masters), target)
+
+    # other consistency checks...
+    if replacement:
+        # consistency check: if there is a replacement, it must have some (new) role(s)
+        if not replacement_roles:
+            abort('internal error: replacement %s has no roles assigned', replacement)
+    else:
+        # if no valid replacement has been found, clear the roles too
+        replacement_roles = []
+
+    return replacement, replacement_roles
+
+
+def get_expr_affected_by(target, **kwargs):
+    '''
+    Get an expression for matching nodes that are affected by the
+    addition/removal of `target`. Those affected nodes should
+    be highstated in order to update their configuration.
+
+    Some notes:
+
+      * we only consider bootstraped nodes.
+      * we ignore nodes where some oither operation is in progress (ie, an update)
+
+    Optional arguments:
+
+      * `exclude_in_progress`: (default=True) exclude any node with *_in_progress
+      * `excluded`: list of nodes to exclude
+      * `excluded_roles`: list of roles to exclude
+    '''
+    affected_items = []
+    affected_roles = []
+
+    etcd_members = get_from_args_or_with_expr('etcd_members', kwargs, 'G@roles:etcd')
+    masters = get_from_args_or_with_expr('masters', kwargs, 'G@roles:kube-master')
+    minions = get_from_args_or_with_expr('minions', kwargs, 'G@roles:kube-minion')
+
+    if target in etcd_members:
+        # we must highstate:
+        # * etcd members (ie, peers list in /etc/sysconfig/etcd)
+        affected_roles.append('etcd')
+        # * api servers (ie, etcd endpoints in /etc/kubernetes/apiserver
+        affected_roles.append('kube-master')
+
+    if target in masters:
+        # we must highstate:
+        # * admin (ie, haproxy)
+        affected_roles.append('admin')
+        # * minions (ie, haproxy)
+        affected_roles.append('kube-minion')
+
+    if target in minions:
+        # ok, ok, /etc/hosts will contain the old node, but who cares!
+        pass
+
+    if not affected_roles:
+        debug('no roles affected by the removal/addition of %s', target)
+        return ''
+
+    affected_items.append('G@bootstrap_complete:true')
+
+    affected_roles.sort()
+    affected_items.append('P@roles:(' + '|'.join(affected_roles) + ')')
+
+    if kwargs.get('exclude_in_progress', True):
+        affected_items.append('not G@bootstrap_in_progress:true')
+        affected_items.append('not G@update_in_progress:true')
+        affected_items.append('not G@removal_in_progress:true')
+        affected_items.append('not G@addition_in_progress:true')
+
+    excluded_nodes = _sanitize_list([target] + kwargs.get('excluded', []))
+    if excluded_nodes:
+        affected_items.append('not L@' + ','.join(excluded_nodes))
+
+    excluded_roles = _sanitize_list(kwargs.get('excluded_roles', []))
+    if excluded_roles:
+        affected_items.append('not P@roles:(' + '|'.join(excluded_roles) + ')')
+
+    return ' and '.join(affected_items)
+
+
+def get_super_master(**kwargs):
+    '''
+    Get one random master that can be used as super-master
+    '''
+    masters = get_from_args_or_with_expr('masters', kwargs, 'G@roles:kube-master')
+
+    excluded = kwargs.get('excluded', [])
+
+    for master in masters:
+        if master not in excluded:
+            return master
+
+    return ''

--- a/salt/_modules/tests/test_caasp_nodes.py
+++ b/salt/_modules/tests/test_caasp_nodes.py
@@ -1,0 +1,372 @@
+from __future__ import absolute_import
+
+import unittest
+
+from caasp_log import ExecutionAborted
+from caasp_nodes import (get_expr_affected_by, get_from_args_or_with_expr,
+                         get_replacement_for, get_with_prio)
+
+try:
+    from mock import patch, MagicMock
+except ImportError:
+    _mocking_lib_available = False
+else:
+    _mocking_lib_available = True
+
+
+class TestGetFromArgsOrWithExpr(unittest.TestCase):
+    '''
+    Some basic tests for get_from_args_or_with_expr()
+    '''
+
+    def test_get_from_args_or_with_expr(self):
+        def do_test(**kwargs):
+            with patch('caasp_nodes.get_with_expr', MagicMock(return_value=[4, 5, 6])):
+                return get_from_args_or_with_expr(
+                    'etcd_members', kwargs, 'G@roles:etcd')
+
+        res = do_test(etcd_members=[1, 2, 3])
+        self.assertEqual(res, [1, 2, 3],
+                         'did not get the etcd members from the kwargs: {}'.format(res))
+
+        res = do_test(masters=[1, 2, 3])
+        self.assertEqual(res, [4, 5, 6],
+                         'did not get the masters with the expresion: {}'.format(res))
+
+
+class TestGetWithPrio(unittest.TestCase):
+    '''
+    Some basic tests for get_with_prio()
+    '''
+
+    def setUp(self):
+        self.unassigned_node_1 = 'unassigned_node_1'
+        self.unassigned_node_2 = 'unassigned_node_2'
+        self.unassigned_node_3 = 'unassigned_node_3'
+
+    @unittest.skipIf(not _mocking_lib_available,
+                     "no mocking library available (install rpm:python-mock)")
+    def test_get_with_prio_for_etcd(self):
+        '''
+        Check get_with_prio() tries to get as many nodes as
+        we requested.
+        '''
+        from caasp_nodes import _get_prio_etcd
+        etcd_prio = _get_prio_etcd()
+
+        counter = {'value': 0}
+
+        def mocked_get_with_expr(expr, **kwargs):
+            counter['value'] += 1
+            return [self.unassigned_node_1]
+
+        # we return always unassigned_node_1, so we should
+        # exahust the priorities list looking for more nodes
+        with patch('caasp_nodes.get_with_expr', mocked_get_with_expr):
+            nodes = get_with_prio(2, 'etcd', etcd_prio)
+
+            self.assertIn(self.unassigned_node_1, nodes,
+                          'unassigned_node_1 not found in list')
+            self.assertEqual(counter['value'], len(etcd_prio),
+                             'priority list was not exahusted')
+
+        counter = {'value': 0}
+
+        def mocked_get_with_expr(expr, **kwargs):
+            counter['value'] += 1
+            return [self.unassigned_node_1, self.unassigned_node_2]
+
+        # now we will get all the nodes required in just one call
+        with patch('caasp_nodes.get_with_expr', mocked_get_with_expr):
+            nodes = get_with_prio(2, 'etcd', etcd_prio)
+
+            self.assertIn(self.unassigned_node_1, nodes,
+                          'unassigned_node_1 not found in list')
+            self.assertIn(self.unassigned_node_2, nodes,
+                          'unassigned_node_2 not found in list')
+            self.assertEqual(counter['value'], 1,
+                             'unexpected number of calls ({}) to get_with_expr()'.format(counter['value']))
+
+        counter = {'value': 0}
+
+        def mocked_get_with_expr(expr, **kwargs):
+            counter['value'] += 1
+            return {1: [self.unassigned_node_1],
+                    2: [self.unassigned_node_1, self.unassigned_node_2],
+                    3: [self.unassigned_node_1, self.unassigned_node_2, self.unassigned_node_3]}[counter['value']]
+
+        # now we will return one more node every time we
+        # invoke get_with_expr()
+        with patch('caasp_nodes.get_with_expr',
+                   mocked_get_with_expr):
+            nodes = get_with_prio(3, 'etcd', etcd_prio)
+
+            self.assertIn(self.unassigned_node_1, nodes,
+                          'unassigned_node_1 not found in list')
+            self.assertIn(self.unassigned_node_2, nodes,
+                          'unassigned_node_2 not found in list')
+            self.assertIn(self.unassigned_node_3, nodes,
+                          'unassigned_node_3 not found in list')
+            self.assertEqual(counter['value'], 3,
+                             'unexpected number of calls ({}) to get_with_expr()'.format(counter['value']))
+
+
+class TestGetReplacementFor(unittest.TestCase):
+    '''
+    Some basic tests for get_replacement_for()
+    '''
+
+    def setUp(self):
+        self.ca = 'ca'
+        self.master_1 = 'master_1'
+        self.master_2 = 'master_2'
+        self.master_3 = 'master_3'
+        self.minion_1 = 'minion_1'
+        self.minion_2 = 'minion_2'
+        self.minion_3 = 'minion_3'
+        self.other_node = 'other_node'
+
+        self.masters = [self.master_1, self.master_2, self.master_3]
+        self.etcd_members = [self.master_1, self.master_2, self.master_3]
+        self.minions = [self.minion_1, self.minion_2, self.minion_3]
+
+        self.get_replacement_for_kwargs = {
+            'forbidden': [self.ca],
+            'etcd_members': self.etcd_members,
+            'masters': self.masters,
+            'minions': self.minions,
+            'booted_etcd_members': self.etcd_members,
+            'booted_masters': self.masters,
+            'booted_minions': self.minions
+        }
+
+    def test_user_provided_for_etc_master(self):
+        '''
+        Check the user-provided etcd & master replacement is valid,
+        at least for some roles
+        '''
+        replacement, roles = get_replacement_for(self.master_2,
+                                                 replacement=self.other_node,
+                                                 **self.get_replacement_for_kwargs)
+
+        self.assertEqual(replacement, self.other_node,
+                         'unexpected replacement')
+        self.assertIn('etcd', roles,
+                      'etcd role not found in replacement')
+        self.assertIn('kube-master', roles,
+                      'kube-master role not found in replacement')
+        self.assertNotIn('kube-minion', roles,
+                         'kube-minion role found in replacement')
+
+    def test_user_provided_for_etcd_minion(self):
+        '''
+        Check the user-provided etcd & minion replacement is valid,
+        at least for some roles
+        '''
+        # add one of the minions to the etcd cluster
+        etcd_members = [self.master_1, self.master_2, self.minion_1]
+
+        self.get_replacement_for_kwargs.update({
+            'etcd_members': etcd_members,
+            'booted_etcd_members': etcd_members,
+        })
+
+        replacement, roles = get_replacement_for(self.minion_1,
+                                                 replacement=self.other_node,
+                                                 **self.get_replacement_for_kwargs)
+
+        # when removing minion_1 (with roles minion and etcd), we can migrate
+        # both roles to a free node
+        self.assertEqual(replacement, self.other_node,
+                         'unexpected replacement')
+        self.assertIn('etcd', roles,
+                      'etcd role not found in replacement')
+        self.assertNotIn('kube-master', roles,
+                         'kube-master role found in replacement')
+        self.assertIn('kube-minion', roles,
+                      'kube-minion role not found in replacement')
+
+        # however, we can migrate only the etcd role to another minion
+        # (as it is a user provided replacement, it will raise an exception)
+        with self.assertRaises(ExecutionAborted):
+            replacement, roles = get_replacement_for(self.minion_1,
+                                                     replacement=self.minion_3,
+                                                     **self.get_replacement_for_kwargs)
+
+    def test_user_provided_for_minion(self):
+        '''
+        Check the user-provided minion replacement is valid,
+        at least for some roles
+        '''
+        replacement, roles = get_replacement_for(self.minion_3,
+                                                 replacement=self.other_node,
+                                                 **self.get_replacement_for_kwargs)
+
+        # the minion role should be migrated to other_node
+        self.assertEqual(replacement, self.other_node,
+                         'unexpected replacement')
+        self.assertNotIn('etcd', roles,
+                         'etcd role found in replacement')
+        self.assertNotIn('kube-master', roles,
+                         'kube-master role found in replacement')
+        self.assertIn('kube-minion', roles,
+                      'kube-minion role not found in replacement')
+
+    def test_invalid_etcd_replacement(self):
+        '''
+        Check get_replacement_for() realizes a minion
+        is not a valid replacement for a master & etcd.
+        '''
+        # the master role cannot be migrated to a minion
+        with self.assertRaises(ExecutionAborted):
+            replacement, roles = get_replacement_for(self.master_2,
+                                                     replacement=self.minion_3,
+                                                     **self.get_replacement_for_kwargs)
+
+    def test_forbidden_replacement(self):
+        '''
+        Check get_replacement_for() realizes the CA
+        is not a valid replacement.
+        '''
+        # the master role cannot be migrated to a CA
+        with self.assertRaises(ExecutionAborted):
+            replacement, roles = get_replacement_for(self.master_2,
+                                                     replacement=self.ca,
+                                                     **self.get_replacement_for_kwargs)
+
+    def test_forbidden_target(self):
+        '''
+        Check get_replacement_for() realizes the CA
+        cannot be removed
+        '''
+        with self.assertRaises(ExecutionAborted):
+            replacement, roles = get_replacement_for(self.ca,
+                                                     replacement=self.minion_3,
+                                                     **self.get_replacement_for_kwargs)
+
+    @unittest.skipIf(not _mocking_lib_available,
+                     "no mocking library available (install rpm:python-mock)")
+    def test_auto_etcd_replacement(self):
+        '''
+        Check we can get a replacement for a master, migrating all the
+        roles we can to that replacement...
+        '''
+        with patch('caasp_nodes._get_one_for_role', MagicMock(return_value=self.other_node)):
+
+            replacement, roles = get_replacement_for(self.master_2,
+                                                     **self.get_replacement_for_kwargs)
+
+            # we can migrate both the master and the etcd role to a empty node
+            self.assertEqual(replacement, self.other_node,
+                             'unexpected replacement')
+            self.assertIn('etcd', roles,
+                          'etcd role not found in replacement')
+            self.assertIn('kube-master', roles,
+                          'kube-master role not found in replacement')
+            self.assertNotIn('kube-minion', roles,
+                             'kube-minion role found in replacement')
+
+        with patch('caasp_nodes._get_one_for_role', MagicMock(return_value=self.minion_1)):
+
+            replacement, roles = get_replacement_for(self.master_2,
+                                                     **self.get_replacement_for_kwargs)
+
+            # we can only migrate the etcd role (and not the master role) to a minion
+            self.assertEqual(replacement, self.minion_1,
+                             'unexpected replacement')
+            self.assertIn('etcd', roles,
+                          'etcd role not found in replacement')
+            self.assertNotIn('kube-master', roles,
+                             'kube-master role not found in replacement')
+
+
+class TestGetExprAffectedBy(unittest.TestCase):
+    '''
+    Some basic tests for get_expr_affected_by()
+    '''
+
+    def setUp(self):
+        self.ca = 'ca'
+        self.master_1 = 'master_1'
+        self.master_2 = 'master_2'
+        self.master_3 = 'master_3'
+        self.minion_1 = 'minion_1'
+        self.minion_2 = 'minion_2'
+        self.minion_3 = 'minion_3'
+        self.other_node = 'other_node'
+        self.only_etcd_1 = 'only_etcd_1'
+
+        self.masters = [self.master_1, self.master_2, self.master_3]
+        self.etcd_members = [self.master_1, self.master_2,
+                             self.master_3, self.only_etcd_1]
+        self.minions = [self.minion_1, self.minion_2, self.minion_3]
+
+        self.common_expected_affected_matches = [
+            'G@bootstrap_complete:true',
+            'not G@bootstrap_in_progress:true',
+            'not G@update_in_progress:true',
+            'not G@removal_in_progress:true',
+            'not G@addition_in_progress:true'
+        ]
+
+    def test_get_expr_affected_by_master_removal(self):
+        '''
+        Calculate the exporession for matching nodes affected by
+        a master (k8s master & etcd) node removal
+        '''
+        affected_expr = get_expr_affected_by(self.master_1,
+                                             masters=self.masters,
+                                             minions=self.minions,
+                                             etcd_members=self.etcd_members)
+
+        affected_items = affected_expr.split(' and ')
+        expected_matches = self.common_expected_affected_matches + [
+            'P@roles:(admin|etcd|kube-master|kube-minion)',
+            'not L@master_1',
+        ]
+
+        for expr in expected_matches:
+            self.assertIn(expr, affected_items,
+                          '{} is not in affected in expr: {}'.format(expr, affected_expr))
+
+    def test_get_expr_affected_by_etcd_removal(self):
+        '''
+        Calculate the expression for matching nodes affected by
+        a etcd-only node removal
+        '''
+        affected_expr = get_expr_affected_by(self.only_etcd_1,
+                                             masters=self.masters,
+                                             minions=self.minions,
+                                             etcd_members=self.etcd_members)
+
+        affected_items = affected_expr.split(' and ')
+        expected_matches = self.common_expected_affected_matches + [
+            'P@roles:(etcd|kube-master)',
+            'not L@only_etcd_1']
+
+        for expr in expected_matches:
+            self.assertIn(expr, affected_items,
+                          '{} is not in affected in expr: {}'.format(expr, affected_expr))
+
+    def test_get_expr_affected_by_etcd_removal_with_excluded(self):
+        '''
+        Same test, but with some excluded node
+        '''
+        affected_expr = get_expr_affected_by(self.only_etcd_1,
+                                             excluded=[self.master_2],
+                                             masters=self.masters,
+                                             minions=self.minions,
+                                             etcd_members=self.etcd_members)
+
+        affected_items = affected_expr.split(' and ')
+        expected_matches = self.common_expected_affected_matches + [
+            'P@roles:(etcd|kube-master)',
+            'not L@master_2,only_etcd_1']
+
+        for expr in expected_matches:
+            self.assertIn(expr, affected_items,
+                          '{} is not in affected in expr: {}'.format(expr, affected_expr))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/salt/_modules/tests/tests.sh
+++ b/salt/_modules/tests/tests.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+python -m unittest discover --top .. --verbose $@

--- a/salt/_states/caasp_etcd.py
+++ b/salt/_states/caasp_etcd.py
@@ -14,6 +14,9 @@ DEFAULT_ATTEMPTS = 10
 # ... and the interval between them
 DEFAULT_ATTEMPTS_INTERVAL = 2
 
+# default etcd peer port
+ETCD_PEER_PORT = 2380
+
 
 def etcdctl(name, retry={}, **kwargs):
     '''
@@ -42,8 +45,11 @@ def member_add(name, **kwargs):
     '''
     Add this node to the etcd cluster
     '''
+    port = kwargs.pop('port', ETCD_PEER_PORT)
+
     this_id = __salt__['grains.get']('id')
-    this_peer_url = 'https://' + __salt__['grains.get']('nodename') + ':2380'
+    this_nodename = __salt__['caasp_net.get_nodename']()
+    this_peer_url = 'https://{}:{}'.format(this_nodename, port)
 
     name = 'member add {} {}'.format(this_id, this_peer_url)
     log.debug('CaaS: adding etcd member')

--- a/salt/orch/removal.sls
+++ b/salt/orch/removal.sls
@@ -1,164 +1,19 @@
 # must provide the node (id) to be removed in the 'target' pillar
 {%- set target = salt['pillar.get']('target') %}
 
-# ... and we can provide an optional replacement node, and
-# this Salt code will always trust that node as a valid replacement
-{%- set replacement = salt['pillar.get']('replacement', '') %}
-{%- set replacement_provided = (replacement != '') %}
-{%- set replacement_roles = [] %}
-
-
-{##############################
- # preparations
- #############################}
-
-{#- check: we cannot try to remove some 'virtual' nodes #}
-{%- set forbidden = salt.saltutil.runner('mine.get', tgt='P@roles:(admin|ca)', fun='network.interfaces', tgt_type='compound').keys() %}
-{%- if target in forbidden %}
-  {%- do salt.caasp_log.abort('CaaS: %s cannot be removed: it has a "ca" or "admin" role', target) %}
-{%- elif replacement in forbidden %}
-  {%- do salt.caasp_log.abort('CaaS: %s cannot be replaced by %s: the replacement has a "ca" or "admin" role', target, replacement) %}
-{%- endif %}
-
 {%- set etcd_members = salt.saltutil.runner('mine.get', tgt='G@roles:etcd',        fun='network.interfaces', tgt_type='compound').keys() %}
 {%- set masters      = salt.saltutil.runner('mine.get', tgt='G@roles:kube-master', fun='network.interfaces', tgt_type='compound').keys() %}
 {%- set minions      = salt.saltutil.runner('mine.get', tgt='G@roles:kube-minion', fun='network.interfaces', tgt_type='compound').keys() %}
 
-{#
- # replacement for etcd members
- #}
-{%- if target in etcd_members %}
-  {%- if not replacement %}
-    {# we must choose another node and promote it to be an etcd member #}
-    {%- set replacement = salt.caasp_etcd.get_replacement_for_member() %}
-  {%- endif %}
+{#- ... and we can provide an optional replacement node #}
+{%- set replacement = salt['pillar.get']('replacement', '') %}
 
-  {# check if the replacement provided is valid #}
-  {%- if replacement %}
-    {%- set bootstrapped_etcd_members = salt.saltutil.runner('mine.get', tgt='G@roles:etcd and G@bootstrap_complete:true', fun='network.interfaces', tgt_type='compound').keys() %}
-    {%- if replacement in bootstrapped_etcd_members %}
-      {%- do salt.caasp_log.warn('CaaS: the replacement for the etcd server %s cannot be %s: another etcd server is already running there', target, replacement) %}
-      {%- if replacement_provided %}
-        {%- do salt.caasp_log.abort('CaaS: fatal!! the user provided replacement %s cannot be used', replacement) %}
-      {%- endif %}
-      {%- set replacement = '' %}
-    {%- endif %}
-  {%- endif %}
-
-  {%- if replacement %}
-    {%- do salt.caasp_log.debug('CaaS: setting %s as the replacement for the etcd member %s', replacement, target) %}
-    {%- do replacement_roles.append('etcd') %}
-  {%- elif etcd_members|length > 1 %}
-    {%- do salt.caasp_log.warn('CaaS: number of etcd members will be reduced to %d, as no replacement for %s has been found (or provided)', etcd_members|length, target) %}
-  {%- else %}
-    {#- we need at least one etcd server #}
-    {%- do salt.caasp_log.abort('CaaS: cannot remove etcd member %s: too few etcd members, and no replacement found or provided', target) %}
-  {%- endif %}
-{%- endif %} {# target in etcd_members #}
-
-{#
- # replacement for k8s masters
- #}
-{%- if target in masters %}
-  {%- if not replacement %}
-    {# TODO: implement a replacement finder for k8s masters #}
-    {# NOTE: even if no `replacement` was provided in the pillar,
-     #       we probably have one at this point: if the master was
-     #       running etcd as well, we have already tried to find
-     #       a replacement in the previous step...
-     #       however, we must verify that the etcd replacement
-     #       is a valid k8s master replacement too.
-     #       (ideally we should find the union of etcd and
-     #       masters candidates)
-     #}
-  {%- endif %}
-
-  {# check if the replacement provided/found is valid #}
-  {%- if replacement %}
-    {%- set bootstrapped_masters = salt.saltutil.runner('mine.get', tgt='G@roles:kube-master and G@bootstrap_complete:true', fun='network.interfaces', tgt_type='compound').keys() %}
-    {%- if replacement in bootstrapped_masters %}
-      {%- do salt.caasp_log.warn('CaaS: error!! the replacement for an k8s master %s cannot be %s: another k8s master is already running there', target, replacement) %}
-      {%- if replacement_provided %}
-        {%- do salt.caasp_log.abort('CaaS: fatal!! the user provided replacement %s cannot be used', replacement) %}
-      {%- endif %}
-      {%- set replacement = '' %}
-    {%- elif replacement in minions %}
-      {%- do salt.caasp_log.warn('CaaS: warning!! will not replace the k8s master at %s: the replacement found/provided is the k8s minion %s', target, replacement) %}
-      {%- if replacement_provided %}
-        {%- do salt.caasp_log.abort('CaaS: fatal!! the user provided replacement %s cannot be used', replacement) %}
-      {%- endif %}
-      {%- set replacement = '' %}
-    {%- endif %}
-  {%- endif %}
-
-  {%- if replacement %}
-    {%- do salt.caasp_log.debug('CaaS: setting %s as replacement for the kubernetes master %s', replacement, target) %}
-    {%- do replacement_roles.append('kube-master') %}
-  {%- elif masters|length > 1 %}
-    {%- do salt.caasp_log.warn('CaaS: number of k8s masters will be reduced to %d, as no replacement for %s has been found (or provided)', masters|length, target) %}
-  {%- else %}
-    {#- we need at least one master (for runing the k8s API at all times) #}
-    {%- do salt.caasp_log.abort('CaaS: cannot remove master %s: too few k8s masters, and no replacement found or provided', target) %}
-  {%- endif %}
-{%- endif %} {# target in masters #}
-
-{#
- # replacement for k8s minions
- #}
-{%- if target in minions %}
-  {%- if not replacement %}
-    {# TODO: implement a replacement finder for k8s minions #}
-  {%- endif %}
-
-  {# check if the replacement provided/found is valid #}
-  {# NOTE: maybe the new role has already been assigned in Velum... #}
-  {%- if replacement %}
-    {%- set bootstrapped_minions = salt.saltutil.runner('mine.get', tgt='G@roles:kube-minion and G@bootstrap_complete:true', fun='network.interfaces', tgt_type='compound').keys() %}
-    {%- if replacement in bootstrapped_minions %}
-      {%- do salt.caasp_log.warn('CaaS: warning! replacement for %s, %s, has already been assigned a k8s minion role', target, replacement) %}
-      {%- if replacement_provided %}
-        {%- do salt.caasp_log.abort('CaaS: fatal!! the user provided replacement %s cannot be used', replacement) %}
-      {%- endif %}
-      {%- set replacement = '' %}
-    {%- elif replacement in masters %}
-      {%- do salt.caasp_log.warn('CaaS: will not replace the k8s minion %s: the replacement %s is already a k8s master', target, replacement) %}
-      {%- if replacement_provided %}
-        {%- do salt.caasp_log.abort('CaaS: fatal!! the user provided replacement %s cannot be used', replacement) %}
-      {%- endif %}
-      {%- set replacement = '' %}
-    {%- elif 'kube-master' in replacement_roles %}
-      {%- do salt.caasp_log.warn('CaaS: will not replace the k8s minion %s: the replacement found/provided, %s, is already scheduled for being a new k8s master', target, replacement) %}
-      {%- if replacement_provided %}
-        {%- do salt.caasp_log.abort('CaaS: fatal!! the user provided replacement %s cannot be used', replacement) %}
-      {%- endif %}
-      {%- set replacement = '' %}
-    {%- endif %}
-  {%- endif %}
-
-  {%- if replacement %}
-    {%- do salt.caasp_log.debug('CaaS: setting %s as replacement for the k8s minion %s', replacement, target) %}
-    {%- do replacement_roles.append('kube-minion') %}
-  {%- elif minions|length > 1 %}
-    {%- do salt.caasp_log.warn('CaaS: number of k8s minions will be reduced to %d, as no replacement for %s has been found (or provided)', masters|length, target) %}
-  {%- else %}
-    {#- we need at least one minion (for running dex, kube-dns, etc..) #}
-    {%- do salt.caasp_log.abort('CaaS: cannot remove minion %s: too few k8s minions, and no replacement found or provided', target) %}
-  {%- endif %}
-{%- endif %} {# target in minions #}
-
-{#- other consistency checks... #}
-
-{%- if replacement %}
-  {#- consistency check: if there is a replacement, it must have some (new) role(s) #}
-  {%- if not replacement_roles %}
-    {%- do salt.caasp_log.abort('CaaS: %s cannot be removed: too few etcd members, and no replacement found', target) %}
-  {%- endif %}
-{%- else %}
-  {#- consistency check: if some of the previous checks set replacement to an empty string, clear replacement_roles #}
-  {%- set replacement_roles = [] %}
-{%- endif %}
-
-{#- end other consistency checks... #}
+{#- try to use the user-provided replacement or find a replacement by ourselves #}
+{#- if no valid replacement can be used/found, `replacement` will be '' #}
+{%- set replacement, replacement_roles = salt.caasp_nodes.get_replacement_for(target, replacement,
+                                                                              masters=masters,
+                                                                              minions=minions,
+                                                                              etcd_members=etcd_members) %}
 
 {##############################
  # set grains
@@ -373,45 +228,15 @@ remove-target-salt-key:
 # the etcd server we have just removed (but they would
 # keep working fine as long as we had >1 etcd servers)
 
-{%- set affected_roles = [] %}
+{%- set affected_expr = salt.caasp_nodes.get_expr_affected_by(target,
+                                                              excluded=[replacement],
+                                                              masters=masters,
+                                                              minions=minions,
+                                                              etcd_members=etcd_members) %}
+{%- if affected_expr %}
+  {%- do salt.caasp_log.debug('will high-state machines affected by removal: %s', affected_expr) %}
 
-{%- if target in etcd_members %}
-  {# we must highstate: #}
-  {# * etcd members (ie, peers list in /etc/sysconfig/etcd) #}
-  {%- do affected_roles.append('etcd') %}
-  {# * api servers (ie, etcd endpoints in /etc/kubernetes/apiserver #}
-  {%- do affected_roles.append('kube-master') %}
-{%- endif %}
-
-{%- if target in masters %}
-  {# we must highstate: *}
-  {# * admin (ie, haproxy) #}
-  {%- do affected_roles.append('admin') %}
-  {# * minions (ie, haproxy) #}
-  {%- do affected_roles.append('kube-minion') %}
-{%- endif %}
-
-{%- if target in minions %}
-  {# ok, ok, /etc/hosts will contain the old node, but who cares! #}
-{%- endif %}
-
-{%- if affected_roles %}
-  {%- set excluded_nodes = [target] %}
-  {%- if replacement %}
-    {#- do not try to highstate the replacement again #}
-    {%- do excluded_nodes.append(replacement) %}
-  {%- endif %}
-
-  {%- set affected_expr = 'G@bootstrap_complete:true' +
-                          ' and not G@bootstrap_in_progress:true' +
-                          ' and not G@update_in_progress:true' +
-                          ' and not G@node_removal_in_progress:true' +
-                          ' and P@roles:(' + affected_roles|join('|') + ')' +
-                          ' and not L@' + excluded_nodes|join(',') %}
-
-  {%- do salt.caasp_log.debug('CaaS: applying high state in affected machines: %s', affected_expr) %}
-
-highstate-affected-{{ affected_roles|join('-and-') }}:
+highstate-affected:
   salt.state:
     - tgt: {{ affected_expr }}
     - tgt_type: compound

--- a/salt/orch/update-etc-hosts.sls
+++ b/salt/orch/update-etc-hosts.sls
@@ -2,7 +2,8 @@
                              'G@bootstrap_complete:true and ' +
                              'not G@bootstrap_in_progress:true and ' +
                              'not G@update_in_progress:true and ' +
-                             'not G@removal_in_progress:true' %}
+                             'not G@node_removal_in_progress:true and ' +
+                             'not G@node_addition_in_progress:true' %}
 
 {%- if salt.saltutil.runner('mine.get', tgt=updates_all_target, fun='nodename', tgt_type='compound')|length > 0 %}
 update_pillar:

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -2,7 +2,7 @@ base:
   'roles:ca':
     - match: grain
     - ca
-  'roles:(admin|kube-(master|minion))':
+  'roles:(admin|kube-master|kube-minion|etcd)':
     - match: grain_pcre
     - swap
     - etc-hosts
@@ -23,7 +23,7 @@ base:
     - kube-apiserver
     - kube-controller-manager
     - kube-scheduler
-  'roles:kube-(master|minion)':
+  'roles:(kube-master|kube-minion|etcd)':
     - match: grain_pcre
     - ca-cert
     - repositories


### PR DESCRIPTION
* Do some code cleanups in `caasp_etcd.py` by using  the same logic for getting etcd replacements as
  for getting additional etcd servers when bootstrapping.
* Move most of the removal logic to a `caasp_nodes.py` Python module, as Jinja is not a proper language...
* Add the corresponding unit tests for this new Python code.
* Do not be so strict when finding a replacement: if the replacement is not valid for a k8s master, do not
  make it unsuitable for `etcd` too.
* Use a common replacement finder. New replacement finder for k8s masters and minions.
* Try to use some common logging functions
* Refactor out the `grains.get` code to a new `caasp_grains.py` module (as it is shared by several custom modules)

See https://trello.com/c/O7daOErL

feature#node_removal
