### PR TITLE
Remove unneeded includes `ca-cert` and `cert` for `velum/init.sls` and `ldap/init.sls`

### DIFF
--- a/salt/ldap/init.sls
+++ b/salt/ldap/init.sls
@@ -1,7 +1,3 @@
-include:
-  - ca-cert
-  - cert
-
 {% set names = [salt.caasp_pillar.get('dashboard'), 'ldap.' + pillar['internal_infra_domain']] %}
 
 {% from '_macros/certs.jinja' import alt_names, certs with context %}

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -4,6 +4,7 @@ base:
     - ca
   'roles:(admin|kube-(master|minion))':
     - match: grain_pcre
+    - ca-cert
     - swap
     - etc-hosts
     - proxy
@@ -25,7 +26,6 @@ base:
     - kube-scheduler
   'roles:kube-(master|minion)':
     - match: grain_pcre
-    - ca-cert
     - repositories
     - motd
     - users

--- a/salt/velum/init.sls
+++ b/salt/velum/init.sls
@@ -1,7 +1,5 @@
 include:
   - etc-hosts
-  - ca-cert
-  - cert
 
 {% set names = [salt.caasp_pillar.get('dashboard_external_fqdn'),
                 salt.caasp_pillar.get('dashboard')] %}


### PR DESCRIPTION
feature#deployment-stability