### PR TITLE
WIP: Sync modules before refreshing grains

### DIFF
--- a/salt/orch/kubernetes.sls
+++ b/salt/orch/kubernetes.sls
@@ -35,14 +35,23 @@ set-etcd-roles:
       - set-bootstrap-in-progress-flag
 {% endif %}
 
-sync-pillar:
-  salt.runner:
-    - name: saltutil.sync_pillar
+update-modules:
+  salt.function:
+    - tgt: '*'
+    - name: saltutil.sync_all
+    - kwarg:
+        refresh: True
     - require:
       - set-bootstrap-in-progress-flag
 {%- if additional_etcd_members|length > 0 %}
       - set-etcd-roles
 {%- endif %}
+
+sync-pillar:
+  salt.runner:
+    - name: saltutil.sync_pillar
+    - require:
+      - update-modules
 
 update-pillar:
   salt.function:
@@ -66,15 +75,6 @@ update-mine:
       - update-pillar
       - update-grains
 
-update-modules:
-  salt.function:
-    - tgt: '*'
-    - name: saltutil.sync_all
-    - kwarg:
-        refresh: True
-    - require:
-      - update-mine
-
 disable-rebootmgr:
   salt.state:
     - tgt: 'roles:(admin|kube-master|minion|etcd)'
@@ -82,7 +82,7 @@ disable-rebootmgr:
     - sls:
       - rebootmgr
     - require:
-      - update-modules
+      - update-mine
 
 etc-hosts-setup:
   salt.state:

--- a/salt/orch/removal.sls
+++ b/salt/orch/removal.sls
@@ -73,10 +73,10 @@ sync-all:
   salt.function:
     - tgt: '*'
     - names:
+      - saltutil.sync_all
       - saltutil.refresh_pillar
       - saltutil.refresh_grains
       - mine.update
-      - saltutil.sync_all
     - require:
       - set-cluster-wide-removal-grain
       - assign-removal-grain

--- a/salt/orch/update.sls
+++ b/salt/orch/update.sls
@@ -40,12 +40,22 @@ set-update-grain:
       - update_in_progress
       - true
 
+update-modules:
+  salt.function:
+    - name: saltutil.sync_all
+    - tgt: '{{ is_responsive_node_tgt }}'
+    - tgt_type: compound
+    - kwarg:
+        refresh: True
+    - require:
+      - set-update-grain
+
 # this will load the _pillars/velum.py on the master
 sync-pillar:
   salt.runner:
     - name: saltutil.sync_pillar
     - require:
-      - set-update-grain
+      - update-modules
 
 update-data:
   salt.function:
@@ -58,16 +68,6 @@ update-data:
     - require:
       - sync-pillar
 
-update-modules:
-  salt.function:
-    - name: saltutil.sync_all
-    - tgt: '{{ is_responsive_node_tgt }}'
-    - tgt_type: compound
-    - kwarg:
-        refresh: True
-    - require:
-      - update-data
-
 # Generate sa key (we should refactor this as part of the ca highstate along with its counterpart
 # in orch/kubernetes.sls)
 generate-sa-key:
@@ -77,7 +77,7 @@ generate-sa-key:
     - sls:
       - kubernetes-common.generate-serviceaccount-key
     - require:
-      - update-modules
+      - update-data
 
 admin-apply-haproxy:
   salt.state:


### PR DESCRIPTION
Modules can provide pillar and grains. We should push those modules out before we
sync the pillar and grains data.