### PR TITLE
[2.0] When we are upgrading between releases (2.0 -> updates), we need to also highstate the admin node as we do on 3.0

### DIFF
--- a/salt/orch/update.sls
+++ b/salt/orch/update.sls
@@ -37,6 +37,14 @@ update_modules:
     - require:
       - salt: update_mine
 
+admin-setup:
+  salt.state:
+    - tgt: 'roles:admin'
+    - tgt_type: grain
+    - highstate: True
+    - require:
+      - update_modules
+
 # Get list of masters needing reboot
 {%- set masters = salt.saltutil.runner('mine.get', tgt='G@roles:kube-master and G@tx_update_reboot_needed:true', fun='network.interfaces', tgt_type='compound') %}
 {%- for master_id in masters.keys() %}


### PR DESCRIPTION
Without doing this, fixes like `fe3e5c8eccd9b48c` render completely
invalid as we won't regenerate the LDAP certificate when the upgrade
happens.

While `fe3e5c8eccd9b48c` fixed the issue for new bootstraps on 2.0
(because the `orch.kubernetes` orchestration highstates the admin),
this would never work with maintenance requests of an already
bootstrapped cluster.

Fixes: bsc#1069175