### PR TITLE
Ensure salt master and api configs are complete

### DIFF
--- a/config/master.d/50-api.conf
+++ b/config/master.d/50-api.conf
@@ -1,3 +1,5 @@
+user: root
+
 log_level: info
 log_fmt_console: '%(asctime)s,%(msecs)03d [%(levelname)-8s] %(message)s'
 
@@ -7,12 +9,3 @@ rest_cherrypy:
   ssl_crt: /etc/pki/salt-api.crt
   ssl_key: /etc/pki/salt-api.key
   ssl_chain: /etc/pki/ca.crt
-
-external_auth:
-  pam:
-    saltapi:
-      - .*
-      - '@wheel'
-      - '@runner'
-      - '@jobs'
-      - '@events'

--- a/config/master.d/50-master.conf
+++ b/config/master.d/50-master.conf
@@ -39,3 +39,13 @@ ext_pillar:
   - velum:
       url: https://localhost:444/internal-api/v1/pillar.json
       ca_bundle: /etc/pki/ca.crt
+
+# External Authentication Mechanisms
+external_auth:
+  pam:
+    saltapi:
+      - .*
+      - '@wheel'
+      - '@runner'
+      - '@jobs'
+      - '@events'


### PR DESCRIPTION
This moves the external_auth section over to 50-master.conf, as this is needed
by the salt-master process, and duplicates `user: root` from 50-master.conf to
50-api.conf - which allows salt-api to start and function without it reading
50-master.conf

Related to https://github.com/kubic-project/caasp-container-manifests/pull/171