### PR TITLE
Use get_with_expr() instead of mine.get/saltutil.runner

### DIFF
--- a/salt/_modules/caasp_nodes.py
+++ b/salt/_modules/caasp_nodes.py
@@ -172,6 +172,21 @@ def get_with_expr(expr, **kwargs):
     return res
 
 
+def get_etcd_members(**kwargs):
+    ''' Get the etcd members (accepting the same arguments as `get_with_expr`) '''
+    return get_with_expr('G@roles:etcd', **kwargs)
+
+
+def get_masters(**kwargs):
+    ''' Get the k8s masters (accepting the same arguments as `get_with_expr`) '''
+    return get_with_expr('G@roles:kube-master', **kwargs)
+
+
+def get_minions(**kwargs):
+    ''' Get the k8s minions (accepting the same arguments as `get_with_expr`) '''
+    return get_with_expr('G@roles:kube-minion', **kwargs)
+
+
 def get_from_args_or_with_expr(arg_name, args_dict, *args, **kwargs):
     '''
     Utility function for getting a list of nodes from either the kwargs

--- a/salt/cleanup/remove-post-orchestration.sls
+++ b/salt/cleanup/remove-post-orchestration.sls
@@ -24,7 +24,7 @@ include:
 # etcd node
 ###############
 
-{%- set etcd_members = salt.caasp_nodes.get_with_expr('G@roles:etcd', booted=True) %}
+{%- set etcd_members = salt.caasp_nodes.get_etcd_members(booted=True) %}
 {%- if forced or target in etcd_members %}
 
 etcd-remove-member:

--- a/salt/kube-apiserver/apiserver.jinja
+++ b/salt/kube-apiserver/apiserver.jinja
@@ -31,7 +31,7 @@ KUBE_ADMISSION_CONTROL="--admission-control={{ kube_admission_control|join(',') 
 
 # Add your own!
 KUBE_API_ARGS="--advertise-address={{ salt.caasp_net.get_primary_ip() }} \
-               --apiserver-count={{ salt['mine.get']('roles:kube-master', 'nodename', expr_form='grain').values()|length }} \
+               --apiserver-count={{ salt.caasp_nodes.get_masters()|length }} \
 {%- if cloud_provider %}
                --cloud-provider={{ pillar['cloud']['provider'] }} \
   {%- if cloud_provider == 'openstack' %}

--- a/salt/orch/force-removal.sls
+++ b/salt/orch/force-removal.sls
@@ -1,7 +1,7 @@
 # must provide the node (id) to be removed in the 'target' pillar
 {%- set target = salt['pillar.get']('target') %}
 
-{%- set super_master = salt.saltutil.runner('manage.up', tgt='G@roles:kube-master and not ' + target, expr_form='compound')|first %}
+{%- set super_master = salt.caasp_nodes.get_masters(excluded=[target])|first %}
 
 set-cluster-wide-removal-grain:
   salt.function:

--- a/salt/orch/kubernetes.sls
+++ b/salt/orch/kubernetes.sls
@@ -1,8 +1,8 @@
 {%- set default_batch = 5 %}
 
-{%- set etcd_members = salt.saltutil.runner('mine.get', tgt='G@roles:etcd',        fun='network.interfaces', tgt_type='compound').keys() %}
-{%- set masters      = salt.saltutil.runner('mine.get', tgt='G@roles:kube-master', fun='network.interfaces', tgt_type='compound').keys() %}
-{%- set minions      = salt.saltutil.runner('mine.get', tgt='G@roles:kube-minion', fun='network.interfaces', tgt_type='compound').keys() %}
+{%- set etcd_members = salt.caasp_nodes.get_etcd_members() %}
+{%- set masters      = salt.caasp_nodes.get_masters() %}
+{%- set minions      = salt.caasp_nodes.get_minions() %}
 
 {%- set super_master = masters|first %}
 

--- a/salt/orch/removal.sls
+++ b/salt/orch/removal.sls
@@ -22,9 +22,9 @@
   {%- endif %}
 {%- endif %}
 
-{%- set etcd_members = salt.saltutil.runner('mine.get', tgt='G@roles:etcd',        fun='network.interfaces', tgt_type='compound').keys() %}
-{%- set masters      = salt.saltutil.runner('mine.get', tgt='G@roles:kube-master', fun='network.interfaces', tgt_type='compound').keys() %}
-{%- set minions      = salt.saltutil.runner('mine.get', tgt='G@roles:kube-minion', fun='network.interfaces', tgt_type='compound').keys() %}
+{%- set etcd_members = salt.caasp_nodes.get_etcd_members() %}
+{%- set masters      = salt.caasp_nodes.get_masters() %}
+{%- set minions      = salt.caasp_nodes.get_minions() %}
 
 {%- set super_master_tgt = salt.caasp_nodes.get_super_master(masters=masters,
                                                              excluded=[target] + nodes_down) %}

--- a/salt/orch/update-etc-hosts.sls
+++ b/salt/orch/update-etc-hosts.sls
@@ -5,7 +5,7 @@
                              'not G@removal_in_progress:true and ' +
                              'not G@force_removal_in_progress:true' %}
 
-{%- if salt.saltutil.runner('mine.get', tgt=updates_all_target, fun='nodename', tgt_type='compound')|length > 0 %}
+{%- if salt.caasp_nodes.get_with_expr(updates_all_target)|length > 0 %}
 update_pillar:
   salt.function:
     - tgt: {{ updates_all_target }}

--- a/salt/orch/update.sls
+++ b/salt/orch/update.sls
@@ -30,8 +30,8 @@
 {%- set is_updateable_worker_tgt = is_updateable_tgt + ' and ' + is_worker_tgt %}
 {%- set is_updateable_node_tgt   = '( ' + is_updateable_master_tgt + ' ) or ( ' + is_updateable_worker_tgt + ' )' %}
 
-{%- set all_masters = salt.saltutil.runner('mine.get', tgt=is_master_tgt, fun='network.interfaces', tgt_type='compound').keys() %}
-{%- set super_master = all_masters|first %}
+{%- set all_masters              = salt.caasp_nodes.get_with_expr(is_master_tgt) %}
+{%- set super_master             = all_masters|first %}
 
 # Ensure all nodes with updates are marked as upgrading. This will reduce the time window in which
 # the update-etc-hosts orchestration can run in between machine restarts.
@@ -183,7 +183,7 @@ early-services-setup:
       - etcd-setup
 
 # Get list of masters needing reboot
-{%- set masters = salt.saltutil.runner('mine.get', tgt=is_updateable_master_tgt, fun='network.interfaces', tgt_type='compound') %}
+{%- set masters = salt.caasp_nodes.get_with_expr(is_updateable_master_tgt) %}
 {%- for master_id in masters.keys() %}
 
 # Kubelet needs other services, e.g. the cri, up + running. This provide a way
@@ -341,7 +341,7 @@ all-workers-3.0-pre-clean-shutdown:
         - all-workers-2.0-pre-clean-shutdown
 # END NOTE: Remove me for 4.0
 
-{%- set workers = salt.saltutil.runner('mine.get', tgt=is_updateable_worker_tgt, fun='network.interfaces', tgt_type='compound') %}
+{%- set workers = salt.caasp_nodes.get_with_expr(is_updateable_worker_tgt) %}
 {%- for worker_id, ip in workers.items() %}
 
 # Call the node clean shutdown script

--- a/salt/reboot/init.sls
+++ b/salt/reboot/init.sls
@@ -2,8 +2,7 @@
 # Configuration for the reboot manager
 ##################################################
 
-{%- set etcd_members = salt['mine.get']('G@roles:etcd', 'nodename', expr_form='compound').values() %}
-{%- set etcd_server = etcd_members|first %}
+{%- set etcd_server = salt.caasp_nodes.get_etcd_members()|first %}
 
 {% set reboot_uri = "https://" + etcd_server + ":2379/v2/keys/" + pillar['reboot']['directory'] + "/" +
          pillar['reboot']['group'] %}


### PR DESCRIPTION
## Rationale

We use `mine.get` in many places just for getting etcd members, k8s masters and minions. However, this does not work in the Salt master, so we must use the `saltutil.runner` with different arguments for doing the same thing: getting some list of nodes...

So instead of using these two functions (and after some problems with argument in `mine.get` solved in #496), I think it woud be better to just use the (already present) `get_with_expr` everywhere (or some shortcuts) for getting nodes.

## Changes

* New `get_etcd_members()`, `get_masters()`, `get_minions()` for getting the etcd members, k8s masters and minions.
* Use these shortcuts as well as `get_with_expr()` instead of using mine.get().


feature#cleanup