### PR TITLE
override volume plugin dir (bsc#1084766)

### DIFF
--- a/salt/kubelet/kubelet.jinja
+++ b/salt/kubelet/kubelet.jinja
@@ -55,4 +55,5 @@ KUBELET_ARGS="\
     --network-plugin=cni \
     --cni-bin-dir={{ pillar['cni']['dirs']['bin'] }} \
     --cni-conf-dir={{ pillar['cni']['dirs']['conf'] }} \
-    --kubeconfig={{ pillar['paths']['kubelet_config'] }}"
+    --kubeconfig={{ pillar['paths']['kubelet_config'] }} \
+    --volume-plugin-dir=/usr/lib/kubernetes/kubelet-plugins"


### PR DESCRIPTION
kubernetes 1.10 uses /usr/libexec by default which doesnt exist,
and we want to stick with /usr/lib

Signed-off-by: Maximilian Meister <mmeister@suse.de>

kubelet config fix in the package is part of https://build.opensuse.org/request/show/612897