### PR TITLE
No not require an external_fqdn: try to guess an IP if no name provided.

### DIFF
--- a/salt/_macros/certs.jinja
+++ b/salt/_macros/certs.jinja
@@ -27,7 +27,7 @@
                        "kubernetes.default.svc",
                        "api",
                        "api." + pillar['internal_infra_domain'],
-                       salt.caasp_pillar.get('api:server:external_fqdn'),
+                       salt.caasp_net.get_external_api_fqdn(),
                        salt.caasp_pillar.get('api:cluster_ip')] +
                        salt.caasp_pillar.get('api:server:extra_names', []) +
                        salt.caasp_pillar.get('api:server:extra_ips', []) +

--- a/salt/_modules/caasp_net.py
+++ b/salt/_modules/caasp_net.py
@@ -5,6 +5,11 @@
 
 from __future__ import absolute_import
 
+# note: do not import caasp modules other than caasp_log
+from caasp_log import abort, debug, error, info, warn
+
+
+EXTERNAL_API_FQDN_PILLAR = 'api:server:external_fqdn'
 
 def __virtual__():
     return "caasp_net"
@@ -69,3 +74,18 @@ def get_nodename(**kwargs):
     else:
         all_nodenames = __salt__['caasp_grains.get'](host, 'nodename', type='glob')
         return all_nodenames[host]
+
+def get_external_api_fqdn():
+    '''
+    Get the external FQDN from the pillar, or provide a reasonable default value
+    '''
+    external_fqdn = __salt__['caasp_pillar.get'](EXTERNAL_API_FQDN_PILLAR)
+    if not external_fqdn:
+        warn('no external fqdn specified in the pillar %s', external_fqdn)
+        try:
+            external_fqdn = get_primary_ips_for('G@roles:kube-master')[0]
+            info('using a master IP: %s', external_fqdn)
+        except:
+            external_fqdn = ''
+
+    return external_fqdn

--- a/salt/addons/dex/manifests/15-configmap.yaml
+++ b/salt/addons/dex/manifests/15-configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: kube-system
 data:
   config.yaml: |
-    issuer: "https://{{ pillar['api']['server']['external_fqdn'] }}:{{ pillar['dex']['node_port'] }}"
+    issuer: "https://{{ salt.caasp_net.get_external_api_fqdn() }}:{{ pillar['dex']['node_port'] }}"
     storage:
       type: kubernetes
       config:

--- a/salt/addons/dex/wait.sls
+++ b/salt/addons/dex/wait.sls
@@ -2,7 +2,7 @@ ensure-dex-running:
   # Wait until the Dex API is actually up and running
   http.wait_for_successful_query:
     {% set dex_api_server = "api." + pillar['internal_infra_domain']  -%}
-    {% set dex_api_server_ext = pillar['api']['server']['external_fqdn'] -%}
+    {% set dex_api_server_ext = salt.caasp_net.get_external_api_fqdn() -%}
     {% set dex_api_port = pillar['dex']['node_port'] -%}
     - name:       {{ 'https://' + dex_api_server + ':' + dex_api_port }}/.well-known/openid-configuration
     - wait_for:   300

--- a/salt/etc-hosts/hosts.jinja
+++ b/salt/etc-hosts/hosts.jinja
@@ -3,9 +3,9 @@
 {%- set this_roles    = salt['grains.get']('roles', []) %}
 
 {%- set internal_fqdn = "api api." + pillar['internal_infra_domain'] -%}
-{%- set external_fqdn = "" -%}
-{%- if not salt['caasp_filters.is_ip'](pillar['api']['server']['external_fqdn']) -%}
-{%- set external_fqdn = pillar['api']['server']['external_fqdn'] -%}
+{%- set external_fqdn = salt.caasp_net.get_external_api_fqdn() -%}
+{%- if salt['caasp_filters.is_ip'](external_fqdn) -%}
+  {%- set external_fqdn = '' -%}
 {%- endif -%}
 
 {%- macro nodes_entries(expr) -%}

--- a/salt/kube-apiserver/apiserver.jinja
+++ b/salt/kube-apiserver/apiserver.jinja
@@ -46,7 +46,7 @@ KUBE_API_ARGS="--advertise-address={{ salt.caasp_net.get_primary_ip() }} \
                --service-account-lookup=true \
                --runtime-config=admissionregistration.k8s.io/v1alpha1 \
                --authorization-mode=Node,RBAC \
-               --oidc-issuer-url=https://{{ pillar['api']['server']['external_fqdn'] }}:{{ pillar['dex']['node_port'] }} \
+               --oidc-issuer-url=https://{{ salt.caasp_net.get_external_api_fqdn() }}:{{ pillar['dex']['node_port'] }} \
                --oidc-client-id=kubernetes \
                --oidc-ca-file={{ pillar['ssl']['ca_file'] }} \
                --oidc-username-claim=email \


### PR DESCRIPTION
We are currently requiring an external API fqdn, but it is not extrictly neccessary as we could just get the IP address of one of the masters.

feature#cleanup