### PR TITLE
[2.0] Do not instruct salt to reload the `container-feeder` service

### DIFF
--- a/salt/container-feeder/init.sls
+++ b/salt/container-feeder/init.sls
@@ -9,7 +9,6 @@ include:
 container-feeder:
   service.running:
     - enable: True
-    - reload: True
     - require:
       - cmd: docker
     - watch:


### PR DESCRIPTION
This service does not support reloading, so it doesn't make sense to
ask for a reload of this service. It makes the bootstrap orchestration
fail.

It's a one-shot service, so in any case I doubt we need this in our
salt states at all (always after a new snapshot is booted,
`container-feeder` will load all images first thing) -- the only reason
we should keep this is because it ensures the service is enabled for
a reboot, but when this is ran it's when we are already in the new
snapshot.

Fixes: bsc#1070989