### PR TITLE
[WIP] Add Openstack Keystone Trust ID option for Kubernetes CPI, bsc#1094196

### DIFF
--- a/pillar/params.sls
+++ b/pillar/params.sls
@@ -150,6 +150,8 @@ cloud:
     region:         ''
     username:       ''
     password:       ''
+    # OpenStack Keystone Trust ID to avoid storing user credentials
+    trust_id:       ''
     # OpenStack subnet UUID for the CaasP private network
     subnet:         ''
     # OpenStack floating network UUID

--- a/salt/kubernetes-common/openstack-config.jinja
+++ b/salt/kubernetes-common/openstack-config.jinja
@@ -2,6 +2,7 @@
 auth-url="{{ pillar['cloud']['openstack']['auth_url'] }}"
 username="{{ pillar['cloud']['openstack']['username'] }}"
 password="{{ pillar['cloud']['openstack']['password'] }}"
+trust-id="{{ pillar['cloud']['openstack']['trust_id'] }}"
 {% if pillar['cloud']['openstack']['project_id'] %}
 tenant-id="{{ pillar['cloud']['openstack']['project_id'] }}"
 {% else %}


### PR DESCRIPTION
Add OpenStack Keystone Trust ID option for Kubernetes cloudprovider  driver
to avoid storing user credentials.

More about OpenStack Keystone Trust you can find here
https://wiki.openstack.org/wiki/Keystone/Trusts

Option name added to CaaSP is "trust-id"