### PR TITLE
Queue the /etc/hosts update when triggered from a reactor.

### DIFF
--- a/salt/orch/update-etc-hosts.sls
+++ b/salt/orch/update-etc-hosts.sls
@@ -31,6 +31,8 @@ etc_hosts_setup:
   salt.state:
     - tgt: {{ updates_all_target }}
     - tgt_type: compound
+    - kwarg:
+        queue: True
     - sls:
       - etc-hosts
     - require:


### PR DESCRIPTION
It seems that the `update-etc-hosts` orchestration can conflict with... itself. Apparently this can happen when a new orchestration has been started and the previous one has not finished yet. This tried to solve that problem by queueing the only problematic part of the orchestration, the `salt.state` clause.

Fixes part of bsc#1093123