### PR TITLE
Feature gates

### DIFF
--- a/pillar/args.sls
+++ b/pillar/args.sls
@@ -15,3 +15,9 @@ components:
   proxy:
     # Extra arguments to be passed to kube-proxy.
     args: ''
+
+# kubernetes feature gates to be enabled
+# https://kubernetes.io/docs/reference/feature-gates/
+# params passed to the --feature-gates cli flag.
+kubernetes:
+  feature_gates: ''

--- a/salt/kubernetes-common/config.jinja
+++ b/salt/kubernetes-common/config.jinja
@@ -24,3 +24,16 @@ KUBE_ENABLE_DAEMONSETS=true
 # How the controller-manager, scheduler, and proxy find the apiserver
 # note: we will configure everything with a kubeconfig file
 # KUBE_MASTER=""
+
+# Kubernetes feature gates, by default no feature gate is enabled.
+# Customers can enable feature gates **at their risk** by executing the
+# following command on the admin node:
+#
+#   docker exec $(docker ps | grep velum-dashboard | awk {'print $1'}) entrypoint.sh bundle exec rails runner "Pillar.apply(kubernetes_feature_gates: 'DevicePlugins=true')"
+#
+# This will set the KUBE_FEATURE_GATES flag to `DevicePlugins=true`
+{%- if salt.caasp_pillar.get('kubernetes:feature_gates', '') %}
+KUBE_FEATURE_GATES="--feature-gates={{ pillar['kubernetes']['feature_gates'] }}"
+{%- else %}
+KUBE_FEATURE_GATES=""
+{% endif %}


### PR DESCRIPTION
## Preamble

Right now this PR is made by two commits. The first one is pretty straight forward, the second one is more complicated and needs some discussion.

## The requirement

Kubernetes feature-gates are going to be controlled via a dedicated pillar. We won't expose this pillar inside of Velum because these settings are "dangerous" for the average user; plus they can enable features that we don't support.

The idea is to provide instructions to users who deliberately want to run into this unsupported area of kubernetes. These instructions will involve using some CLI commands.

## Being generic

The first commit allows any kind of feature-gate to be enabled or disabled. This is great because we don't have to provide dedicated boolean pillars for each kind of feature that is supported by kubernetes.

That makes our users independent from us :wink: 

## Going the extra mile (RFC)

The first commit isn't enough to make the feature consumable by our users: we have to expose the pillar through Velum to allow our users to override it.

That means:
  * Extend Velum database: create a new table to store feature-gates (we cannot reuse the generic table we currently have).
  * Extend Velum controller: read the contents of the new table and returns the new pillar through the API.

Finally, from a user perspective toggling feature-gates via the database isn't that fancy. I thought we could do something nicer, so here we go...

Thanks to the second commit users just have to create (or edit) a `/etc/salt/customizations.sls` file on the admin node (outside of any container!) with the custom values chosen by the user. Finally, the user has to issue a `saltutils.sync_all` statement on the salt master.

Basically we would allow our users to quickly overload our pillars by just writing a simple text file.

## Getting even more minimal

While working on this PR I found out we already have a way to provide generic arguments to all the kubernetes components (api-server, kubelet, ...):

https://github.com/kubic-project/salt/blob/85f8aed775b7e358e184a9f9ce78e62deff8c4d3/pillar/args.sls#L2-L17

Right now these pillars are not exported by Velum, which makes them unusable for regular users.

If we accept this `customization.sls` proposal we would allow users to provide custom args to kubernetes components. That would perfectly solve [this FATE request](https://fate.suse.com/324045).

We could even go one step further and remove the feature gates pillar and just instruct our users to take advantage of the `components` pillar.

**Note well:** as you can see the `/srv/pillar` directory is already used by the cloud guys. If you like this approach we would have to clean a little the code to ensure we don't overstep.

What are your thoughts?