### PR TITLE
Remove unneeded state

### DIFF
--- a/salt/addons/dex/init.sls
+++ b/salt/addons/dex/init.sls
@@ -1,6 +1,5 @@
 include:
   - crypto
-  - repositories
   - kubectl-config
   - kube-apiserver
 

--- a/salt/docker/init.sls
+++ b/salt/docker/init.sls
@@ -1,6 +1,3 @@
-include:
-  - repositories
-
 ######################
 # additional ca.crt(s)
 #######################
@@ -64,8 +61,6 @@ docker:
   pkg.installed:
     - name: {{ salt.caasp_pillar.get('docker:pkg', 'docker') }}
     - install_recommends: False
-    - require:
-      - file: /etc/zypp/repos.d/containers.repo
   file.replace:
     # remove any DOCKER_OPTS in the sysconfig file, as we will be
     # using the "daemon.json". In fact, we don't want any DOCKER_OPS

--- a/salt/etcd/init.sls
+++ b/salt/etcd/init.sls
@@ -1,5 +1,4 @@
 include:
-  - repositories
   - ca-cert
   - cert
 
@@ -11,8 +10,6 @@ include:
 add-etcd-to-cluster:
   pkg.installed:
     - name: etcdctl
-    - require:
-      - file: /etc/zypp/repos.d/containers.repo
   caasp_etcd.member_add:
     - retry:
         interval: 4
@@ -42,8 +39,6 @@ etcd:
       - iptables
       - etcdctl
       - etcd
-    - require:
-      - file: /etc/zypp/repos.d/containers.repo
   caasp_retriable.retry:
     - name: iptables-etcd
     - target: iptables.append

--- a/salt/kube-apiserver/init.sls
+++ b/salt/kube-apiserver/init.sls
@@ -1,5 +1,4 @@
 include:
-  - repositories
   - ca-cert
   - cert
   - haproxy
@@ -18,8 +17,6 @@ kube-apiserver:
     - pkgs:
       - iptables
       - kubernetes-master
-    - require:
-      - file: /etc/zypp/repos.d/containers.repo
   caasp_retriable.retry:
     - name: iptables-kube-apiserver
     - target: iptables.append

--- a/salt/kube-controller-manager/init.sls
+++ b/salt/kube-controller-manager/init.sls
@@ -1,5 +1,4 @@
 include:
-  - repositories
   - kubernetes-common
   - kubernetes-common.serviceaccount-key
 
@@ -7,8 +6,6 @@ kube-controller-manager:
   pkg.installed:
     - pkgs:
       - kubernetes-master
-    - require:
-      - file: /etc/zypp/repos.d/containers.repo
   file.managed:
     - name:       /etc/kubernetes/controller-manager
     - source:     salt://kube-controller-manager/controller-manager.jinja

--- a/salt/kube-proxy/init.sls
+++ b/salt/kube-proxy/init.sls
@@ -1,5 +1,4 @@
 include:
-  - repositories
   - kubernetes-common
 
 {% from '_macros/certs.jinja' import certs with context %}
@@ -26,8 +25,6 @@ kube-proxy:
       - iptables
       - conntrack-tools
       - kubernetes-node
-    - require:
-      - file: /etc/zypp/repos.d/containers.repo
   file.managed:
     - name: /etc/kubernetes/proxy
     - source: salt://kube-proxy/proxy.jinja

--- a/salt/kube-scheduler/init.sls
+++ b/salt/kube-scheduler/init.sls
@@ -1,14 +1,11 @@
 include:
   - crypto
-  - repositories
   - kubernetes-common
 
 kube-scheduler:
   pkg.installed:
     - pkgs:
       - kubernetes-master
-    - require:
-      - file: /etc/zypp/repos.d/containers.repo
   file.managed:
     - name: /etc/kubernetes/scheduler
     - source: salt://kube-scheduler/scheduler.jinja

--- a/salt/kubelet/init.sls
+++ b/salt/kubelet/init.sls
@@ -1,5 +1,4 @@
 include:
-  - repositories
   - ca-cert
   - cert
   - kubernetes-common
@@ -60,8 +59,6 @@ kubelet:
       - iptables
       - kubernetes-client
       - kubernetes-node
-    - require:
-      - file: /etc/zypp/repos.d/containers.repo
   file.managed:
     - name:     /etc/kubernetes/kubelet
     - source:   salt://kubelet/kubelet.jinja

--- a/salt/kubernetes-common/init.sls
+++ b/salt/kubernetes-common/init.sls
@@ -1,6 +1,3 @@
-include:
-  - repositories
-
 kubernetes-common:
   pkg.installed:
     - pkgs:

--- a/salt/repositories/containers.repo
+++ b/salt/repositories/containers.repo
@@ -1,7 +1,0 @@
-[containers]
-name=containers
-type=rpm-md
-gpgcheck=0
-enabled=1
-autorefresh=1
-baseurl=http://download.opensuse.org/repositories/Virtualization:/containers/openSUSE_Leap_{{ grains['osrelease'] }}/

--- a/salt/repositories/init.sls
+++ b/salt/repositories/init.sls
@@ -1,8 +1,0 @@
-/etc/zypp/repos.d/containers.repo:
-  file.managed:
-    - source: salt://repositories/containers.repo
-    - order: 0
-    - template: jinja
-{% if not grains['oscodename'].startswith("openSUSE Leap") %}
-    - create: False
-{% endif %}

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -37,7 +37,6 @@ base:
     - kube-scheduler
   'roles:(kube-master|kube-minion|etcd)':
     - match: grain_pcre
-    - repositories
     - motd
     - users
     - cert


### PR DESCRIPTION
The registries state is something from the early days of caasp.
Something we don't need (and use) anymore.

feature#remove-unneeded-code-registries

Signed-off-by: Flavio Castelli <fcastelli@suse.com>