### PR TITLE
Enable the ValidatingAdmissionWebhook

### DIFF
--- a/pillar/certificates.sls
+++ b/pillar/certificates.sls
@@ -44,9 +44,6 @@ ssl:
   kube_apiserver_proxy_crt: '/etc/pki/kube-apiserver-proxy.crt'
   kube_apiserver_proxy_bundle: '/etc/pki/private/kube-apiserver-proxy-bundle.pem'
 
-  kube_apiserver_proxy_client_key: '/etc/pki/kube-apiserver-proxy-client.key'
-  kube_apiserver_proxy_client_crt: '/etc/pki/kube-apiserver-proxy-client.crt'
-
   kube_scheduler_key: '/etc/pki/kube-scheduler.key'
   kube_scheduler_crt: '/etc/pki/kube-scheduler.crt'
 

--- a/pillar/certificates.sls
+++ b/pillar/certificates.sls
@@ -44,6 +44,9 @@ ssl:
   kube_apiserver_proxy_crt: '/etc/pki/kube-apiserver-proxy.crt'
   kube_apiserver_proxy_bundle: '/etc/pki/private/kube-apiserver-proxy-bundle.pem'
 
+  kube_apiserver_proxy_client_key: '/etc/pki/kube-apiserver-proxy-client.key'
+  kube_apiserver_proxy_client_crt: '/etc/pki/kube-apiserver-proxy-client.crt'
+
   kube_scheduler_key: '/etc/pki/kube-scheduler.key'
   kube_scheduler_crt: '/etc/pki/kube-scheduler.crt'
 

--- a/pillar/kube-master.sls
+++ b/pillar/kube-master.sls
@@ -3,6 +3,10 @@ api:
     external_fqdn: null
     extra_names:   []
     extra_ips:     []
+  admission_webhook:
+    enabled: False
+    cert: ''
+    key: ''
   audit:
     log:
       enabled: false

--- a/salt/_pillar/velum.py
+++ b/salt/_pillar/velum.py
@@ -72,6 +72,7 @@ def ext_pillar(minion_id,
                                       ca_bundle=ca_bundle,
                                       username=username,
                                       password=password,
+                                      params={"minion_id": minion_id},
                                       decode=True,
                                       decode_type='json')
     except Exception as e:

--- a/salt/kube-apiserver/apiserver.jinja
+++ b/salt/kube-apiserver/apiserver.jinja
@@ -61,8 +61,10 @@ KUBE_API_ARGS="--advertise-address={{ salt.caasp_net.get_primary_ip() }} \
                --tls-cert-file={{ pillar['ssl']['kube_apiserver_crt'] }} \
                --tls-private-key-file={{ pillar['ssl']['kube_apiserver_key'] }} \
                --tls-ca-file={{ pillar['ssl']['ca_file'] }} \
-               --proxy-client-cert-file={{ pillar['ssl']['kube_apiserver_proxy_client_crt'] }} \
-               --proxy-client-key-file={{ pillar['ssl']['kube_apiserver_proxy_client_key'] }} \
+{%- if salt.caasp_pillar.get('api:admission_webhook:enabled', False) %}
+               --proxy-client-cert-file=/etc/pki/kube-apiserver-proxy-client.crt \
+               --proxy-client-key-file=/etc/pki/kube-apiserver-proxy-client.key \
+{%- endif -%}
                --cert-dir=/etc/pki \
                {{ salt.caasp_pillar.get('components:apiserver:args') }} \
                --requestheader-username-headers=X-Remote-User \

--- a/salt/kube-apiserver/apiserver.jinja
+++ b/salt/kube-apiserver/apiserver.jinja
@@ -5,7 +5,19 @@
 #
 
 {% set cloud_provider = salt.caasp_pillar.get('cloud:provider') %}
-{% set kube_admission_control = ['Initializers', 'NamespaceLifecycle', 'LimitRanger', 'ServiceAccount', 'NodeRestriction', 'PersistentVolumeLabel', 'DefaultStorageClass', 'ResourceQuota', 'DefaultTolerationSeconds'] %}
+{# Note well: order matters #}
+{% set kube_admission_control = [
+  'Initializers',
+  'NamespaceLifecycle',
+  'LimitRanger',
+  'ServiceAccount',
+  'NodeRestriction',
+  'PersistentVolumeLabel',
+  'DefaultStorageClass',
+  'DefaultTolerationSeconds',
+  'ValidatingAdmissionWebhook',
+  'ResourceQuota'] %}
+
 # The address on the local server to listen to.
 KUBE_API_ADDRESS="--insecure-bind-address=127.0.0.1 --bind-address=0.0.0.0"
 
@@ -49,6 +61,8 @@ KUBE_API_ARGS="--advertise-address={{ salt.caasp_net.get_primary_ip() }} \
                --tls-cert-file={{ pillar['ssl']['kube_apiserver_crt'] }} \
                --tls-private-key-file={{ pillar['ssl']['kube_apiserver_key'] }} \
                --tls-ca-file={{ pillar['ssl']['ca_file'] }} \
+               --proxy-client-cert-file={{ pillar['ssl']['kube_apiserver_proxy_client_crt'] }} \
+               --proxy-client-key-file={{ pillar['ssl']['kube_apiserver_proxy_client_key'] }} \
                --cert-dir=/etc/pki \
                {{ salt.caasp_pillar.get('components:apiserver:args') }} \
                --requestheader-username-headers=X-Remote-User \

--- a/salt/kube-apiserver/init.sls
+++ b/salt/kube-apiserver/init.sls
@@ -12,6 +12,12 @@ include:
          cn = grains['nodename'],
          o = pillar['certificate_information']['subject_properties']['O']) }}
 
+{{ certs("kube-apiserver-proxy-client",
+         pillar['ssl']['kube_apiserver_proxy_client_crt'],
+         pillar['ssl']['kube_apiserver_proxy_client_key'],
+         cn = grains['nodename'],
+         o = pillar['certificate_information']['subject_properties']['O']) }}
+
 kube-apiserver:
   pkg.installed:
     - pkgs:
@@ -43,6 +49,7 @@ kube-apiserver:
       - caasp_retriable: iptables-kube-apiserver
       - sls:             ca-cert
       - caasp_retriable: {{ pillar['ssl']['kube_apiserver_crt'] }}
+      - caasp_retriable: {{ pillar['ssl']['kube_apiserver_proxy_client_crt'] }}
       - x509:            {{ pillar['paths']['service_account_key'] }}
       - file:            /etc/kubernetes/audit-policy.yaml
       - file:            /var/log/kube-apiserver
@@ -52,6 +59,7 @@ kube-apiserver:
       - file:            /etc/kubernetes/audit-policy.yaml
       - sls:             ca-cert
       - caasp_retriable: {{ pillar['ssl']['kube_apiserver_crt'] }}
+      - caasp_retriable: {{ pillar['ssl']['kube_apiserver_proxy_client_crt'] }}
       - x509:            {{ pillar['paths']['service_account_key'] }}
 
 /var/log/kube-apiserver:


### PR DESCRIPTION
Enable by default this admission controller. Users can later define
custom validators leveraging external webhooks.

The validators definition happens via kubernetes native resources, hence
without any intervention from our side.

Note well: this commit introduces a new set of certificate. This pair of
certificate is going to be used by the API server to perform Mutual TLS
authentication against the external webhook.

In this scenario the API server is the client, while the server is the
webhook service specified by the user.

feature#ValidatingAdmissionWebhook

This is based on the research I did sometimes ago on image admission controllers: https://github.com/flavio/kube-image-bouncer

cc @ajaeger: this is going to make some of our customers happy, the ones who requested the possibility to use this generic admission controller.