### PR TITLE
Ensure swap is disabled before kubelet is started

### DIFF
--- a/salt/kubelet/init.sls
+++ b/salt/kubelet/init.sls
@@ -4,6 +4,7 @@ include:
   - cert
   - kubernetes-common
   - kubectl-config
+  - swap
 
 /etc/kubernetes/kubelet-initial:
   file.managed:
@@ -82,6 +83,7 @@ kubelet:
       - file:   /etc/kubernetes/manifests
       - file:   /etc/kubernetes/kubelet-initial
       - kubelet-config
+      - cmd: unmount-swaps
   caasp_retriable.retry:
     - name: iptables-kubelet
     - target: iptables.append


### PR DESCRIPTION
We have to ensure the swap state is executed before the kubelet service is started, otherwise kubelt won't run and this will lead to issues like the ones causing bsc#1090337