### PR TITLE
[WIP] Allow salt tests to be ran via tox and Jenkins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,6 @@ junit.xml
 Makefile
 *.tgz
 *.pyc
-
+tests-*.xml
 # local config files
 config/master.d/99-local-*.conf

--- a/Jenkinsfile.tests
+++ b/Jenkinsfile.tests
@@ -1,0 +1,80 @@
+def label = "salt-tests-${UUID.randomUUID().toString()}"
+
+podTemplate(label: label, containers: [
+        containerTemplate(
+            name: 'opensuse',
+            image: 'opensuse:42.3',
+            ttyEnabled: true,
+            command: 'cat',
+            envVars: [
+                envVar(key: 'http_proxy', value: env.http_proxy),
+                envVar(key: 'https_proxy', value: env.http_proxy),
+            ],
+        ),
+]) {
+    node(label) {
+        stage('Retrieve Code') {
+            checkout scm
+        }
+
+        stage('Install Dependencies') {
+            try {
+                container('opensuse') {
+                    // TODO: Build a opensuse based python-tox image..
+                    sh 'zypper in --no-confirm python-tox python-pip python-pyOpenSSL libopenssl1_0_0 openssl git python3 python-devel python3-devel gcc libzmq5 zeromq-devel python-xml'
+                }
+            } catch (Exception e) {
+                containerLog 'opensuse'
+                throw e
+            }
+        }
+
+        stage('Create Test Virtualenv') {
+            try {
+                parallel(
+                    'Python 2.7': {
+                        container('opensuse') {
+                            sh 'tox --notest -e tests-salt-2016.11.4-py27'
+                        }
+                    },
+                    'Python 3.4': {
+                        container('opensuse') {
+                            sh 'tox --notest -e tests-salt-2016.11.4-py34'
+                        }
+                    }
+                )
+            } catch (Exception e) {
+                containerLog 'opensuse'
+                throw e
+            }
+        }
+
+        stage('Run Tests') {
+            try {
+                parallel(
+                    'Python 2.7': {
+                        container('opensuse') {
+                            try {
+                                sh 'tox -e tests-salt-2016.11.4-py27 -- --with-xunit --xunit-testsuite-name=salt-2016.11.4-py27 --xunit-file=tests-salt-2016.11.4-py27.xml'
+                            } finally {
+                                junit "tests-salt-2016.11.4-py27.xml"
+                            }
+                        }
+                    },
+                    'Python 3.4': {
+                        container('opensuse') {
+                            try {
+                                sh 'tox -e tests-salt-2016.11.4-py34 -- --with-xunit --xunit-testsuite-name=salt-2016.11.4-py34 --xunit-file=tests-salt-2016.11.4-py34.xml'
+                            } finally {
+                                junit "tests-salt-2016.11.4-py34.xml"
+                            }
+                        }
+                    }
+                )
+            } catch (Exception e) {
+                containerLog 'opensuse'
+                throw e
+            }
+        }
+    }
+}

--- a/salt/_modules/tests/test_caasp_etcd.py
+++ b/salt/_modules/tests/test_caasp_etcd.py
@@ -49,6 +49,6 @@ class TestGetEndpoints(unittest.TestCase):
             mock.reset_mock()
 
             res = get_endpoints(skip_removed=True)
-            mock.assert_called_once_with('G@roles:etcd and not G@removal_in_progress:true')
+            mock.assert_called_once_with('G@roles:etcd and not G@node_removal_in_progress:true')
 
             mock.reset_mock()

--- a/salt/_modules/tests/tests.sh
+++ b/salt/_modules/tests/tests.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-python -m unittest discover --top .. --verbose $@

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,34 @@
 [tox]
-envlist = flake8
+envlist = tests-salt-2016.11.4-py27,flake8
 skipsdist = True
 
 [testenv]
 sitepackages = False
+
+commands =
+    false
+
+[testenv:tests-salt-2016.11.4-py27]
+basepython = python2.7
+
+deps =
+    git+https://github.com/opensuse/salt@openSUSE-2016.11.4
+    mock==2.0.0
+    nose==1.3.7
+
+commands =
+    nosetests -v -w {toxinidir}/salt/_modules {posargs}
+
+[testenv:tests-salt-2016.11.4-py34]
+basepython = python3.4
+
+deps =
+    git+https://github.com/opensuse/salt@openSUSE-2016.11.4
+    mock==2.0.0
+    nose==1.3.7
+
+commands =
+    nosetests -v -w {toxinidir}/salt/_modules {posargs}
 
 [testenv:flake8]
 deps =


### PR DESCRIPTION
Example to run them locally:

    tox -e tests-salt-2016.11.4-py27

or:

    tox -e tests-salt-2016.11.4-py34