### PR TITLE
Make crictl handling more robust

### DIFF
--- a/salt/_modules/caasp_cri.py
+++ b/salt/_modules/caasp_cri.py
@@ -197,14 +197,18 @@ def __wait_CRI_socket():
     at bootstrap time, where the CRI is not yet running
     but some state interacting with it is applied.
     '''
-
-    socket = cri_runtime_endpoint()
     timeout = int(__salt__['pillar.get']('cri:socket_timeout', '20'))
     expire = time.time() + timeout
 
     while time.time() < expire:
-        if os.path.exists(socket):
+        cmd = "crictl --runtime-endpoint {socket} info".format(
+                socket=cri_runtime_endpoint())
+        result = __salt__['cmd.run_all'](cmd,
+                                         output_loglevel='trace',
+                                         python_shell=False)
+        if result['retcode'] == 0:
             return
+
         time.sleep(0.3)
 
     raise CommandExecutionError(

--- a/salt/_modules/caasp_nodes.py
+++ b/salt/_modules/caasp_nodes.py
@@ -500,3 +500,15 @@ def get_super_master(**kwargs):
             return master
 
     return ''
+
+
+def is_admin_node():
+    '''
+    Returns true if the node has the 'admin' and/or the 'ca'
+    roles.
+
+    Returns false otherwise
+    '''
+
+    node_roles = __salt__['grains.get']('roles', [])
+    return any(role in ('admin', 'ca') for role in node_roles)

--- a/salt/container-feeder/init.sls
+++ b/salt/container-feeder/init.sls
@@ -19,7 +19,7 @@ container-feeder:
   service.running:
     - enable: True
     - require:
-      {% if not salt.caasp_cri.needs_docker() %}
+      {% if not salt.caasp_nodes.is_admin_node() %}
       # the admin node uses docker as CRI, requiring its state
       # will cause the docker daemon to be restarted, which will
       # lead to the premature termination of the orchestration.
@@ -32,7 +32,7 @@ container-feeder:
       - file: /etc/sysconfig/container-feeder
       - file: /etc/container-feeder.json
     - watch:
-      {% if not salt.caasp_cri.needs_docker() %}
+      {% if not salt.caasp_nodes.is_admin_node() %}
       - service: {{ pillar['cri'][salt.caasp_cri.cri_name()]['service'] }}
       {% endif %}
       - file: /etc/containers/storage.conf

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -7,7 +7,13 @@ base:
     - ca-cert
     - cri
     - container-feeder
-    {% if not salt.caasp_cri.needs_docker() %}
+    {% if not salt.caasp_nodes.is_admin_node() %}
+      # the admin node uses docker as CRI, requiring its state
+      # will cause the docker daemon to be restarted, which will
+      # lead to the premature termination of the orchestration.
+      # Hence let's not require docker on the admin node.
+      # This is not a big deal because the admin node has already
+      # working since the boot time.
     - {{ salt['pillar.get']('cri:chosen', 'docker') }}
     {% endif %}
     - swap


### PR DESCRIPTION
Some of our states are now depending on `crictl` tool. All these states have to depend on the `kubelet service.running` one, otherwise the `crictl` socket won't be available and the state will fail.

Also, with these changes, the "blame" of a failure should point directly to the guilty (`kubelet` service not running for whatever reason) instead of falling on the `haproxy` one.

Finally, the check looking for `crictl` socket has been changed to ensure the socket file exists and the service is actually listening.

This will help with bugs like bsc#1091419