### PR TITLE
Use six compatibility library

### DIFF
--- a/salt/_modules/caasp_docker.py
+++ b/salt/_modules/caasp_docker.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from urlparse import urlparse
+from salt.ext.six.moves.urllib.parse import urlparse
 
 from caasp_log import debug, error
 

--- a/salt/_states/caasp_cmd.py
+++ b/salt/_states/caasp_cmd.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import time
+from salt.ext.six.moves import range
 
 
 def run(name,
@@ -168,7 +169,7 @@ def run(name,
 
     ret = None
 
-    for attempt in xrange(retry_['attempts']):
+    for attempt in range(retry_['attempts']):
         ret = __states__['cmd.run'](name=name,
                                     onlyif=onlyif,
                                     unless=unless,

--- a/salt/_states/caasp_retriable.py
+++ b/salt/_states/caasp_retriable.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 import time
+from salt.ext.six.moves import range
 
 
 def retry(name, target, retry={}, **kwargs):
@@ -26,7 +27,7 @@ def retry(name, target, retry={}, **kwargs):
 
     ret = None
 
-    for attempt in xrange(retry_['attempts']):
+    for attempt in range(retry_['attempts']):
         try:
             ret = __states__[target](name=name, **kwargs)
         except BaseException as e:

--- a/salt/_states/caasp_service.py
+++ b/salt/_states/caasp_service.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 import time
+from salt.ext.six.moves import range
 
 
 def running_stable(name, enable=None, sig=None, init_delay=None, successful_retries_in_a_row=50,
@@ -55,7 +56,7 @@ def running_stable(name, enable=None, sig=None, init_delay=None, successful_retr
     latest_pid = None
     current_successful_retries_in_a_row = 0
     max_current_successful_retries_in_a_row = 0
-    for retry in xrange(max_retries):
+    for retry in range(max_retries):
         pid = __salt__['service.status'](name=name,
                                          sig=sig)
 


### PR DESCRIPTION
Fix imports that do no longer exist in `python3` and no longer use the `xrange` function.