### PR TITLE
Wait for deployments during the orchestration time.

### DIFF
--- a/salt/_macros/kubectl.jinja
+++ b/salt/_macros/kubectl.jinja
@@ -84,3 +84,19 @@
                   watch=["file: " + dest] + kwargs.pop('watch', []),
                   **kwargs) }}
 {%- endmacro %}
+
+#####################################################################
+
+{% macro kubectl_wait_for_deployment(deployment, namespace = 'kube-system', timeout = 600) -%}
+wait-for-{{ deployment }}-deployment:
+  caasp_cmd.run:
+    - name: |-
+        desiredReplicas=$(kubectl --kubeconfig={{ pillar['paths']['kubeconfig'] }} get deployment {{ deployment }} --namespace={{ namespace }} --template {{ '{{.spec.replicas}}' }})
+        readyReplicas=$(kubectl --kubeconfig={{ pillar['paths']['kubeconfig'] }} get deployment {{ deployment }} --namespace={{ namespace }} --template {{ '{{.status.readyReplicas}}' }})
+        availableReplicas=$(kubectl --kubeconfig={{ pillar['paths']['kubeconfig'] }} get deployment {{ deployment }} --namespace={{ namespace }} --template {{ '{{.status.availableReplicas}}' }})
+        updatedReplicas=$(kubectl --kubeconfig={{ pillar['paths']['kubeconfig'] }} get deployment {{ deployment }} --namespace={{ namespace }} --template {{ '{{.status.updatedReplicas}}' }})
+        [ "$readyReplicas" == "$desiredReplicas" ] && [ "$availableReplicas" == "$desiredReplicas" ] && [ "$updatedReplicas" == "$desiredReplicas" ]
+    - retry:
+        attempts: {{ timeout }}
+        interval: 1
+{%- endmacro %}

--- a/salt/addons/dex/deployment-wait.sls
+++ b/salt/addons/dex/deployment-wait.sls
@@ -1,0 +1,3 @@
+{% from '_macros/kubectl.jinja' import kubectl_wait_for_deployment with context %}
+
+{{ kubectl_wait_for_deployment('dex') }}

--- a/salt/addons/dns/deployment-wait.sls
+++ b/salt/addons/dns/deployment-wait.sls
@@ -1,0 +1,3 @@
+{% from '_macros/kubectl.jinja' import kubectl_wait_for_deployment with context %}
+
+{{ kubectl_wait_for_deployment('kube-dns') }}

--- a/salt/addons/tiller/deployment-wait.sls
+++ b/salt/addons/tiller/deployment-wait.sls
@@ -1,0 +1,13 @@
+{% if salt.caasp_pillar.get('addons:tiller', False) %}
+
+{% from '_macros/kubectl.jinja' import kubectl_wait_for_deployment with context %}
+
+{{ kubectl_wait_for_deployment('tiller-deploy') }}
+
+{% else %}
+
+dummy:
+  cmd.run:
+    - name: echo "Tiller addon not enabled in config"
+
+{% endif %}

--- a/salt/orch/kubernetes.sls
+++ b/salt/orch/kubernetes.sls
@@ -210,6 +210,17 @@ services-setup:
     - require:
       - reboot-setup
 
+# Wait for deployments to have the expected number of pods running.
+super-master-wait-for-services:
+  salt.state:
+    - tgt: {{ super_master }}
+    - sls:
+      - addons.dns.deployment-wait
+      - addons.tiller.deployment-wait
+      - addons.dex.deployment-wait
+    - require:
+      - services-setup
+
 # Velum will connect to dex through the local haproxy instance in the admin node (because the
 # /etc/hosts include the external apiserver pointing to 127.0.0.1). Make sure that before calling
 # the orchestration done, we can access dex from the admin node as Velum would do.
@@ -221,7 +232,7 @@ admin-wait-for-services:
     - sls:
       - addons.dex.wait
     - require:
-      - services-setup
+      - super-master-wait-for-services
 
 # This flag indicates at least one bootstrap has completed at some
 # point in time on this node.

--- a/salt/orch/update.sls
+++ b/salt/orch/update.sls
@@ -383,6 +383,17 @@ services-setup:
     - require:
       - cni-setup
 
+# Wait for deployments to have the expected number of pods running.
+super-master-wait-for-services:
+  salt.state:
+    - tgt: {{ super_master }}
+    - sls:
+      - addons.dns.deployment-wait
+      - addons.tiller.deployment-wait
+      - addons.dex.deployment-wait
+    - require:
+      - services-setup
+
 # Velum will connect to dex through the local haproxy instance in the admin node (because the
 # /etc/hosts include the external apiserver pointing to 127.0.0.1). Make sure that before calling
 # the orchestration done, we can access dex from the admin node as Velum would do.
@@ -394,7 +405,7 @@ admin-wait-for-services:
     - sls:
       - addons.dex.wait
     - require:
-      - services-setup
+      - super-master-wait-for-services
 
 # Remove the now defuct caasp_fqdn grain (Remove for 4.0).
 remove-caasp-fqdn-grain:


### PR DESCRIPTION
Additionally to other checks, we should also consider the orchestration
done once that the expected pods are running.

feature#deployment-stability