### PR TITLE
Add flannel readiness/liveness probe

### DIFF
--- a/pillar/cni.sls
+++ b/pillar/cni.sls
@@ -3,6 +3,7 @@ flannel:
   image:          'sles12/flannel:0.9.1'
   backend:        'vxlan'
   port:           '8472'    # UDP port to use for sending encapsulated packets. Defaults to kernel default, currently 8472.
+  healthz_port:   '8471'    # TCP port used for flannel healthchecks
 # log level for flanneld service
 # 0 - Generally useful for this to ALWAYS be visible to an operator.
 # 1 - A reasonable default log level if you don't want verbosity.

--- a/salt/cni/kube-flannel.yaml.jinja
+++ b/salt/cni/kube-flannel.yaml.jinja
@@ -103,8 +103,21 @@ spec:
           - "--kube-subnet-mgr"
           - "--v={{ pillar['flannel']['log_level'] }}"
           - "--iface=$(POD_IP)"
+          - "--healthz-ip=$(POD_IP)"
+          - "--healthz-port={{ pillar['flannel']['healthz_port'] }}"
         securityContext:
           privileged: true
+        ports:
+        - name: healthz
+          containerPort: {{ pillar['flannel']['healthz_port'] }}
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
         env:
         - name: POD_IP
           valueFrom:


### PR DESCRIPTION
This makes sure flannel has at least reached the point where it starts the
healthz API endpoint. However, that point in the flannel code is *very* early
and not all that useful for actual health checking. Additionally, as long as
the HTTP gorouting is running, healthz will *always* respond with a 200. It
performs no actual health checking.

Even still, lets include the probe. If flannel gets better health checking,
it will be enabled for us, on the other hand, if flannel doesn't get better
health checking, it's still *very slightly* useful to know that flannel has
at least reached this point in it's code.