### PR TITLE
[3.0] Log all CRI issues as we go, and show them if we really timeout

### DIFF
--- a/salt/_modules/caasp_cri.py
+++ b/salt/_modules/caasp_cri.py
@@ -202,6 +202,7 @@ def __wait_CRI_socket():
     '''
     timeout = int(__salt__['pillar.get']('cri:socket_timeout', '20'))
     expire = time.time() + timeout
+    errors = {'attempts': []}
 
     while time.time() < expire:
         cmd = "crictl --runtime-endpoint {socket} info".format(
@@ -214,11 +215,13 @@ def __wait_CRI_socket():
         if result['retcode'] == 0:
             return
 
+        errors['attempts'].append(result)
+
         time.sleep(0.3)
 
     raise CommandExecutionError(
         'CRI socket did not become ready',
-        info={'errors': ['CRI socket did not become ready']}
+        info=errors
     )
 
 


### PR DESCRIPTION
Related: bsc#1093918
(cherry picked from commit c5fb8d2158bc17553141c81028455963e4cf1791)

Backport of https://github.com/kubic-project/salt/pull/560