### PR TITLE
50-returner.conf: specfify unix_socket for salt-2018

### DIFF
--- a/config/master.d/50-returner.conf
+++ b/config/master.d/50-returner.conf
@@ -1,8 +1,11 @@
 mysql:
-  # salt does not support specifying the UNIX socket location here - as a workaround,
-  # use the MYSQL_UNIX_PORT environment variable used by libmysqlclient
-  # you still need the 'host' value here, or it will use the defaults and try to connect
-  # on a host named 'salt'
+  # salt-2016 does not support specifying the UNIX socket location here - 
+  # as a workaround, use the MYSQL_UNIX_PORT environment variable used by
+  # libmysqlclient
+  # you still need the 'host' value here, or it will use the defaults and
+  # try to connect on a host named 'salt'
   host: 'localhost'
   user: 'salt'
   db: 'velum_production'
+  # salt-2018 supports the UNIX socket location
+  unix_socket: /var/run/mysql/mysql.sock


### PR DESCRIPTION
With salt-2018 and the new PyMySQL, the MYSQL_UNIX_PORT environment variable will no longer work. But we can specify the UNIX socket directly.