### PR TITLE
Remove default grace period and timeout when draining a node.

### DIFF
--- a/salt/kubelet/stop.sls
+++ b/salt/kubelet/stop.sls
@@ -11,7 +11,7 @@ include:
 drain-kubelet:
   cmd.run:
     - name: |
-        kubectl --request-timeout=1m --kubeconfig={{ pillar['paths']['kubeconfig'] }} drain {{ grains['nodename'] }} --force --delete-local-data=true --ignore-daemonsets --grace-period=300 --timeout=340s
+        kubectl --request-timeout=1m --kubeconfig={{ pillar['paths']['kubeconfig'] }} drain {{ grains['nodename'] }} --force --delete-local-data=true --ignore-daemonsets
     - check_cmd:
       - /bin/true
     - require:


### PR DESCRIPTION
By default, the grace period is -1, or whatever the pod specifies on
its `terminationGracePeriodSeconds` spec. The pod can know better than
us what it needs to cleanly stop, and we don't need to apply arbitrary
timeouts. If this is not specified, the default `terminationGracePeriodSeconds`
value is 30 seconds. After this grace termination period, a SIGKILL will
be sent to the process when evicting pods.

Aside from this, we should have an "inifinite" timeout. Given that this
process doesn't stall, it's safer to perform this operation until it
succeeds. If we have proof that this is causing problems we should add
a timeout, but in general the draining process should not hang.

The alternative is in reality the real problem: if we timeout the draining
process, it can happen that certain pods with remote volumes (nfs, rbd...)
are never evicted, and when we go to restart the machine it hangs, because
systemd fails to kill the processes when there are active mounts.

Since there are no sensible defaults for the grace period and for the global
timeout is better to let the first one to the pod definition, and the second
one to just "infinite" until we really hit an issue because of this.

Fixes: bsc#1085980