### PR TITLE
Harden the waiting for CRI socket to become active

### DIFF
--- a/pillar/cri.sls
+++ b/pillar/cri.sls
@@ -1,6 +1,6 @@
 cri:
   chosen: 'docker'
-  socket_timeout: 10
+  socket_timeout: 20
   docker:
     description: Docker open-source container engine
     package: docker

--- a/salt/_modules/caasp_cri.py
+++ b/salt/_modules/caasp_cri.py
@@ -199,13 +199,18 @@ def __wait_CRI_socket():
     '''
 
     socket = cri_runtime_endpoint()
-    timeout = int(__salt__['pillar.get']('cri:socket_timeout', '10'))
+    timeout = int(__salt__['pillar.get']('cri:socket_timeout', '20'))
     expire = time.time() + timeout
 
     while time.time() < expire:
         if os.path.exists(socket):
             return
         time.sleep(0.3)
+
+    raise CommandExecutionError(
+        'CRI socket did not become ready',
+        info={'errors': ['CRI socket did not become ready']}
+    )
 
 
 def needs_docker():


### PR DESCRIPTION
* Allow more time for the CRI socket to become active - 60 seconds
* Explicitly fail if the socket does not become active within this
  time.

Related to bsc#1091419