### PR TITLE
[3.0] Lower the per-request timeout when we are checking for successful query

### DIFF
--- a/salt/_modules/caasp_http.py
+++ b/salt/_modules/caasp_http.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+'''
+Module for making various web calls. Primarily designed for webhooks and the
+like, but also useful for basic http testing.
+
+CaaS Platform specific:
+
+This module is required so we can pass options like `http_request_timeout` to
+the final `query` call without having to modify the minion global configuration.
+
+This has been implemented in Salt 2018.3.0 version:
+https://github.com/saltstack/salt/commit/f72c2820f2d68f50e0919327a677f4ad8a5584b5
+
+FIXME: Remove after we update to at least Salt 2018.3.0
+'''
+from __future__ import absolute_import
+
+# Import system libs
+import time
+
+# Import salt libs
+import salt.utils.http
+
+
+def query(url, **kwargs):
+    '''
+    Query a resource, and decode the return data
+
+    .. versionadded:: 2015.5.0
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' http.query http://somelink.com/
+        salt '*' http.query http://somelink.com/ method=POST \
+            params='key1=val1&key2=val2'
+        salt '*' http.query http://somelink.com/ method=POST \
+            data='<xml>somecontent</xml>'
+    '''
+    opts = __opts__
+    if 'opts' in kwargs:
+        opts.update(kwargs['opts'])
+        del kwargs['opts']
+
+    return salt.utils.http.query(url=url, opts=opts, **kwargs)
+
+
+def wait_for_successful_query(url, wait_for=300, **kwargs):
+    '''
+    Query a resource until a successful response, and decode the return data
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' http.wait_for_successful_query http://somelink.com/ wait_for=160
+    '''
+
+    starttime = time.time()
+
+    while True:
+        caught_exception = None
+        result = None
+        try:
+            result = query(url=url, **kwargs)
+            if not result.get('Error') and not result.get('error'):
+                return result
+        except Exception as exc:
+            caught_exception = exc
+
+        if time.time() > starttime + wait_for:
+            if not result and caught_exception:
+                # workaround pylint bug https://www.logilab.org/ticket/3207
+                raise caught_exception  # pylint: disable=E0702
+
+            return result

--- a/salt/_states/caasp_http.py
+++ b/salt/_states/caasp_http.py
@@ -1,0 +1,156 @@
+# -*- coding: utf-8 -*-
+'''
+HTTP monitoring states
+
+Perform an HTTP query and statefully return the result
+
+CaaS Platform specific:
+
+This state module is required so we can pass options like `http_request_timeout` to
+the final `query` call without having to modify the minion global configuration.
+
+This has been implemented in Salt 2018.3.0 version:
+https://github.com/saltstack/salt/commit/f72c2820f2d68f50e0919327a677f4ad8a5584b5
+
+FIXME: Remove after we update to at least Salt 2018.3.0
+'''
+
+# Import python libs
+from __future__ import absolute_import
+import re
+
+import time
+
+__monitor__ = ['query']
+
+
+def query(name, match=None, match_type='string', status=None, wait_for=None, **kwargs):
+    '''
+    Perform an HTTP query and statefully return the result
+
+    .. versionadded:: 2015.5.0
+
+    name
+        The name of the query.
+
+    match
+        Specifies a pattern to look for in the return text. By default, this will
+        perform a string comparison of looking for the value of match in the return
+        text.
+
+    match_type
+        Specifies the type of pattern matching to use. Default is ``string``, but
+        can also be set to ``pcre`` to use regular expression matching if a more
+        complex pattern matching is required.
+
+        .. note::
+
+            Despite the name of ``match_type`` for this argument, this setting
+            actually uses Python's ``re.search()`` function rather than Python's
+            ``re.match()`` function.
+
+    status
+        The status code for a URL for which to be checked. Can be used instead of
+        or in addition to the ``match`` setting.
+
+    If both ``match`` and ``status`` options are set, both settings will be checked.
+    However, note that if only one option is ``True`` and the other is ``False``,
+    then ``False`` will be returned. If this case is reached, the comments in the
+    return data will contain troubleshooting information.
+
+    For more information about the ``http.query`` state, refer to the
+    :ref:`HTTP Tutorial <tutorial-http>`.
+
+    .. code-block:: yaml
+
+        query_example:
+          http.query:
+            - name: 'http://example.com/'
+            - status: 200
+
+    '''
+    # Monitoring state, but changes may be made over HTTP
+    ret = {'name': name,
+           'result': None,
+           'comment': '',
+           'changes': {},
+           'data': {}}  # Data field for monitoring state
+
+    if match is None and status is None:
+        ret['result'] = False
+        ret['comment'] += (
+            ' Either match text (match) or a status code (status) is required.'
+        )
+        return ret
+
+    if 'decode' not in kwargs:
+        kwargs['decode'] = False
+    kwargs['text'] = True
+    kwargs['status'] = True
+    if __opts__['test']:
+        kwargs['test'] = True
+
+    if wait_for:
+        data = __salt__['caasp_http.wait_for_successful_query'](name, wait_for=wait_for, **kwargs)
+    else:
+        data = __salt__['caasp_http.query'](name, **kwargs)
+
+    if match is not None:
+        if match_type == 'string':
+            if match in data.get('text', ''):
+                ret['result'] = True
+                ret['comment'] += ' Match text "{0}" was found.'.format(match)
+            else:
+                ret['result'] = False
+                ret['comment'] += ' Match text "{0}" was not found.'.format(match)
+        elif match_type == 'pcre':
+            if re.search(match, data.get('text', '')):
+                ret['result'] = True
+                ret['comment'] += ' Match pattern "{0}" was found.'.format(match)
+            else:
+                ret['result'] = False
+                ret['comment'] += ' Match pattern "{0}" was not found.'.format(match)
+
+    if status is not None:
+        if data.get('status', '') == status:
+            ret['comment'] += 'Status {0} was found, as specified.'.format(status)
+            if ret['result'] is None:
+                ret['result'] = True
+        else:
+            ret['comment'] += 'Status {0} was not found, as specified.'.format(status)
+            ret['result'] = False
+
+    if __opts__['test'] is True:
+        ret['result'] = None
+        ret['comment'] += ' (TEST MODE'
+        if 'test_url' in kwargs:
+            ret['comment'] += ', TEST URL WAS: {0}'.format(kwargs['test_url'])
+        ret['comment'] += ')'
+
+    ret['data'] = data
+    return ret
+
+
+def wait_for_successful_query(name, wait_for=300, **kwargs):
+    '''
+    Like query but, repeat and wait until match/match_type or status is fulfilled. State returns result from last
+    query state in case of success or if no successful query was made within wait_for timeout.
+    '''
+    starttime = time.time()
+
+    while True:
+        caught_exception = None
+        ret = None
+        try:
+            ret = query(name, wait_for=wait_for, **kwargs)
+            if ret['result']:
+                return ret
+        except Exception as exc:
+            caught_exception = exc
+
+        if time.time() > starttime + wait_for:
+            if not ret and caught_exception:
+                # workaround pylint bug https://www.logilab.org/ticket/3207
+                raise caught_exception  # pylint: disable=E0702
+
+            return ret

--- a/salt/addons/dex/wait.sls
+++ b/salt/addons/dex/wait.sls
@@ -1,6 +1,6 @@
 ensure-dex-running:
   # Wait until the Dex API is actually up and running
-  http.wait_for_successful_query:
+  caasp_http.wait_for_successful_query:
     {% set dex_api_server = "api." + pillar['internal_infra_domain']  -%}
     {% set dex_api_server_ext = pillar['api']['server']['external_fqdn'] -%}
     {% set dex_api_port = pillar['dex']['node_port'] -%}
@@ -8,5 +8,7 @@ ensure-dex-running:
     - wait_for:   300
     - ca_bundle:  {{ pillar['ssl']['ca_file'] }}
     - status:     200
+    - opts:
+        http_request_timeout: 30
     - header_dict:
         Host: {{ dex_api_server_ext + ':' + dex_api_port }}

--- a/salt/haproxy/init.sls
+++ b/salt/haproxy/init.sls
@@ -89,11 +89,13 @@ haproxy-restart:
 # The admin node is serving the internal API with the pillars. Wait for it to come back
 # before going on with the orchestration/highstates.
 wait-for-haproxy:
-  http.wait_for_successful_query:
-    - name:       https://localhost:444/internal-api/v1/pillar.json
+  caasp_http.wait_for_successful_query:
+    - name:       https://localhost:444/_health
     - wait_for:   300
-    - status:     401
+    - status:     200
     - verify_ssl: False
+    - opts:
+        http_request_timeout: 30
     - onchanges:
       - haproxy-restart
 {% endif %}

--- a/salt/kube-apiserver/init.sls
+++ b/salt/kube-apiserver/init.sls
@@ -67,7 +67,7 @@ kube-apiserver:
 
 kube-apiserver-wait-port-{{ port }}:
   caasp_retriable.retry:
-    - target:     http.wait_for_successful_query
+    - target:     caasp_http.wait_for_successful_query
     - name:       {{ 'https://' + api_server + ':' + pillar['api'][port] }}/healthz
     - wait_for:   300
     # retry just in case the API server returns a transient error
@@ -75,6 +75,8 @@ kube-apiserver-wait-port-{{ port }}:
         attempts: 3
     - ca_bundle:  {{ pillar['ssl']['ca_file'] }}
     - status:     200
+    - opts:
+        http_request_timeout: 30
     - watch:
       - service: kube-apiserver
 


### PR DESCRIPTION
When we are waiting for some service to be up, if the request hangs for
some reason, we want to retry at least several times. Without setting
this value explicitly, it takes the default (`http_request_timeout` as 3600),
what is way over our `wait_for` argument set at 300 seconds.

By setting the default `http_request_timeout` to a more reasonable default
when doing this kind of checks we can ensure that the request itself will
timeout several times before we call it done.

Fixes: bsc#1093540
Fixes: bsc#1093685
(cherry picked from commit 876f7c7f03c3c6c970ba6f81fa4c676d5ea43b03)