### PR TITLE
Remove 'range' imports from six.

### DIFF
--- a/salt/_states/caasp_cmd.py
+++ b/salt/_states/caasp_cmd.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 import time
-from salt.ext.six.moves import range
 
 
 def run(name,

--- a/salt/_states/caasp_retriable.py
+++ b/salt/_states/caasp_retriable.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 import time
-from salt.ext.six.moves import range
 
 
 def retry(name, target, retry={}, **kwargs):

--- a/salt/_states/caasp_service.py
+++ b/salt/_states/caasp_service.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 import time
-from salt.ext.six.moves import range
 
 
 def running_stable(name, enable=None, sig=None, init_delay=None, successful_retries_in_a_row=50,


### PR DESCRIPTION
There were problems when running 'salt' using these imports and the difference
in semantics seems not significant.