### PR TITLE
Include `ca-cert` and `cert` for the admin node explicitly

### DIFF
--- a/salt/top.sls
+++ b/salt/top.sls
@@ -4,6 +4,8 @@ base:
     - ca
   'roles:(admin|kube-(master|minion))':
     - match: grain_pcre
+    - ca-cert
+    - cert
     - swap
     - etc-hosts
     - proxy
@@ -25,11 +27,9 @@ base:
     - kube-scheduler
   'roles:kube-(master|minion)':
     - match: grain_pcre
-    - ca-cert
     - repositories
     - motd
     - users
-    - cert
     - docker
     - container-feeder
     - kubelet


### PR DESCRIPTION
It is included as a side effect because `velum/init.sls` includes them,
so make it explicit on the top file for the admin too.

feature#deployment-stability