### PR TITLE
Always remove the "we are removing a machine" grain from the cluster

### DIFF
--- a/salt/orch/removal.sls
+++ b/salt/orch/removal.sls
@@ -280,5 +280,3 @@ remove-cluster-wide-removal-grain:
       - removal_in_progress
     - kwarg:
         destructive: True
-    - require:
-      - highstate-affected


### PR DESCRIPTION
Even if the `removal` orchestration has failed, we want to remove this
grain from the cluster, or the subsequent `etc-hosts` orchestrations
won't be executed if a removal failed.

feature#deployment-stability