### PR TITLE
Force drain when trying to drain a node

### DIFF
--- a/salt/kubelet/stop.sls
+++ b/salt/kubelet/stop.sls
@@ -11,7 +11,7 @@ include:
 drain-kubelet:
   cmd.run:
     - name: |
-        kubectl --kubeconfig={{ pillar['paths']['kubeconfig'] }} drain {{ grains['nodename'] }} --ignore-daemonsets --grace-period=300 --timeout=340s
+        kubectl --kubeconfig={{ pillar['paths']['kubeconfig'] }} drain {{ grains['nodename'] }} --force --delete-local-data=true --ignore-daemonsets --grace-period=300 --timeout=340s
     - check_cmd:
       - /bin/true
     - require:


### PR DESCRIPTION
When trying to drain a node we can get an error if the kubelet is
running a pod created by local manifests (manifests living in the
local filesystem):

```
caasp-admin:~ # kubectl drain --ignore-daemonsets caasp-worker-1
node "caasp-worker-1" cordoned
error: unable to drain node "caasp-worker-1", aborting command...

There are pending nodes to be drained:
 caasp-worker-1
error: pods not managed by ReplicationController, ReplicaSet, Job, DaemonSet or StatefulSet (use --force to override): haproxy-caasp-worker-1
```

As opposed to:

```
caasp-admin:~ # kubectl drain --force --ignore-daemonsets caasp-worker-1
node "caasp-worker-1" already cordoned
WARNING: Deleting pods not managed by ReplicationController, ReplicaSet, Job, DaemonSet or StatefulSet: haproxy-caasp-worker-1; Ignoring DaemonSet-managed pods: kube-flannel-vklfc
node "caasp-worker-1" drained
```

Related: bsc#1085980