### PR TITLE
Try to resist inexistent data in the mine

### DIFF
--- a/pillar/params.sls
+++ b/pillar/params.sls
@@ -28,6 +28,10 @@ services_cidr:    '172.24.0.0/16'
 internal_infra_domain: 'infra.caasp.local'
 ldap_internal_infra_domain: 'dc=infra,dc=caasp,dc=local'
 
+hw:
+  # fallback value when we cannot detect the default interface
+  netiface: 'eth0'
+
 api:
   # the API service IP (must be inside the 'services_cidr')
   cluster_ip:     '172.24.0.1'

--- a/salt/_modules/caasp_net.py
+++ b/salt/_modules/caasp_net.py
@@ -6,6 +6,13 @@
 from __future__ import absolute_import
 
 
+# note: do not import caasp modules other than caasp_log
+from caasp_log import error
+
+
+DEFAULT_INTERFACE = 'eth0'
+
+
 def __virtual__():
     return "caasp_net"
 
@@ -15,15 +22,19 @@ def get_iface_ip(iface, host=None, ifaces=None):
     given an 'iface' (and an optional 'host' and list of 'ifaces'),
     return the IP address associated with 'iface'
     '''
-    if not ifaces:
-        if not host or host == get_nodename():
-            ifaces = __salt__['network.interfaces']()
-        else:
-            ifaces = __salt__['caasp_grains.get'](host, 'network.interfaces', type='glob')
+    try:
+        if not ifaces:
+            if not host or host == get_nodename():
+                ifaces = __salt__['network.interfaces']()
+            else:
+                ifaces = __salt__['caasp_grains.get'](host, 'network.interfaces', type='glob')
 
-    iface = ifaces.get(iface)
-    ipv4addr = iface.get('inet', [{}])
-    return ipv4addr[0].get('address')
+        iface = ifaces.get(iface)
+        ipv4addr = iface.get('inet', [{}])
+        return ipv4addr[0].get('address')
+    except Exception as e:
+        error('could not get IP for interface %s: %s', iface, e)
+        return ''
 
 
 def get_primary_iface(host=None):
@@ -31,12 +42,16 @@ def get_primary_iface(host=None):
     (given some optional 'host')
     return the name of the primary iface (the iface associated with the default route)
     '''
-    if not host or host == get_nodename():
-        default_route_lst = __salt__['network.default_route']()
-        return default_route_lst[0]['interface']
-    else:
-        all_routes = __salt__['caasp_grains.get'](host, 'network.default_route', type='glob')
-        return all_routes[host][0]['interface']
+    try:
+        if not host or host == get_nodename():
+            default_route_lst = __salt__['network.default_route']()
+            return default_route_lst[0]['interface']
+        else:
+            all_routes = __salt__['caasp_grains.get'](host, 'network.default_route', type='glob')
+            return all_routes[host][0]['interface']
+    except Exception as e:
+        error('could not get the primary interface: %s', e)
+        return __salt__['caasp_pillar.get']('hw:netiface', DEFAULT_INTERFACE)
 
 
 def get_primary_ip(host=None, ifaces=None):
@@ -52,9 +67,13 @@ def get_primary_ips_for(compound, **kwargs):
     given a compound expression 'compound', return the primary IPs for all the
     nodes that match that expression
     '''
-    res = []
-    all_ifaces = __salt__['caasp_grains.get'](compound, 'network.interfaces')
-    return [get_primary_ip(host=host, **kwargs) for host in all_ifaces.keys()]
+    try:
+        res = []
+        all_ifaces = __salt__['caasp_grains.get'](compound, 'network.interfaces')
+        return [get_primary_ip(host=host, **kwargs) for host in all_ifaces.keys()]
+    except Exception as e:
+        error('could not get primary IPs for %s: %s', compound, e)
+        return []
 
 
 def get_nodename(host=None, **kwargs):
@@ -62,9 +81,13 @@ def get_nodename(host=None, **kwargs):
     (given some optional 'host')
     return the `nodename`
     '''
-    if not host:
-        assert __opts__['__role'] != 'master'
-        return __salt__['grains.get']('nodename')
-    else:
-        all_nodenames = __salt__['caasp_grains.get'](host, 'nodename', type='glob')
-        return all_nodenames[host]
+    try:
+        if not host:
+            assert __opts__['__role'] != 'master'
+            return __salt__['grains.get']('nodename')
+        else:
+            all_nodenames = __salt__['caasp_grains.get'](host, 'nodename', type='glob')
+            return all_nodenames[host]
+    except Exception as e:
+        error('could not get nodename: %s', e)
+        return ''

--- a/salt/etc-hosts/hosts.jinja
+++ b/salt/etc-hosts/hosts.jinja
@@ -11,14 +11,19 @@
 {%- macro nodes_entries(expr) -%}
   {%- set nodes = salt['mine.get'](expr, 'network.interfaces', 'compound') %}
   {%- for id, ifaces in nodes.items() %}
-    {%- set ip = salt.caasp_net.get_primary_ip(host=id, ifaces=ifaces)%}
-    {%- set nodename = salt.caasp_net.get_nodename(host=id) %}
-    {%- set ns = nodename + ' ' +
-                 nodename + '.' + pillar['internal_infra_domain'] + ' ' +
-                 id + ' ' +
-                 id + '.' + pillar['internal_infra_domain'] %}
+    {%- set ip = salt.caasp_net.get_primary_ip(host=id, ifaces=ifaces) %}
+    {%- if ip|length > 0 %}
+      {%- set nodename = salt.caasp_net.get_nodename(host=id) %}
+      {%- if nodename|length > 0 %}
+        {%- set ns = nodename + ' ' +
+                   nodename + '.' + pillar['internal_infra_domain'] + ' ' +
+                   id + ' ' +
+                   id + '.' + pillar['internal_infra_domain'] %}
 
 {{ ip }} {{ ns }}
+
+      {%- endif %}
+    {%- endif %}
 
     {%- if id == this_id %}
 # try to make Salt happy by adding an ipv6 entry


### PR DESCRIPTION
For some unknown reason, the mine can contain data about a node `X` after removing `X` from the cluster. However, when minions try to get some data about `X` (like the IP address), that information is not there and we get an exception. This problem seems to appear only when generating the `/etc/hosts` file.

This PR tries to resist that data missing by just returning empty values and skipping these hosts in `/etc/hosts`. Some hosts will have an entry for node `X` in  their `/etc/hosts` while some others will not...

https://bugzilla.suse.com/show_bug.cgi?id=1091361

bsc#1091361