### PR TITLE
Add support for kube API auditing

### DIFF
--- a/pillar/kube-master.sls
+++ b/pillar/kube-master.sls
@@ -3,3 +3,10 @@ api:
     external_fqdn: null
     extra_names:   []
     extra_ips:     []
+  audit:
+    log:
+      enabled: false
+      maxsize: '10'
+      maxage: '15'
+      maxbackup: '20'
+      policy: '' # note well, an empty policy file would cause the apiserver to NOT start

--- a/salt/kube-apiserver/apiserver.jinja
+++ b/salt/kube-apiserver/apiserver.jinja
@@ -6,7 +6,6 @@
 
 {% set cloud_provider = salt.caasp_pillar.get('cloud:provider') %}
 {% set kube_admission_control = ['Initializers', 'NamespaceLifecycle', 'LimitRanger', 'ServiceAccount', 'NodeRestriction', 'PersistentVolumeLabel', 'DefaultStorageClass', 'ResourceQuota', 'DefaultTolerationSeconds'] %}
-
 # The address on the local server to listen to.
 KUBE_API_ADDRESS="--insecure-bind-address=127.0.0.1 --bind-address=0.0.0.0"
 
@@ -39,6 +38,14 @@ KUBE_API_ARGS="--advertise-address={{ salt.caasp_net.get_primary_ip() }} \
                --cloud-config=/etc/kubernetes/openstack-config \
   {%- endif -%}
 {% endif %}
+{#- An empty audit policy file would cause kubernetes apiserver to not start at all -#}
+{%- if salt.caasp_pillar.get('api:audit:log:enabled', False) and salt.caasp_pillar.get('api:audit:log:policy') %}
+               --audit-policy-file=/etc/kubernetes/audit-policy.yaml \
+               --audit-log-path=/var/log/kube-apiserver/audit.log \
+               --audit-log-maxage={{ salt.caasp_pillar.get('api:audit:log:maxage') }} \
+               --audit-log-maxsize={{ salt.caasp_pillar.get('api:audit:log:maxsize') }} \
+               --audit-log-maxbackup={{ salt.caasp_pillar.get('api:audit:log:maxbackup') }} \
+{%- endif -%}
                --tls-cert-file={{ pillar['ssl']['kube_apiserver_crt'] }} \
                --tls-private-key-file={{ pillar['ssl']['kube_apiserver_key'] }} \
                --tls-ca-file={{ pillar['ssl']['ca_file'] }} \

--- a/salt/kube-apiserver/init.sls
+++ b/salt/kube-apiserver/init.sls
@@ -47,12 +47,28 @@ kube-apiserver:
       - sls:             ca-cert
       - caasp_retriable: {{ pillar['ssl']['kube_apiserver_crt'] }}
       - x509:            {{ pillar['paths']['service_account_key'] }}
+      - file:            /etc/kubernetes/audit-policy.yaml
+      - file:            /var/log/kube-apiserver
     - watch:
       - sls:             kubernetes-common
       - file:            kube-apiserver
+      - file:            /etc/kubernetes/audit-policy.yaml
       - sls:             ca-cert
       - caasp_retriable: {{ pillar['ssl']['kube_apiserver_crt'] }}
       - x509:            {{ pillar['paths']['service_account_key'] }}
+
+/var/log/kube-apiserver:
+  file.directory:
+    - user: kube
+    - group: kube
+    - dirmode: 755
+    - filemode: 644
+    - require:
+      - pkg: kube-apiserver
+
+/etc/kubernetes/audit-policy.yaml:
+  file.managed:
+    - contents_pillar: api:audit:log:policy
 
 #
 # Wait for (in order)


### PR DESCRIPTION
Allow users to enable kubernetes API server auditing feature.

The auditing will produce an audit log file locally that can then be pushed to a central logging solution (eg: by using a fluentd daemonset running on the master nodes).

By default there's no auditing in place. This is enabled only when the user provides a value for each one of the new pillars introduced by this commit.

feature#kube-api-audit
fate#325337

For more information: https://v1-9.docs.kubernetes.io/docs/tasks/debug-application-cluster/audit/#log-backend