### PR TITLE
[3.0] Make HAProxy work as an http proxy instead of a tcp proxy.

### DIFF
--- a/pillar/certificates.sls
+++ b/pillar/certificates.sls
@@ -26,6 +26,7 @@ ssl:
 
   velum_key: '/etc/pki/private/velum.key'
   velum_crt: '/etc/pki/velum.crt'
+  velum_bundle: '/etc/pki/private/velum-bundle.pem'
 
   ldap_key: '/etc/pki/private/ldap.key'
   ldap_crt: '/etc/pki/ldap.crt'
@@ -38,6 +39,10 @@ ssl:
 
   kube_apiserver_key: '/etc/pki/kube-apiserver.key'
   kube_apiserver_crt: '/etc/pki/kube-apiserver.crt'
+
+  kube_apiserver_proxy_key: '/etc/pki/private/kube-apiserver-proxy.key'
+  kube_apiserver_proxy_crt: '/etc/pki/kube-apiserver-proxy.crt'
+  kube_apiserver_proxy_bundle: '/etc/pki/private/kube-apiserver-proxy-bundle.pem'
 
   kube_scheduler_key: '/etc/pki/kube-scheduler.key'
   kube_scheduler_crt: '/etc/pki/kube-scheduler.crt'

--- a/salt/_macros/kubectl.jinja
+++ b/salt/_macros/kubectl.jinja
@@ -11,7 +11,7 @@
 
 {% macro _kubectl_run(args) -%}
   caasp_cmd.run:
-    - name: kubectl --kubeconfig={{ pillar['paths']['kubeconfig'] }} {{ args }}
+    - name: kubectl --request-timeout=1m --kubeconfig={{ pillar['paths']['kubeconfig'] }} {{ args }}
     - retry:
         attempts: 10
         interval: 1
@@ -91,10 +91,10 @@
 wait-for-{{ deployment }}-deployment:
   caasp_cmd.run:
     - name: |-
-        desiredReplicas=$(kubectl --kubeconfig={{ pillar['paths']['kubeconfig'] }} get deployment {{ deployment }} --namespace={{ namespace }} --template {{ '{{.spec.replicas}}' }})
-        readyReplicas=$(kubectl --kubeconfig={{ pillar['paths']['kubeconfig'] }} get deployment {{ deployment }} --namespace={{ namespace }} --template {{ '{{.status.readyReplicas}}' }})
-        availableReplicas=$(kubectl --kubeconfig={{ pillar['paths']['kubeconfig'] }} get deployment {{ deployment }} --namespace={{ namespace }} --template {{ '{{.status.availableReplicas}}' }})
-        updatedReplicas=$(kubectl --kubeconfig={{ pillar['paths']['kubeconfig'] }} get deployment {{ deployment }} --namespace={{ namespace }} --template {{ '{{.status.updatedReplicas}}' }})
+        desiredReplicas=$(kubectl --request-timeout=1m --kubeconfig={{ pillar['paths']['kubeconfig'] }} get deployment {{ deployment }} --namespace={{ namespace }} --template {{ '{{.spec.replicas}}' }})
+        readyReplicas=$(kubectl --request-timeout=1m --kubeconfig={{ pillar['paths']['kubeconfig'] }} get deployment {{ deployment }} --namespace={{ namespace }} --template {{ '{{.status.readyReplicas}}' }})
+        availableReplicas=$(kubectl --request-timeout=1m --kubeconfig={{ pillar['paths']['kubeconfig'] }} get deployment {{ deployment }} --namespace={{ namespace }} --template {{ '{{.status.availableReplicas}}' }})
+        updatedReplicas=$(kubectl --request-timeout=1m --kubeconfig={{ pillar['paths']['kubeconfig'] }} get deployment {{ deployment }} --namespace={{ namespace }} --template {{ '{{.status.updatedReplicas}}' }})
         [ "$readyReplicas" == "$desiredReplicas" ] && [ "$availableReplicas" == "$desiredReplicas" ] && [ "$updatedReplicas" == "$desiredReplicas" ]
     - retry:
         attempts: {{ timeout }}

--- a/salt/addons/dex/init.sls
+++ b/salt/addons/dex/init.sls
@@ -24,19 +24,19 @@ include:
 # TODO: Transitional code, remove for CaaSP v4
 {{ kubectl("remove-old-find-dex-role",
            "delete role find-dex -n kube-system",
-           onlyif="kubectl get role find-dex -n kube-system") }}
+           onlyif="kubectl --request-timeout=1m get role find-dex -n kube-system") }}
 
 # TODO: Transitional code, remove for CaaSP v4
 {{ kubectl("remove-old-find-dex-rolebinding",
            "delete rolebinding find-dex -n kube-system",
-           onlyif="kubectl get rolebinding find-dex -n kube-system") }}
+           onlyif="kubectl --request-timeout=1m get rolebinding find-dex -n kube-system") }}
 
 # TODO: Transitional code, remove for CaaSP v4
 {{ kubectl("remove-old-administrators-in-ldap-clusterrolebinding",
            "delete clusterrolebinding administrators-in-ldap",
-           onlyif="kubectl get clusterrolebinding administrators-in-ldap") }}
+           onlyif="kubectl --request-timeout=1m get clusterrolebinding administrators-in-ldap") }}
 
 # TODO: Transitional code, remove for CaaSP v4
 {{ kubectl("remove-old-dex-clusterrolebinding",
            "delete clusterrolebinding system:dex",
-           onlyif="kubectl get clusterrolebinding system:dex") }}
+           onlyif="kubectl --request-timeout=1m get clusterrolebinding system:dex") }}

--- a/salt/addons/dex/manifests/20-deployment.yaml
+++ b/salt/addons/dex/manifests/20-deployment.yaml
@@ -71,6 +71,7 @@ spec:
         livenessProbe:
           # Give Dex a little time to startup
           initialDelaySeconds: 30
+          timeoutSeconds: 10
           httpGet:
             path: /healthz
             port: https

--- a/salt/addons/dns/init.sls
+++ b/salt/addons/dns/init.sls
@@ -13,7 +13,7 @@ include:
 # TODO: Transitional code, remove for CaaSP v4
 {{ kubectl("remove-old-kube-dns-clusterrolebinding",
            "delete clusterrolebinding system:kube-dns",
-           onlyif="kubectl get clusterrolebinding system:kube-dns") }}
+           onlyif="kubectl --request-timeout=1m get clusterrolebinding system:kube-dns") }}
 
 {% else %}
 

--- a/salt/addons/tiller/init.sls
+++ b/salt/addons/tiller/init.sls
@@ -12,12 +12,12 @@ include:
 # TODO: Transitional code, remove for CaaSP v4
 {{ kubectl("remove-old-tiller-clusterrolebinding",
            "delete clusterrolebinding system:tiller",
-           onlyif="kubectl get clusterrolebinding system:tiller") }}
+           onlyif="kubectl --request-timeout=1m get clusterrolebinding system:tiller") }}
 
 # TODO: Transitional code, remove for CaaSP v4
 {{ kubectl("remove-old-tiller-deployment",
            "delete deploy tiller -n kube-system",
-           onlyif="kubectl get deploy tiller -n kube-system") }}
+           onlyif="kubectl --request-timeout=1m get deploy tiller -n kube-system") }}
 
 {% else %}
 

--- a/salt/addons/tiller/manifests/20-deployment.yaml
+++ b/salt/addons/tiller/manifests/20-deployment.yaml
@@ -40,8 +40,8 @@ spec:
           httpGet:
             path: /liveness
             port: 44135
-          initialDelaySeconds: 1
-          timeoutSeconds: 1
+          initialDelaySeconds: 10
+          timeoutSeconds: 10
         name: tiller
         ports:
         - containerPort: 44134

--- a/salt/cni/init.sls
+++ b/salt/cni/init.sls
@@ -20,7 +20,7 @@ include:
       - file:      /etc/kubernetes/addons
   cmd.run:
     - name: |
-        kubectl apply --namespace kube-system -f /etc/kubernetes/addons/kube-flannel-rbac.yaml
+        kubectl --request-timeout=1m apply --namespace kube-system -f /etc/kubernetes/addons/kube-flannel-rbac.yaml
     - env:
       - KUBECONFIG: {{ pillar['paths']['kubeconfig'] }}
     - require:
@@ -38,7 +38,7 @@ include:
       - file:      /etc/kubernetes/addons
   cmd.run:
     - name: |
-        kubectl apply --namespace kube-system -f /etc/kubernetes/addons/kube-flannel.yaml
+        kubectl --request-timeout=1m apply --namespace kube-system -f /etc/kubernetes/addons/kube-flannel.yaml
     - env:
       - KUBECONFIG: {{ pillar['paths']['kubeconfig'] }}
     - require:
@@ -65,7 +65,7 @@ include:
 
   cmd.run:
     - name: |
-        kubectl apply --namespace kube-system -f /etc/kubernetes/addons/cilium-config.yaml
+        kubectl --request-timeout=1m apply --namespace kube-system -f /etc/kubernetes/addons/cilium-config.yaml
     - env:
       - KUBECONFIG: {{ pillar['paths']['kubeconfig'] }}
     - require:
@@ -83,7 +83,7 @@ include:
       - file:      /etc/kubernetes/addons
   cmd.run:
     - name: |
-        kubectl apply --namespace kube-system -f /etc/kubernetes/addons/cilium-rbac.yaml
+        kubectl --request-timeout=1m apply --namespace kube-system -f /etc/kubernetes/addons/cilium-rbac.yaml
     - env:
       - KUBECONFIG: {{ pillar['paths']['kubeconfig'] }}
     - require:
@@ -101,7 +101,7 @@ include:
       - file:      /etc/kubernetes/addons
   cmd.run:
     - name: |
-        kubectl apply --namespace kube-system -f /etc/kubernetes/addons/cilium-ds.yaml
+        kubectl --request-timeout=1m apply --namespace kube-system -f /etc/kubernetes/addons/cilium-ds.yaml
     - env:
       - KUBECONFIG: {{ pillar['paths']['kubeconfig'] }}
     - require:

--- a/salt/cni/kube-flannel.yaml.jinja
+++ b/salt/cni/kube-flannel.yaml.jinja
@@ -117,6 +117,8 @@ spec:
             path: /healthz
             port: healthz
         livenessProbe:
+          initialDelaySeconds: 10
+          timeoutSeconds: 10
           httpGet:
             path: /healthz
             port: healthz

--- a/salt/cni/update-pre-orchestration.sh
+++ b/salt/cni/update-pre-orchestration.sh
@@ -18,11 +18,11 @@ exit_changes() {
 }
 
 get_node_cidr() {
-	kubectl get node "$NODE_ID" --template="{{.spec.podCIDR}}"
+	kubectl --request-timeout=1m get node "$NODE_ID" --template="{{.spec.podCIDR}}"
 }
 
 patch_node() {
-	kubectl patch node $NODE_ID -p "$@" 2>/dev/null
+	kubectl --request-timeout=1m patch node $NODE_ID -p "$@" 2>/dev/null
 }
 
 ##########################################################

--- a/salt/haproxy/haproxy.cfg.jinja
+++ b/salt/haproxy/haproxy.cfg.jinja
@@ -9,28 +9,56 @@ global
 
 defaults
         log     global
-        mode    tcp
-        option  tcplog
+        mode    http
+        option  redispatch
         option  dontlognull
-        timeout connect 5000
-        timeout client 120000
-        timeout server 120000
+        balance roundrobin
+        timeout connect      5s
+        timeout client       120s
+        timeout http-request 30s
+        timeout client-fin   30s
+        timeout server       120s
+        timeout tunnel       0
+        default-server inter 10s fall 2
 
 # Listen on the standard Kube-API Public port, 6443 by default, and proxy to the masters on
 # the Kube-API internal port, 6444 by default.
-listen kubernetes-master
-        bind {{ bind_ip }}:{{ pillar['api']['ssl_port'] }}
-        mode tcp
-        default-server inter 10s fall 2
-        balance roundrobin
-        option redispatch
+frontend kubernetes-master
+        bind {{ bind_ip }}:{{ pillar['api']['ssl_port'] }} ssl crt {{ pillar['ssl']['kube_apiserver_proxy_bundle'] }} ca-file /etc/pki/ca.crt verify optional
+        timeout client 0
+        http-request set-header X-Remote-User  %{+Q}[ssl_c_s_dn(cn)] if { ssl_c_used ssl_c_verify 0 }
+        http-request set-header X-Remote-Group %{+Q}[ssl_c_s_dn(o)] if { ssl_c_used ssl_c_verify 0 }
+        # If no certificate is passed, or if it's invalid, remove the auth headers
+        http-request del-header X-Remote-User  unless { ssl_c_used ssl_c_verify 0 }
+        http-request del-header X-Remote-Group unless { ssl_c_used ssl_c_verify 0 }
+        http-request del-header X-Remote-Extra unless { ssl_c_used ssl_c_verify 0 }
+        acl streaming_logs url_reg [?&]follow=true
+        acl streaming_logs url_reg [?&]watch=true
+        use_backend no-timeout-backend if streaming_logs
+        acl interactive_session url_reg [?&]tty=true
+        use_backend no-timeout-backend if interactive_session
+        default_backend default-backend
+
+backend default-backend
+        option forwardfor
         option httpchk GET /healthz
+{% for minion_id, nodename in salt['mine.get']('roles:kube-master', 'nodename', 'grain').items() %}
+        server master-{{ nodename }} {{ nodename }}.{{ pillar['internal_infra_domain'] }}:{{ pillar['api']['int_ssl_port'] }} ssl crt {{ pillar['ssl']['kube_apiserver_proxy_bundle'] }} ca-file /etc/pki/ca.crt check check-ssl port {{ pillar['api']['int_ssl_port'] }} verify required
+{%- endfor %}
 
-{%- for minion_id, nodename in salt['mine.get']('roles:kube-master', 'nodename', 'grain').items() %}
-        server master-{{ nodename }} {{ nodename }}.{{ pillar['internal_infra_domain'] }}:{{ pillar['api']['int_ssl_port'] }} check check-ssl port {{ pillar['api']['int_ssl_port'] }} verify none
-{% endfor -%}
+backend no-timeout-backend
+        option forwardfor
+        option forceclose
+        option http-server-close
+        option httpchk GET /healthz
+        timeout server 0
+        timeout tunnel 0
+{% for minion_id, nodename in salt['mine.get']('roles:kube-master', 'nodename', 'grain').items() %}
+        server master-{{ nodename }} {{ nodename }}.{{ pillar['internal_infra_domain'] }}:{{ pillar['api']['int_ssl_port'] }} ssl crt {{ pillar['ssl']['kube_apiserver_proxy_bundle'] }} ca-file /etc/pki/ca.crt check check-ssl port {{ pillar['api']['int_ssl_port'] }} verify required
+{%- endfor %}
 
-{%- if "admin" in salt['grains.get']('roles', []) %}
+
+{% if "admin" in salt['grains.get']('roles', []) %}
 # Velum should be able to access Kube API and Dex service as well to get kubeconfig
 listen kubernetes-dex
         bind {{ bind_ip }}:{{ pillar['dex']['node_port'] }}
@@ -39,29 +67,22 @@ listen kubernetes-dex
         balance roundrobin
         option redispatch
         option httpchk GET /healthz
-
-{%- for minion_id, nodename in salt['mine.get']('roles:kube-master', 'nodename', 'grain').items() %}
+{% for minion_id, nodename in salt['mine.get']('roles:kube-master', 'nodename', 'grain').items() %}
         server master-{{ nodename }} {{ nodename }}.{{ pillar['internal_infra_domain'] }}:{{ pillar['dex']['node_port'] }} check check-ssl port {{ pillar['dex']['node_port'] }} verify none
-{% endfor %}
+{%- endfor %}
 
 listen velum
         bind 0.0.0.0:80
-        bind 0.0.0.0:443 ssl crt /etc/pki/velum.pem ca-file /etc/pki/ca.crt
-        mode http
+        bind 0.0.0.0:443 ssl crt {{ pillar['ssl']['velum_bundle'] }} ca-file /etc/pki/ca.crt
         acl path_autoyast path_reg ^/autoyast$
         option forwardfor
         http-request set-header X-Forwarded-Proto https
         redirect scheme https code 302 if !{ ssl_fc } !path_autoyast
-        default-server inter 10s fall 3
-        balance roundrobin
         server velum unix@/var/run/puma/dashboard.sock
 
 listen velum-api
-        bind 127.0.0.1:444 ssl crt /etc/pki/velum.pem ca-file /etc/pki/ca.crt
-        mode http
+        bind 127.0.0.1:444 ssl crt {{ pillar['ssl']['velum_bundle'] }} ca-file /etc/pki/ca.crt
         option forwardfor
         http-request set-header X-Forwarded-Proto https
-        default-server inter 10s fall 3
-        balance roundrobin
         server velum unix@/var/run/puma/api.sock
-{% endif -%}
+{% endif %}

--- a/salt/haproxy/haproxy.yaml.jinja
+++ b/salt/haproxy/haproxy.yaml.jinja
@@ -28,14 +28,17 @@ spec:
       volumeMounts:
         - name: haproxy-cfg
           mountPath: /etc/haproxy
+        - name: ca-certificate
+          mountPath: /etc/pki/ca.crt
+          readOnly: True
+        - name: kubernetes-proxy-bundle-certificate
+          mountPath: {{ pillar['ssl']['kube_apiserver_proxy_bundle'] }}
+          readOnly: True
 {% if "admin" in salt['grains.get']('roles', []) %}
         - name: etc-hosts
           mountPath: /etc/hosts
         - name: velum-bundle-certificate
-          mountPath: /etc/pki/velum.pem
-          readOnly: True
-        - name: ca-certificate
-          mountPath: /etc/pki/ca.crt
+          mountPath: {{ pillar['ssl']['velum_bundle'] }}
           readOnly: True
         - name: velum-unix-socket
           mountPath: /var/run/puma
@@ -44,16 +47,25 @@ spec:
     - name: haproxy-cfg
       hostPath:
         path: /etc/caasp/haproxy
+    - name: ca-certificate
+      hostPath:
+{% if "admin" in salt['grains.get']('roles', []) %}
+        path: /etc/pki/ca.crt
+{% else %}
+        path: {{ pillar['ssl']['ca_file'] }}
+{% endif %}
+        type: FileOrCreate
+    - name: kubernetes-proxy-bundle-certificate
+      hostPath:
+        path: {{ pillar['ssl']['kube_apiserver_proxy_bundle'] }}
+        type: FileOrCreate
 {% if "admin" in salt['grains.get']('roles', []) %}
     - name: etc-hosts
       hostPath:
         path: /etc/hosts
     - name: velum-bundle-certificate
       hostPath:
-        path: /etc/pki/private/velum-bundle.pem
-    - name: ca-certificate
-      hostPath:
-        path: /etc/pki/ca.crt
+        path: {{ pillar['ssl']['velum_bundle'] }}
     - name: velum-unix-socket
       hostPath:
         path: /var/run/puma

--- a/salt/kube-apiserver/apiserver.jinja
+++ b/salt/kube-apiserver/apiserver.jinja
@@ -44,7 +44,10 @@ KUBE_API_ARGS="--advertise-address={{ salt.caasp_net.get_primary_ip() }} \
                --tls-ca-file={{ pillar['ssl']['ca_file'] }} \
                --cert-dir=/etc/pki \
                {{ salt.caasp_pillar.get('components:apiserver:args') }} \
-               --client-ca-file={{ pillar['ssl']['ca_file'] }} \
+               --requestheader-username-headers=X-Remote-User \
+               --requestheader-group-headers=X-Remote-Group \
+               --requestheader-extra-headers-prefix=X-Remote-Extra \
+               --requestheader-client-ca-file={{ pillar['ssl']['ca_file'] }} \
                --storage-backend={{ pillar['api']['etcd_version'] }} \
                --storage-media-type=application/json \
                --service-account-key-file={{ pillar['paths']['service_account_key'] }} \

--- a/salt/kube-apiserver/init.sls
+++ b/salt/kube-apiserver/init.sls
@@ -76,6 +76,6 @@ kube-apiserver-wait-port-{{ port }}:
     - ca_bundle:  {{ pillar['ssl']['ca_file'] }}
     - status:     200
     - watch:
-      - service:  kube-apiserver
+      - service: kube-apiserver
 
 {% endfor %}

--- a/salt/kubelet/init.sls
+++ b/salt/kubelet/init.sls
@@ -105,12 +105,12 @@ kubelet:
 uncordon-node:
   caasp_cmd.run:
     - name: |
-        kubectl uncordon {{ grains['nodename'] }}
+        kubectl --request-timeout=1m uncordon {{ grains['nodename'] }}
     - retry:
         attempts: 10
         interval: 3
         until: |
-          test "$(kubectl --kubeconfig={{ pillar['paths']['kubeconfig'] }} get nodes {{ grains['nodename'] }} -o=jsonpath='{.spec.unschedulable}' 2>/dev/null)" != "true"
+          test "$(kubectl --request-timeout=1m --kubeconfig={{ pillar['paths']['kubeconfig'] }} get nodes {{ grains['nodename'] }} -o=jsonpath='{.spec.unschedulable}' 2>/dev/null)" != "true"
     - require:
       - file: {{ pillar['paths']['kubeconfig'] }}
   grains.absent:

--- a/salt/kubelet/stop.sls
+++ b/salt/kubelet/stop.sls
@@ -4,14 +4,14 @@
 include:
   - kubectl-config
 
-{% set should_uncordon = salt['cmd.run']("kubectl --kubeconfig=" + pillar['paths']['kubeconfig'] + " get nodes " + grains['nodename'] + " -o=jsonpath='{.spec.unschedulable}' 2>/dev/null") != "true" %}
+{% set should_uncordon = salt['cmd.run']("kubectl --request-timeout=1m --kubeconfig=" + pillar['paths']['kubeconfig'] + " get nodes " + grains['nodename'] + " -o=jsonpath='{.spec.unschedulable}' 2>/dev/null") != "true" %}
 {% set node_removal_in_progress = salt['grains.get']('node_removal_in_progress', False) %}
 
 # If this fails we should ignore it and proceed anyway as Kubernetes will recover
 drain-kubelet:
   cmd.run:
     - name: |
-        kubectl --kubeconfig={{ pillar['paths']['kubeconfig'] }} drain {{ grains['nodename'] }} --force --delete-local-data=true --ignore-daemonsets --grace-period=300 --timeout=340s
+        kubectl --request-timeout=1m --kubeconfig={{ pillar['paths']['kubeconfig'] }} drain {{ grains['nodename'] }} --force --delete-local-data=true --ignore-daemonsets --grace-period=300 --timeout=340s
     - check_cmd:
       - /bin/true
     - require:

--- a/salt/kubelet/update-post-start-services.sls
+++ b/salt/kubelet/update-post-start-services.sls
@@ -3,8 +3,8 @@
 
 remove-old-node-entry:
   cmd.run:
-    - name: kubectl delete node {{ grains['machine_id'] + "." + pillar['internal_infra_domain'] }}
+    - name: kubectl --request-timeout=1m delete node {{ grains['machine_id'] + "." + pillar['internal_infra_domain'] }}
     - check_cmd:
       - /bin/true
     - onlyif:
-      - kubectl get node {{ grains['machine_id'] + "." + pillar['internal_infra_domain'] }}
+      - kubectl --request-timeout=1m get node {{ grains['machine_id'] + "." + pillar['internal_infra_domain'] }}

--- a/salt/kubelet/update-pre-orchestration.sh
+++ b/salt/kubelet/update-pre-orchestration.sh
@@ -25,7 +25,7 @@ exit_changes() {
 
 get_node_data() {
 	local template="$1"
-	kubectl get node "$OLD_NODE_NAME" --template="{{$template}}"
+	kubectl --request-timeout=1m get node "$OLD_NODE_NAME" --template="{{$template}}"
 }
 
 exit_handler() {
@@ -43,8 +43,8 @@ trap "exit_handler" INT TERM EXIT
 
 log "migrating $OLD_NODE_NAME to $NEW_NODE_NAME"
 
-kubectl get node $NEW_NODE_NAME && exit_changes "no" "$NEW_NODE_NAME already exists, nothing to migrate"
-kubectl get node $OLD_NODE_NAME || exit_changes "no" "$OLD_NODE_NAME does not exist, nothing to migrate"
+kubectl --request-timeout=1m get node $NEW_NODE_NAME && exit_changes "no" "$NEW_NODE_NAME already exists, nothing to migrate"
+kubectl --request-timeout=1m get node $OLD_NODE_NAME || exit_changes "no" "$OLD_NODE_NAME does not exist, nothing to migrate"
 
 cat << EOF > /tmp/k8s-node-migration.yaml
 apiVersion: v1
@@ -67,7 +67,7 @@ spec:
   podCIDR: $(get_node_data .spec.podCIDR)
 EOF
 
-kubectl create -f /tmp/k8s-node-migration.yaml 2>/dev/null
+kubectl --request-timeout=1m create -f /tmp/k8s-node-migration.yaml 2>/dev/null
 
 rm /tmp/k8s-node-migration.yaml
 


### PR DESCRIPTION
This allows us to add fine-grained timeouts depending on the endpoint being
accessed or with what parameters (e.g. /log?follow=true should have no
timeout as happens on the apiserver). /exec is another example, but in this
case the protocol is upgraded to spdy.

Fixes: bsc#1071994
(cherry picked from commit 442a76cad214f2308f6a1de0ddef8febca8074c8)