### PR TITLE
Wait for dex on the admin node before calling the orchestration done

### DIFF
--- a/salt/addons/dex/init.sls
+++ b/salt/addons/dex/init.sls
@@ -40,18 +40,3 @@ include:
 {{ kubectl("remove-old-dex-clusterrolebinding",
            "delete clusterrolebinding system:dex",
            onlyif="kubectl get clusterrolebinding system:dex") }}
-
-ensure_dex_running:
-  # Wait until the Dex API is actually up and running
-  http.wait_for_successful_query:
-    {% set dex_api_server = "api." + pillar['internal_infra_domain']  -%}
-    {% set dex_api_server_ext = pillar['api']['server']['external_fqdn'] -%}
-    {% set dex_api_port = pillar['dex']['node_port'] -%}
-    - name:       {{ 'https://' + dex_api_server + ':' + dex_api_port }}/.well-known/openid-configuration
-    - wait_for:   300
-    - ca_bundle:  {{ pillar['ssl']['ca_file'] }}
-    - status:     200
-    - header_dict:
-        Host: {{ dex_api_server_ext + ':' + dex_api_port }}
-    - watch:
-      - /etc/kubernetes/addons/dex/

--- a/salt/addons/dex/wait.sls
+++ b/salt/addons/dex/wait.sls
@@ -1,0 +1,12 @@
+ensure-dex-running:
+  # Wait until the Dex API is actually up and running
+  http.wait_for_successful_query:
+    {% set dex_api_server = "api." + pillar['internal_infra_domain']  -%}
+    {% set dex_api_server_ext = pillar['api']['server']['external_fqdn'] -%}
+    {% set dex_api_port = pillar['dex']['node_port'] -%}
+    - name:       {{ 'https://' + dex_api_server + ':' + dex_api_port }}/.well-known/openid-configuration
+    - wait_for:   300
+    - ca_bundle:  {{ pillar['ssl']['ca_file'] }}
+    - status:     200
+    - header_dict:
+        Host: {{ dex_api_server_ext + ':' + dex_api_port }}

--- a/salt/haproxy/haproxy.cfg.jinja
+++ b/salt/haproxy/haproxy.cfg.jinja
@@ -33,14 +33,15 @@ listen kubernetes-master
 {%- if "admin" in salt['grains.get']('roles', []) %}
 # Velum should be able to access Kube API and Dex service as well to get kubeconfig
 listen kubernetes-dex
-        bind {{ bind_ip }}:32000
+        bind {{ bind_ip }}:{{ pillar['dex']['node_port'] }}
         mode tcp
         default-server inter 10s fall 2
         balance roundrobin
         option redispatch
+        option httpchk GET /healthz
 
 {%- for minion_id, nodename in salt['mine.get']('roles:kube-master', 'nodename', 'grain').items() %}
-        server master-{{ nodename }} {{ nodename }}.{{ pillar['internal_infra_domain'] }}:32000 check
+        server master-{{ nodename }} {{ nodename }}.{{ pillar['internal_infra_domain'] }}:{{ pillar['dex']['node_port'] }} check check-ssl port {{ pillar['dex']['node_port'] }} verify none
 {% endfor %}
 
 listen velum

--- a/salt/orch/kubernetes.sls
+++ b/salt/orch/kubernetes.sls
@@ -210,6 +210,19 @@ services-setup:
     - require:
       - reboot-setup
 
+# Velum will connect to dex through the local haproxy instance in the admin node (because the
+# /etc/hosts include the external apiserver pointing to 127.0.0.1). Make sure that before calling
+# the orchestration done, we can access dex from the admin node as Velum would do.
+admin-wait-for-services:
+  salt.state:
+    - tgt: 'roles:admin'
+    - tgt_type: grain
+    - batch: {{ default_batch }}
+    - sls:
+      - addons.dex.wait
+    - require:
+      - services-setup
+
 # This flag indicates at least one bootstrap has completed at some
 # point in time on this node.
 set-bootstrap-complete-flag:
@@ -220,7 +233,7 @@ set-bootstrap-complete-flag:
       - bootstrap_complete
       - true
     - require:
-      - services-setup
+      - admin-wait-for-services
 
 # Ensure the node is marked as finished bootstrapping
 clear-bootstrap-in-progress-flag:

--- a/salt/orch/update.sls
+++ b/salt/orch/update.sls
@@ -375,6 +375,19 @@ services-setup:
     - require:
       - cni-setup
 
+# Velum will connect to dex through the local haproxy instance in the admin node (because the
+# /etc/hosts include the external apiserver pointing to 127.0.0.1). Make sure that before calling
+# the orchestration done, we can access dex from the admin node as Velum would do.
+admin-wait-for-services:
+  salt.state:
+    - tgt: 'roles:admin'
+    - tgt_type: grain
+    - batch: 1
+    - sls:
+      - addons.dex.wait
+    - require:
+      - services-setup
+
 # Remove the now defuct caasp_fqdn grain (Remove for 4.0).
 remove-caasp-fqdn-grain:
   salt.function:
@@ -385,7 +398,7 @@ remove-caasp-fqdn-grain:
     - kwarg:
         destructive: True
     - require:
-      - services-setup
+      - admin-wait-for-services
 
 masters-remove-update-grain:
   salt.function:


### PR DESCRIPTION
When we finish the orchestration all bits and pieces should be working
as expected. Wait for the haproxy on the admin node to be correctly
pointing to dex before finishing the orchestration.