### PR TITLE
[WIP] Add `failureThreshold` and `successThresold` to Dex' liveness probe

### DIFF
--- a/salt/addons/dex/manifests/20-deployment.yaml
+++ b/salt/addons/dex/manifests/20-deployment.yaml
@@ -70,6 +70,8 @@ spec:
         livenessProbe:
           # Give Dex a little time to startup
           initialDelaySeconds: 30
+          failureThreshold: 5
+          successThreshold: 1
           httpGet:
             path: /healthz
             port: https


### PR DESCRIPTION
This is an attempt to have more stable CI runs.