### PR TITLE
Fix conflict with the etc-hosts-update orchestration

### DIFF
--- a/salt/_modules/caasp_etcd.py
+++ b/salt/_modules/caasp_etcd.py
@@ -137,7 +137,8 @@ def get_replacement_for_member():
         expr += ' and not G@roles:admin and not G@roles:ca'
         expr += ' and not G@bootstrap_in_progress:true'
         expr += ' and not G@update_in_progress:true'
-        expr += ' and not G@removal_in_progress:true'
+        expr += ' and not G@node_removal_in_progress:true'
+        expr += ' and not G@node_addition_in_progress:true'
         expr += ' and {}'.format(role)
 
         log.debug('CaaS: trying to find an etcd replacement with %s', expr)
@@ -220,12 +221,12 @@ def get_endpoints(with_id=False, skip_this=False, skip_removed=False, port=ETCD_
     It will skip
 
       * current node, when `skip_this=True`
-      * nodes with G@removal_in_progress=true, when `skip_removed=True`
+      * nodes with G@node_removal_in_progress=true, when `skip_removed=True`
 
     '''
     expr = 'G@roles:etcd'
     if skip_removed:
-        expr += ' and not G@removal_in_progress:true'
+        expr += ' and not G@node_removal_in_progress:true'
 
     etcd_members_lst = []
     for (node_id, name) in _get_grain(expr).items():

--- a/salt/etcd/etcd.conf.jinja
+++ b/salt/etcd/etcd.conf.jinja
@@ -29,7 +29,7 @@ ETCD_INITIAL_CLUSTER_TOKEN="{{ pillar['etcd']['token'] }}"
 ETCD_INITIAL_ADVERTISE_PEER_URLS="https://{{ this_addr }}:2380"
 
 {#- we will not use "existing" unless we are adding a new node to the cluster  #}
-{%- if salt['grains.get']('addition_in_progress', False) %}
+{%- if salt['grains.get']('node_addition_in_progress', False) %}
 ETCD_INITIAL_CLUSTER_STATE="existing"
 {%- endif %}
 

--- a/salt/etcd/init.sls
+++ b/salt/etcd/init.sls
@@ -3,8 +3,8 @@ include:
   - ca-cert
   - cert
 
-{%- set addition_in_progress = salt['grains.get']('addition_in_progress', False) %}
-{%- if addition_in_progress %}
+{%- set node_addition_in_progress = salt['grains.get']('node_addition_in_progress', False) %}
+{%- if node_addition_in_progress %}
 
 # add the member to the cluster _before_ `etcd` is started
 # then `etcd` will have to be started with the `existing` flag
@@ -72,7 +72,7 @@ etcd:
       - {{ pillar['ssl']['key_file'] }}
       - {{ pillar['ssl']['ca_file'] }}
       - file: /etc/sysconfig/etcd
-    {%- if addition_in_progress %}
+    {%- if node_addition_in_progress %}
       - add-etcd-to-cluster
     {%- endif %}
   # wait until etcd is actually up and running

--- a/salt/orch/update-etc-hosts.sls
+++ b/salt/orch/update-etc-hosts.sls
@@ -1,4 +1,8 @@
-{%- set updates_all_target = 'P@roles:(admin|kube-(master|minion)) and G@bootstrap_complete:true and not G@bootstrap_in_progress:true and not G@update_in_progress:true and not G@removal_in_progress:true' %}
+{%- set updates_all_target = 'P@roles:(admin|kube-(master|minion)) and ' +
+                             'G@bootstrap_complete:true and ' +
+                             'not G@bootstrap_in_progress:true and ' +
+                             'not G@update_in_progress:true and ' +
+                             'not G@removal_in_progress:true' %}
 
 {%- if salt.saltutil.runner('mine.get', tgt=updates_all_target, fun='nodename', tgt_type='compound')|length > 0 %}
 update_pillar:


### PR DESCRIPTION
Change the meaning of some grains:

  * The old `removal_in_progress`/`addition_in_progress` grains have been renamed to `node_removal_in_progress`/`node_addition_in_progress` (set only on the node that is being removed)
  * `removal_in_progress` is cluster-wide grain now, used for marking that some node is being removed.

We are currently avoiding the `etc-hosts-update` __only on nodes with `removal_in_progress`__, but now it will be set __in all the nodes__ during the whole orchetsration, so this should avoid conflicts with the etc-hosts-update orchestration...

https://bugzilla.suse.com/show_bug.cgi?id=1087108

bsc#1087108