### PR TITLE
Node removal: fix error when removing grain

### DIFF
--- a/salt/_modules/caasp_nodes.py
+++ b/salt/_modules/caasp_nodes.py
@@ -467,6 +467,9 @@ def get_expr_affected_by(target, **kwargs):
     affected_roles.sort()
     affected_items.append('P@roles:(' + '|'.join(affected_roles) + ')')
 
+    # exclude some roles
+    affected_items.append('not G@roles:ca')
+
     if kwargs.get('exclude_in_progress', True):
         affected_items.append('not G@bootstrap_in_progress:true')
         affected_items.append('not G@update_in_progress:true')


### PR DESCRIPTION
* Fix the `remove-cluster-wide-removal-grain` stage: I forgot the `tgt_type: compound`.
* In some cases (when applying post-bootstrap highstates?), the kubernetes API server can return a `599 Timeout` and our `wait_for_successful_query` seems to fail fast. Retry several times just in case.
* Use the same `cleanup.post-orchestration` that the `forced-removal` uses.
* Some other removal orchestration fixes and improvements.


feature#node_removal