### PR TITLE
kubelet: allow resource reservation

### DIFF
--- a/pillar/params.sls
+++ b/pillar/params.sls
@@ -112,6 +112,22 @@ etcd:
 
 kubelet:
   port:           '10250'
+  compute-resources:
+    kube:
+      cpu: ''
+      memory: ''
+      ephemeral-storage: ''
+      # example:
+      # cpu: 100m
+      # memory: 100M
+      # ephemeral-storage: 1G
+    system:
+      cpu: ''
+      memory: ''
+      ephemeral-storage: ''
+    eviction-hard: ''
+    # example:
+    # eviction-hard: memory.available<500M
 
 proxy:
   http:           ''

--- a/salt/_modules/caasp_pillar.py
+++ b/salt/_modules/caasp_pillar.py
@@ -33,3 +33,31 @@ def get(name, default=''):
             return False
 
     return res
+
+
+def get_kubelet_reserved_resources(component):
+    '''
+    Returns the kubelet cli argument specifying the
+    reserved computational resources of the specified component.
+
+    Returns an empty string if no reservations are in place for the specified
+    component.
+
+    Example values for `component`: `kube`, `system`
+
+    See https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
+
+    '''
+    reservations = []
+
+    for resource in ('cpu', 'memory', 'ephemeral-storage'):
+        quantity = get(
+                'kubelet:compute-resources:{component}:{resource}'.format(
+                    component=component,
+                    resource=resource))
+        if quantity:
+            reservations.append('{resource}={quantity}'.format(
+                resource=resource,
+                quantity=quantity))
+
+    return ','.join(reservations)

--- a/salt/kubelet/kubelet.jinja
+++ b/salt/kubelet/kubelet.jinja
@@ -17,6 +17,21 @@ KUBELET_HOSTNAME="--hostname-override={{ grains['nodename'] }}"
 
 # Add your own!
 KUBELET_ARGS="\
+    --cgroups-per-qos \
+    --cgroup-driver=cgroupfs \
+    --cgroup-root=/ \
+    --kube-reserved-cgroup=podruntime.slice \
+{% if salt.caasp_pillar.get_kubelet_reserved_resources('kube') -%}
+    --kube-reserved={{ salt.caasp_pillar.get_kubelet_reserved_resources('kube') }} \
+{% endif -%}
+    --system-reserved-cgroup=system \
+{% if salt.caasp_pillar.get_kubelet_reserved_resources('system') -%}
+    --kube-reserved={{ salt.caasp_pillar.get_kubelet_reserved_resources('system') }} \
+{% endif -%}
+    --enforce-node-allocatable=pods \
+{% if pillar['kubelet']['compute-resources']['eviction-hard'] -%}
+    --eviction-hard={{ pillar['kubelet']['compute-resources']['eviction-hard'] }} \
+{% endif -%}
     --cluster-dns={{ pillar['dns']['cluster_ip'] }} \
     --cluster-domain={{ pillar['dns']['domain'] }} \
     --node-ip={{ salt.caasp_net.get_primary_ip() }} \


### PR DESCRIPTION
Allow kubelet to take into account resource reservation and eviction
threshold.

## Resource reservation

It's possible to reserve resources for the `kube` and the `system`
components.

The `kube` component is the one including the kubernetes components:
api server, controller manager, scheduler, proxy, kubelet and the container
engine components (docker, containerd, cri-o, runc).

The `system` component is the `system.slice`, basically all the system
services: sshd, cron, logrotate,...

By default don't specify any kind of resource reservation. Note well:
when the resource reservations are in place kubelet will reduce the
amount or resources allocatable by the node. However **no** enforcement
will be done neither on the `kube.slice` nor on the `system.slice`.

This is not happening because:

  * Resource enforcement is done using cgroups.
  * The slices are created by systemd.
  * systemd doesn't manage all the available cgroups yet.
  * kubelet tries to manage cgroups that are not handled by systemd,
    resulting in the kubelet failing at startup.
  * Changing the cgroup driver to `systemd` doesn't fix the issue.

Moreover enforcing limits on the `system` and the `kube` slices can lead
to resource starvation of core components of the system. As advised even by
the official kubernetes docs, this is something that only expert users
should do only after extensive profiling of their nodes.

Finally, even if we wanted to enforce the limits, the right place would
be systemd (by tuning the slice settings).

For more information see the official documentation:
https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/

## Eviction threshold

By default no eviction threshold is set.

bsc#1086185

## Future work

I'll create a PR against Velum to allow these pillar values to be overloaded by our users.