### PR TITLE
[2.1] salt-master config: support public cloud

### DIFF
--- a/config/master.d/50-master.conf
+++ b/config/master.d/50-master.conf
@@ -20,6 +20,8 @@ file_roots:
 pillar_roots:
   base:
     - /usr/share/salt/kubernetes/pillar
+  prod:
+    - /srv/pillar
 
 # The mechanism that provides custom modules to the master
 # is different from that which serves them to the minions.

--- a/config/master.d/50-returner.conf
+++ b/config/master.d/50-returner.conf
@@ -9,7 +9,8 @@ mysql:
 
 ext_pillar:
   - mysql:
-    # This queries allows us to override our pillar values up to a depth of 3.
+    # This queries allows us to override our pillar values up to a depth of 5
+    # and a cloud specific query with a depth of 6.
     #
     # Considering we have on our static pillar:
     #
@@ -73,3 +74,39 @@ ext_pillar:
                        (LENGTH(pillar) - LENGTH(REPLACE(pillar, ":", "")) = 2) AND
                        (minion_id IS NULL OR minion_id = %s)'
       as_list: True
+    # Query for forth level pillar values (three dots in `pillar` key)
+    - query: 'SELECT SUBSTRING_INDEX(SUBSTRING_INDEX(pillar, ":", 1), ":", -1) AS key1,
+                     SUBSTRING_INDEX(SUBSTRING_INDEX(pillar, ":", 2), ":", -1) AS key2,
+                     SUBSTRING_INDEX(SUBSTRING_INDEX(pillar, ":", 3), ":", -1) AS key3,
+                     SUBSTRING_INDEX(SUBSTRING_INDEX(pillar, ":", 4), ":", -1) AS key4,
+                     value
+                     FROM pillars WHERE
+                       (LENGTH(pillar) - LENGTH(REPLACE(pillar, ":", "")) = 3) AND
+                       (minion_id IS NULL OR minion_id = %s)'
+      as_list: True
+    # Query for fifth level pillar values (four dots in `pillar` key)
+    - query: 'SELECT SUBSTRING_INDEX(SUBSTRING_INDEX(pillar, ":", 1), ":", -1) AS key1,
+                     SUBSTRING_INDEX(SUBSTRING_INDEX(pillar, ":", 2), ":", -1) AS key2,
+                     SUBSTRING_INDEX(SUBSTRING_INDEX(pillar, ":", 3), ":", -1) AS key3,
+                     SUBSTRING_INDEX(SUBSTRING_INDEX(pillar, ":", 4), ":", -1) AS key4,
+                     SUBSTRING_INDEX(SUBSTRING_INDEX(pillar, ":", 5), ":", -1) AS key5,
+                     value
+                     FROM pillars WHERE
+                       (LENGTH(pillar) - LENGTH(REPLACE(pillar, ":", "")) = 4) AND
+                       (minion_id IS NULL OR minion_id = %s)'
+      as_list: True
+    # Query for sixth level pillar values (four dots in `pillar` key)
+    # This specificially queries the network_interfaces configuration for EC2,
+    # which requires to be a list
+    - query: 'SELECT SUBSTRING_INDEX(SUBSTRING_INDEX(pillar, ":", 1), ":", -1) AS key1,
+                     SUBSTRING_INDEX(SUBSTRING_INDEX(pillar, ":", 2), ":", -1) AS key2,
+                     SUBSTRING_INDEX(SUBSTRING_INDEX(pillar, ":", 3), ":", -1) AS key3,
+                     SUBSTRING_INDEX(SUBSTRING_INDEX(pillar, ":", 4), ":", -1) AS key4,
+                     SUBSTRING_INDEX(SUBSTRING_INDEX(pillar, ":", 5), ":", -1) AS key5,
+                     SUBSTRING_INDEX(SUBSTRING_INDEX(pillar, ":", 6), ":", -1) AS key6,
+                     value
+                     FROM pillars WHERE
+                       (LENGTH(pillar) - LENGTH(REPLACE(pillar, ":", "")) = 5) AND
+                       (minion_id IS NULL OR minion_id = %s)'
+      as_list: True
+      with_lists: [4]

--- a/config/master.d/50-returner.conf
+++ b/config/master.d/50-returner.conf
@@ -9,8 +9,7 @@ mysql:
 
 ext_pillar:
   - mysql:
-    # This queries allows us to override our pillar values up to a depth of 5
-    # and a cloud specific query with a depth of 6.
+    # These queries allow us to override our pillar values up to a depth of 6
     #
     # Considering we have on our static pillar:
     #
@@ -95,7 +94,7 @@ ext_pillar:
                        (LENGTH(pillar) - LENGTH(REPLACE(pillar, ":", "")) = 4) AND
                        (minion_id IS NULL OR minion_id = %s)'
       as_list: True
-    # Query for sixth level pillar values (four dots in `pillar` key)
+    # Query for sixth level pillar values (five dots in `pillar` key)
     # This specificially queries the network_interfaces configuration for EC2,
     # which requires to be a list
     - query: 'SELECT SUBSTRING_INDEX(SUBSTRING_INDEX(pillar, ":", 1), ":", -1) AS key1,


### PR DESCRIPTION
Configure salt-master to read public cloud pillar
Configure mysql pillar to support public cloud specific datanae pillars
that have more nested levels and also require a list data set.

Depends-On: https://github.com/kubic-project/caasp-container-manifests/pull/172