### PR TITLE
Fix get_primary_ip()

### DIFF
--- a/salt/_modules/caasp_net.py
+++ b/salt/_modules/caasp_net.py
@@ -10,38 +10,41 @@ def __virtual__():
     return "caasp_net"
 
 
-def _get_local_id():
-    return __salt__['grains.get']('id')
-
-
-def get_iface_ip(iface, **kwargs):
+def get_iface_ip(iface, host=None, ifaces=None):
     '''
     given an 'iface' (and an optional 'host' and list of 'ifaces'),
     return the IP address associated with 'iface'
     '''
-    host = kwargs.pop('host', _get_local_id())
-    all_ifaces = __salt__['caasp_grains.get'](host, 'network.interfaces', type='glob')
-    ifaces = kwargs.pop('ifaces', all_ifaces[host])
+    if not ifaces:
+        if not host or host == get_nodename():
+            ifaces = __salt__['network.interfaces']()
+        else:
+            ifaces = __salt__['caasp_grains.get'](host, 'network.interfaces', type='glob')
 
-    return ifaces.get(iface).get('inet', [{}])[0].get('address')
+    iface = ifaces.get(iface)
+    ipv4addr = iface.get('inet', [{}])
+    return ipv4addr[0].get('address')
 
 
-def get_primary_iface(**kwargs):
+def get_primary_iface(host=None):
     '''
     (given some optional 'host')
     return the name of the primary iface (the iface associated with the default route)
     '''
-    host = kwargs.pop('host', _get_local_id())
-    all_routes = __salt__['caasp_grains.get'](host, 'network.default_route', type='glob')
-    return all_routes[host][0]['interface']
+    if not host or host == get_nodename():
+        default_route_lst = __salt__['network.default_route']()
+        return default_route_lst[0]['interface']
+    else:
+        all_routes = __salt__['caasp_grains.get'](host, 'network.default_route', type='glob')
+        return all_routes[host][0]['interface']
 
 
-def get_primary_ip(**kwargs):
+def get_primary_ip(host=None, ifaces=None):
     '''
     (given an optional minion 'host' and a list of its network interfaces, 'ifaces'),
     return the primary IP
     '''
-    return get_iface_ip(get_primary_iface(**kwargs), **kwargs)
+    return get_iface_ip(iface=get_primary_iface(host=host), host=host, ifaces=ifaces)
 
 
 def get_primary_ips_for(compound, **kwargs):
@@ -51,19 +54,15 @@ def get_primary_ips_for(compound, **kwargs):
     '''
     res = []
     all_ifaces = __salt__['caasp_grains.get'](compound, 'network.interfaces')
-    for host in all_ifaces.keys():
-        res.append(get_primary_ip(host=host, **kwargs))
-    return res
+    return [get_primary_ip(host=host, **kwargs) for host in all_ifaces.keys()]
 
 
-def get_nodename(**kwargs):
+def get_nodename(host=None, **kwargs):
     '''
     (given some optional 'host')
     return the `nodename`
     '''
-    _not_provided = object()
-    host = kwargs.pop('host', _not_provided)
-    if host is _not_provided:
+    if not host:
         assert __opts__['__role'] != 'master'
         return __salt__['grains.get']('nodename')
     else:


### PR DESCRIPTION
For some unknown reason `get_primary_ip` is sometimes failing when it tries to find data in the mine for a host. So do not try to use the mine when we can get the same information with a module.

(cherry picked from commit dfd3b8a6a65c7d969466b09a1f20536a525ae42a)

bsc#1091077