### PR TITLE
Try to resist transient node failures on updates

### DIFF
--- a/salt/orch/update-etc-hosts.sls
+++ b/salt/orch/update-etc-hosts.sls
@@ -1,4 +1,4 @@
-{%- set updates_all_target = 'P@roles:(admin|kube-(master|minion)) and ' +
+{%- set updates_all_target = 'P@roles:(admin|etcd|kube-(master|minion)) and ' +
                              'G@bootstrap_complete:true and ' +
                              'not G@bootstrap_in_progress:true and ' +
                              'not G@update_in_progress:true and ' +


### PR DESCRIPTION
# Description

Try to resist transient node failures on updates, so users can updte the cluster even if some node X is down.

# Testing

This can be tested by
1) orchestrating
2) stopping a Salt minion in a node `X` (it can be any master or worker)
3) then trying to run the update orchestration (it can be forced with a _fake_ orchestration, setting the `tx_reboot_needed:true` grain in all those nodes)

The update orchestration sould succeed and all the nodes but `X` should be udpated.

See https://trello.com/c/irviWd1m

feature#update_on_node_failures