### PR TITLE
introduce haproxy errors (bsc#1080636)

### DIFF
--- a/salt/haproxy/haproxy.cfg.jinja
+++ b/salt/haproxy/haproxy.cfg.jinja
@@ -86,6 +86,8 @@ listen velum
         http-request set-header X-Forwarded-Proto https
         redirect scheme https code 302 if !{ ssl_fc } !path_autoyast
         server velum unix@/var/run/puma/dashboard.sock
+        errorfile 503 /etc/caasp/haproxy/errors/503.html.http
+
 
 listen velum-api
         bind 127.0.0.1:444 ssl crt {{ pillar['ssl']['velum_bundle'] }} ca-file /etc/pki/ca.crt

--- a/salt/haproxy/haproxy.yaml.jinja
+++ b/salt/haproxy/haproxy.yaml.jinja
@@ -43,6 +43,8 @@ spec:
           readOnly: True
         - name: velum-unix-socket
           mountPath: /var/run/puma
+        - name: velum-static-pages
+          mountPath: /etc/caasp/haproxy/errors
 {% endif %}
   volumes:
     - name: haproxy-cfg
@@ -70,4 +72,7 @@ spec:
     - name: velum-unix-socket
       hostPath:
         path: /var/run/puma
+    - name: velum-static-pages
+      hostPath:
+        path: /usr/share/velum/static-pages
 {% endif %}


### PR DESCRIPTION
when the velum database is initializing, show a static 503 page

Signed-off-by: Maximilian Meister <mmeister@suse.de>

## depends on

* https://github.com/kubic-project/caasp-container-manifests/pull/188
* https://github.com/kubic-project/velum-branding/pull/6