### PR TITLE
Extend certificates to one year lifespan

### DIFF
--- a/pillar/certificates.sls
+++ b/pillar/certificates.sls
@@ -10,7 +10,7 @@ certificate_information:
     ST: Bavaria
   days_valid:
     ca_certificate: 3650
-    certificate: 100
+    certificate: 365
   days_remaining:
     ca_certificate: 90
     certificate: 90


### PR DESCRIPTION
100 days is a very short lifespan, lets bump this to one year - a much more
common value for certificate lifetime.

Related to bsc#1082722