### PR TITLE
[3.0] Fix kubelet arguments

### DIFF
--- a/salt/kubelet/kubelet.jinja
+++ b/salt/kubelet/kubelet.jinja
@@ -52,7 +52,6 @@ KUBELET_ARGS="\
     --runtime-request-timeout=10m \
 {% endif -%}
     --client-ca-file={{ pillar['ssl']['ca_file'] }} \
-    --require-kubeconfig \
     --network-plugin=cni \
     --cni-bin-dir={{ pillar['cni']['dirs']['bin'] }} \
     --cni-conf-dir={{ pillar['cni']['dirs']['conf'] }} \


### PR DESCRIPTION
Remove unsupported `--require-kubeconfig` argument deprecated in Kubernetes (and removed in 1.10)

Backport of https://github.com/kubic-project/salt/pull/562