### PR TITLE
[WIP] Node addition orchestration

### DIFF
--- a/salt/_modules/caasp_log.py
+++ b/salt/_modules/caasp_log.py
@@ -26,6 +26,14 @@ def abort(msg, *args, **kwargs):
     raise ExecutionAborted(msg % args)
 
 
+def abort_if(expr, *args, **kwargs):
+    '''
+    Abort if expr is True
+    '''
+    if expr:
+        abort('Assertion failed', *args, **kwargs)
+
+
 def error(msg, *args, **kwargs):
     '''
     Log a error message

--- a/salt/_modules/caasp_utils.py
+++ b/salt/_modules/caasp_utils.py
@@ -1,0 +1,19 @@
+from __future__ import absolute_import
+
+
+def __virtual__():
+    return "caasp_utils"
+
+
+def intersect(a, b):
+    '''
+    Return the intersection of two lists `a` and `b`
+    '''
+    return list(set(a) & set(b))
+
+
+def issubset(a, b):
+    '''
+    Return True if `a` is a subset of `b`
+    '''
+    return set(a).issubset(set(b))

--- a/salt/_modules/tests/test_caasp_etcd.py
+++ b/salt/_modules/tests/test_caasp_etcd.py
@@ -1,0 +1,175 @@
+from __future__ import absolute_import
+
+import unittest
+
+import caasp_etcd
+from caasp_etcd import get_reorg
+
+try:
+    from mock import patch, MagicMock
+except ImportError:
+    _mocking_lib_available = False
+else:
+    _mocking_lib_available = True
+
+
+caasp_etcd.__salt__ = {}
+
+
+class TestGetReorg(unittest.TestCase):
+    '''
+    Some basic tests for get_reorg()
+    '''
+
+    def test_get_reorg(self):
+
+        from caasp_utils import intersect
+        from caasp_nodes import get_from_args_or_with_expr
+
+        mocks_dict = {
+            'caasp_nodes.get_from_args_or_with_expr': get_from_args_or_with_expr,
+            'caasp_utils.intersect': intersect,
+        }
+
+        with patch.dict(caasp_etcd.__salt__, mocks_dict):
+            nodes = ['node{}'.format(i) for i in xrange(10)]
+
+            #
+            # check that
+            #   * 1 new master (without etcd)
+            #   * 1 minion running etcd
+            # leads to 1 etcd migrations
+            #
+            masters = nodes[:2]
+            minions = nodes[2:]
+            etcd_members = [nodes[1], nodes[2]]      # one master and one minion
+
+            new_etcd, old_etcd = get_reorg([nodes[0]],
+                                           masters=masters,
+                                           minions=minions,
+                                           etcd_members=etcd_members)
+
+            self.assertTrue(len(new_etcd) == 1,
+                            'unexpected number of new etcd nodes: got {} (masters={}, minions={}, etc={})'.format(
+                            new_etcd, masters, minions, etcd_members))
+            self.assertTrue(len(old_etcd) == 1,
+                            'unexpected number of old etcd nodes: got {} (masters={}, minions={}, etc={})'.format(
+                            old_etcd, masters, minions, etcd_members))
+            self.assertIn(nodes[0], new_etcd,
+                          'expected node0 to be in the new etcd members, but got {} (masters={}, minions={}, etc={})'.format(
+                          new_etcd, masters, minions, etcd_members))
+            self.assertIn(nodes[2], old_etcd,
+                          'expected node2 to be in the old etcd members, but got {} (masters={}, minions={}, etc={})'.format(
+                          old_etcd, masters, minions, etcd_members))
+
+            #
+            # check that
+            #   * 1 new master and 1 new minion (without etcd)
+            #   * 1 minion running etcd
+            # leads to 1 etcd migration
+            #
+            masters = nodes[:4]
+            minions = nodes[4:]
+            etcd_members = [nodes[2], nodes[3], nodes[4]]
+
+            new_etcd, old_etcd = get_reorg([nodes[0], nodes[5]],
+                                           masters=masters,
+                                           minions=minions,
+                                           etcd_members=etcd_members)
+
+            self.assertTrue(len(new_etcd) == 1,
+                            'unexpected number of new etcd nodes: got {} (masters={}, minions={}, etc={})'.format(
+                            new_etcd, masters, minions, etcd_members))
+            self.assertTrue(len(old_etcd) == 1,
+                            'unexpected number of old etcd nodes: got {} (masters={}, minions={}, etc={})'.format(
+                            old_etcd, masters, minions, etcd_members))
+            self.assertIn(nodes[0], new_etcd,
+                          'expected node0 to be in the new etcd members, but got {} (masters={}, minions={}, etc={})'.format(
+                          new_etcd, masters, minions, etcd_members))
+            self.assertIn(nodes[4], old_etcd,
+                          'expected node4 to be in the old etcd members, but got {} (masters={}, minions={}, etc={})'.format(
+                          old_etcd, masters, minions, etcd_members))
+
+            #
+            # check that
+            #   * 2 new masters without etcd
+            #   * 2 minions running etcd
+            # leads to 2 etcd migrations
+            #
+            masters = nodes[:4]
+            minions = nodes[4:]
+            etcd_members = [nodes[2], nodes[3], nodes[4], nodes[5]]
+
+            new_etcd, old_etcd = get_reorg([nodes[0], nodes[1], nodes[5]],
+                                           masters=masters,
+                                           minions=minions,
+                                           etcd_members=etcd_members)
+
+            self.assertTrue(len(new_etcd) == 2,
+                            'unexpected number of new etcd nodes: got {} (masters={}, minions={}, etc={})'.format(
+                            new_etcd, masters, minions, etcd_members))
+            self.assertTrue(len(old_etcd) == 2,
+                            'unexpected number of old etcd nodes: got {} (masters={}, minions={}, etc={})'.format(
+                            old_etcd, masters, minions, etcd_members))
+            self.assertIn(nodes[0], new_etcd,
+                          'expected node0 to be in the new etcd members, but got {} (masters={}, minions={}, etc={})'.format(
+                          new_etcd, masters, minions, etcd_members))
+            self.assertIn(nodes[1], new_etcd,
+                          'expected node1 to be in the new etcd members, but got {} (masters={}, minions={}, etc={})'.format(
+                          new_etcd, masters, minions, etcd_members))
+            self.assertIn(nodes[4], old_etcd,
+                          'expected node4 to be in the old etcd members, but got {} (masters={}, minions={}, etc={})'.format(
+                          old_etcd, masters, minions, etcd_members))
+            self.assertIn(nodes[5], old_etcd,
+                          'expected node5 to be in the old etcd members, but got {} (masters={}, minions={}, etc={})'.format(
+                          old_etcd, masters, minions, etcd_members))
+
+            #
+            # check that
+            #   * 2 new masters without etcd
+            #   * 1 minion running etcd
+            # leads to only one etcd migration
+            #
+            masters = nodes[:4]
+            minions = nodes[4:]
+            etcd_members = [nodes[2], nodes[3], nodes[4]]
+
+            new_etcd, old_etcd = get_reorg([nodes[0], nodes[1], nodes[5]],
+                                           masters=masters,
+                                           minions=minions,
+                                           etcd_members=etcd_members)
+
+            self.assertTrue(len(new_etcd) == 1,
+                            'unexpected number of new etcd nodes: got {} (masters={}, minions={}, etc={})'.format(
+                            new_etcd, masters, minions, etcd_members))
+            self.assertTrue(len(old_etcd) == 1,
+                            'unexpected number of old etcd nodes: got {} (masters={}, minions={}, etc={})'.format(
+                            old_etcd, masters, minions, etcd_members))
+            self.assertIn(nodes[0], new_etcd,
+                          'expected node0 to be in the new etcd members, but got {} (masters={}, minions={}, etc={})'.format(
+                          new_etcd, masters, minions, etcd_members))
+            self.assertIn(nodes[4], old_etcd,
+                          'expected node4 to be in the old etcd members, but got {} (masters={}, minions={}, etc={})'.format(
+                          old_etcd, masters, minions, etcd_members))
+
+            #
+            # check that
+            #   * 2 new minion without etcd
+            #   * 1 minion running etcd
+            # leads to no etcd migrations
+            #
+            masters = nodes[:4]
+            minions = nodes[4:]
+            etcd_members = [nodes[2], nodes[3], nodes[4]]
+
+            new_etcd, old_etcd = get_reorg([nodes[5], nodes[6]],
+                                           masters=masters,
+                                           minions=minions,
+                                           etcd_members=etcd_members)
+
+            self.assertTrue(len(new_etcd) == 0,
+                            'unexpected number of new etcd nodes: got {} (masters={}, minions={}, etc={})'.format(
+                            new_etcd, masters, minions, etcd_members))
+            self.assertTrue(len(old_etcd) == 0,
+                            'unexpected number of old etcd nodes: got {} (masters={}, minions={}, etc={})'.format(
+                            old_etcd, masters, minions, etcd_members))

--- a/salt/orch/addition.sls
+++ b/salt/orch/addition.sls
@@ -1,0 +1,242 @@
+# must provide a list of nodes (id) to be added in the 'targets' pillar
+# NOTE: all these nodes must be responsive, otherwise this will fail
+{%- set targets = salt['pillar.get']('target') %}
+
+{#- consistency check: targets is a list #}
+{%- do salt.caasp_log.abort_if(len(targets) == 0) %}
+
+{#- Get a list of nodes seem to be down or unresponsive #}
+{#- This sends a "are you still there?" message to all #}
+{#- the nodes and wait for a response, so it takes some time. #}
+{#- Hopefully this list will not be too long... #}
+{%- set nodes_down = salt.saltutil.runner('manage.down') %}
+{%- if nodes_down|length >= 1 %}
+# {{ nodes_down|join(',') }} seem to be down: skipping
+  {%- do salt.caasp_log.debug('nodes "%s" seem to be down: ignored', nodes_down|join(',')) %}
+  {%- set is_responsive_node_tgt = 'not L@' + nodes_down|join(',') %}
+{%- else %}
+# all nodes seem to be up
+  {%- do salt.caasp_log.debug('all nodes seem to be up') %}
+  {#- we cannot leave this empty (it would produce many " and <empty>" targets) #}
+  {%- set is_responsive_node_tgt = '*' %}
+{%- endif %}
+
+{%- set etcd_members = salt.caasp_nodes.get_etcd_members() %}
+{%- set masters      = salt.caasp_nodes.get_masters() %}
+{%- set minions      = salt.caasp_nodes.get_minions() %}
+
+{# the number of etcd masters that should be in the cluster #}
+{%- set num_etcd_members = salt.caasp_etcd.get_cluster_size(masters=masters,
+                                                            minions=minions) %}
+{%- set additional_etcd_members = salt.caasp_etcd.get_additional_etcd_members(num_wanted=num_etcd_members,
+                                                                              etcd_members=etcd_members,
+                                                                              exclude=nodes_down,
+                                                                              only_from=targets) %}
+
+{#- check if we should migrate some etcd server from minions to masters... #}
+{%- set migrated_new_etcd, migrated_old_etcd = salt.caasp_etcd.get_reorg(targets,
+                                                    masters=masters,
+                                                    minions=minions,
+                                                    etcd_members=etcd_members + additional_etcd_members) %}
+{%- if migrated_new_etcd %}
+  {%- do salt.caasp_log.debug('etcds in %s will be migrated to %s', migrated_old_etcd, migrated_new_etcd) %}
+  {%- set additional_etcd_members = additional_etcd_members + migrated_new_etcd %}
+{%- endif %}
+
+{#- consistency check: additional_etcd_members should all be responsive #}
+{%- do salt.caasp_log.abort_if(salt.caasp_utils.intersect(additional_etcd_members, nodes_down)) %}
+
+{#- consistency check: ... and we should not add roles on nodes other than the targets #}
+{%- do salt.caasp_log.abort_if(not salt.caasp_utils.issubset(additional_etcd_members, targets)) %}
+
+{##############################
+ # set grains
+ #############################}
+
+ # Add a cluster-wide `addition_in_progress` flag
+set-cluster-wide-addition-grain:
+  salt.function:
+    - tgt: '{{ is_responsive_node_tgt }}'
+    - name: grains.setval
+    - arg:
+      - addition_in_progress
+      - true
+
+{%- if additional_etcd_members %}
+
+set-etcd-roles:
+  salt.function:
+    - tgt: {{ additional_etcd_members|join(',') }}
+    - tgt_type: list
+    - name: grains.append
+    - arg:
+      - roles
+      - etcd
+    - require:
+      - set-cluster-wide-addition-grain
+
+{%- endif %}
+
+assign-node-addition-grain:
+  salt.function:
+    - tgt: {{ target|join(',') }}
+    - tgt_type: list
+    - name: grains.setval
+    - arg:
+      - node_addition_in_progress
+      - true
+    - require:
+      - set-cluster-wide-addition-grain
+{%- if additional_etcd_members %}
+      - set-etcd-roles
+{%- endif %}
+
+sync-all:
+  salt.function:
+    - tgt: '*'
+    - names:
+      - saltutil.refresh_pillar
+      - saltutil.refresh_grains
+      - mine.update
+      - saltutil.sync_all
+    - require:
+      - assign-node-addition-grain
+
+{##############################
+ # new nodes setup
+ #############################}
+
+highstate-new-nodes:
+  salt.state:
+    - tgt: {{ target|join(',') }}
+    - tgt_type: list
+    - highstate: True
+    - batch: 1
+    - require:
+      - sync-all
+
+kubelet-setup:
+  salt.state:
+    - tgt: {{ target|join(',') }}
+    - tgt_type: list
+    - sls:
+      - kubelet.configure-taints
+      - kubelet.configure-labels
+    - require:
+      - highstate-new-nodes
+
+set-bootstrap-complete-flag:
+  salt.function:
+    - tgt: {{ target|join(',') }}
+    - tgt_type: list
+    - name: grains.setval
+    - arg:
+      - bootstrap_complete
+      - true
+    - require:
+      - kubelet-setup
+
+# remove the we-are-adding-this-node grain
+remove-addition-grain:
+  salt.function:
+    - tgt: {{ target|join(',') }}
+    - tgt_type: list
+    - name: grains.delval
+    - arg:
+      - node_addition_in_progress
+    - kwarg:
+        destructive: True
+    - require:
+      - set-bootstrap-complete-flag
+
+{##############################
+ # stop old etcd members
+ #############################}
+
+# the new nodes should be ready at this point:
+
+{%- if migrated_old_etcd %}
+
+# we can stop the old etcd servers we have migrated
+stop-etcd-at-minions:
+  salt.state:
+    - tgt: {{ migrated_old_etcd|join(',') }}
+    - tgt_type: list
+    - batch: 1
+    - sls:
+      - etcd.remove-pre-stop-services
+      - etcd.stop
+    - require:
+      - remove-addition-grain
+
+# remove the `etcd` roles on these nodes
+remove-etcd-role:
+  salt.function:
+    - tgt: {{ migrated_old_etcd|join(',') }}
+    - tgt_type: list
+    - name: grains.remove
+    - arg:
+      - roles
+      - etcd
+    - require:
+      - stop-etcd-at-minions
+
+{%- endif %} {#- migrated_old_etcd #}
+
+{##############################
+ # highstate affected
+ #############################}
+
+{%- set affected_expr = salt.caasp_nodes.get_expr_affected_by(targets + migrated_old_etcd,
+                                                              masters=masters,
+                                                              minions=minions,
+                                                              etcd_members=etcd_members,
+                                                              included=migrated_old_etcd) %}
+{%- if affected_expr %}
+  {%- do salt.caasp_log.debug('will high-state machines affected by the addition: %s', affected_expr) %}
+
+# We should update some things in rest of the machines
+# in the cluster
+
+sync-grains:
+  salt.function:
+    - tgt: '*'
+    - names:
+      - saltutil.refresh_pillar
+      - saltutil.refresh_grains
+      - mine.update
+      - saltutil.sync_all
+    - require:
+      - remove-addition-grain
+  {%- if migrated_old_etcd %}
+      - remove-etcd-role
+  {%- endif %}
+
+highstate-affected:
+  salt.state:
+    - tgt: {{ affected_expr }}
+    - tgt_type: compound
+    - highstate: True
+    - batch: 1
+    - require:
+      - sync-grains
+
+{%- endif %} {#- affected_expr #}
+
+# Remove the cluster-wide `addition_in_progress` flag
+remove-cluster-wide-addition-grain:
+  salt.function:
+    - tgt: '*'
+    - name: grains.delval
+    - arg:
+      - addition_in_progress
+    - kwarg:
+        destructive: True
+    - require:
+      - remove-addition-grain
+{%- if migrated_old_etcd %}
+      - remove-etcd-role
+{%- endif %}
+{%- if affected_expr %}
+      - highstate-affected
+{%- endif %}

--- a/salt/orch/removal.sls
+++ b/salt/orch/removal.sls
@@ -228,7 +228,7 @@ remove-target-salt-key:
 # the etcd server we have just removed (but they would
 # keep working fine as long as we had >1 etcd servers)
 
-{%- set affected_expr = salt.caasp_nodes.get_expr_affected_by(target,
+{%- set affected_expr = salt.caasp_nodes.get_expr_affected_by([target],
                                                               excluded=[replacement],
                                                               masters=masters,
                                                               minions=minions,


### PR DESCRIPTION
# Description

New orchestration for adding nodes: instead of using the regular bootstrap orchestration for adding nodes, it would be better to use a more specific one that could:
    
* migrate etcd servers from minions to masters
* highstate only the nodes that are really affected by the new node
* resist nodes that are unresponsive
    
feature#node_addition
