### PR TITLE
Always try to remove the etcd member

### DIFF
--- a/salt/orch/force-removal.sls
+++ b/salt/orch/force-removal.sls
@@ -3,7 +3,6 @@
 {%- set target_nodename = salt.saltutil.runner('mine.get', tgt=target, fun='nodename')[target] %}
 
 {%- set super_master = salt.saltutil.runner('manage.up', tgt='G@roles:kube-master and not ' + target, expr_form='compound')|first %}
-{%- set etcd_members = salt.saltutil.runner('manage.up', tgt='roles:etcd', expr_form='grain') %}
 
 set-cluster-wide-removal-grain:
   salt.function:
@@ -22,7 +21,6 @@ sync-all:
       - mine.update
       - saltutil.sync_all
 
-{%- if target in etcd_members %}
 unregister-{{ target }}-etcd:
   salt.state:
     - tgt: {{ super_master }}
@@ -31,7 +29,6 @@ unregister-{{ target }}-etcd:
     - fail_minions: {{ super_master }}
     - pillar:
         nodename: {{ target_nodename }}
-{%- endif %}
 
 unregister-{{ target }}-kubelet:
   salt.function:


### PR DESCRIPTION
Don't try to be smart here: always try to unregister the etcd member,
since `manage.up` and `manage.down` won't list the down node using
roles, as salt cannot access it.

Just try to always remove the etcd member, if it's not an etcd member
it's fine, nothing will happen.

Fixes: bsc#1090392