### PR TITLE
[3.0] fix get node targets

### DIFF
--- a/salt/_modules/caasp_etcd.py
+++ b/salt/_modules/caasp_etcd.py
@@ -137,6 +137,7 @@ def get_additional_etcd_members(num_wanted=None, **kwargs):
     #
     new_etcd_members = __salt__['caasp_nodes.get_with_prio_for_role'](
         num_additional_etcd_members, 'etcd',
+        unassigned=False,
         excluded=current_etcd_members + excluded)
 
     if len(new_etcd_members) < num_additional_etcd_members:
@@ -214,6 +215,7 @@ def get_member_id(nodename=None):
     target_nodename = nodename or __salt__['caasp_net.get_nodename']()
 
     debug("getting etcd member ID with: %s", command)
+    members_output = ''
     try:
         target_url = 'https://{}:{}'.format(target_nodename, ETCD_CLIENT_PORT)
         members_output = subprocess.check_output(command)

--- a/salt/_modules/caasp_grains.py
+++ b/salt/_modules/caasp_grains.py
@@ -5,11 +5,11 @@ def __virtual__():
     return "caasp_grains"
 
 
-# default grain name, used for getting node IDs
-_GRAIN_NAME = 'nodename'
+# an exported (to the mine) grain used for getting ids
+DEFAULT_GRAIN = 'nodename'
 
 
-def get(expr, grain=_GRAIN_NAME, type='compound'):
+def get(expr, grain=DEFAULT_GRAIN, type='compound'):
     if __opts__['__role'] == 'master':
         # 'mine.get' is not available in the master: it returns nothing
         # in that case, we should use "saltutil.runner"... uh?

--- a/salt/_modules/caasp_net.py
+++ b/salt/_modules/caasp_net.py
@@ -12,6 +12,8 @@ from caasp_log import error
 
 DEFAULT_INTERFACE = 'eth0'
 
+NODENAME_GRAIN = 'nodename'
+
 
 def __virtual__():
     return "caasp_net"
@@ -83,9 +85,9 @@ def get_nodename(host=None, **kwargs):
     try:
         if not host:
             assert __opts__['__role'] != 'master'
-            return __salt__['grains.get']('nodename')
+            return __salt__['grains.get'](NODENAME_GRAIN)
         else:
-            all_nodenames = __salt__['caasp_grains.get'](host, 'nodename', type='glob')
+            all_nodenames = __salt__['caasp_grains.get'](host, grain=NODENAME_GRAIN, type='glob')
             return all_nodenames[host]
     except Exception as e:
         error('could not get nodename: %s', e)

--- a/salt/_states/caasp_cri.py
+++ b/salt/_states/caasp_cri.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+
 from caasp_log import debug
 
 

--- a/salt/_states/caasp_http.py
+++ b/salt/_states/caasp_http.py
@@ -17,8 +17,8 @@ FIXME: Remove after we update to at least Salt 2018.3.0
 
 # Import python libs
 from __future__ import absolute_import
-import re
 
+import re
 import time
 
 __monitor__ = ['query']

--- a/salt/_states/caasp_retriable.py
+++ b/salt/_states/caasp_retriable.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+
 import time
 
 

--- a/salt/_states/caasp_service.py
+++ b/salt/_states/caasp_service.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+
 import time
 
 
@@ -65,17 +66,20 @@ def running_stable(name, enable=None, sig=None, init_delay=None, successful_retr
             current_successful_retries_in_a_row = 0
 
         latest_pid = pid
-        max_current_successful_retries_in_a_row = max(max_current_successful_retries_in_a_row, current_successful_retries_in_a_row)
+        max_current_successful_retries_in_a_row = max(
+            max_current_successful_retries_in_a_row, current_successful_retries_in_a_row)
 
         if current_successful_retries_in_a_row == successful_retries_in_a_row:
             ret['result'] = True
-            ret['comment'] = 'Service {0} is up after {1} total retries. Including {2} retries in a row'.format(name, retry + 1, successful_retries_in_a_row)
+            ret['comment'] = 'Service {0} is up after {1} total retries. Including {2} retries in a row'.format(
+                name, retry + 1, successful_retries_in_a_row)
             break
 
         if delay_between_retries:
             time.sleep(delay_between_retries)
 
     if not ret['result']:
-        ret['comment'] = 'Service {0} is dead after {1} total retries. Expected {2} success in a row, got {3} as maximum'.format(name, max_retries, successful_retries_in_a_row, max_current_successful_retries_in_a_row)
+        ret['comment'] = 'Service {0} is dead after {1} total retries. Expected {2} success in a row, got {3} as maximum'.format(
+            name, max_retries, successful_retries_in_a_row, max_current_successful_retries_in_a_row)
 
     return ret

--- a/salt/etc-hosts/hosts.jinja
+++ b/salt/etc-hosts/hosts.jinja
@@ -9,7 +9,16 @@
 {%- endif -%}
 
 {%- macro nodes_entries(expr) -%}
-  {%- set nodes = salt['mine.get'](expr, 'network.interfaces', 'compound') %}
+  {# note regarding node removals:
+   # we need the "node_(addition|removal)_in_progress" nodes here, otherwise
+   #   - nodes being removed will be immediately banned from the cluster (with a message like:
+   #    'rejected connection from <NODE> (error tls: <NODE-IP> does not match any of DNSNames [...]')
+   #    and the cluster will become unhealthy
+   #   - nodes being added will not be able to join (with some similar TLS verification error)
+   # doing another /etc/hosts update just for one stale entry seem like an overkill,
+   # so the /etc/hosts cleanup will have to be delayed for some other moment...
+   #}
+  {%- set nodes = salt.caasp_nodes.get_with_expr(expr, grain='network.interfaces') %}
   {%- for id, ifaces in nodes.items() %}
     {%- set ip = salt.caasp_net.get_primary_ip(host=id, ifaces=ifaces) %}
     {%- if ip|length > 0 %}

--- a/salt/etcd/etcd.conf.jinja
+++ b/salt/etcd/etcd.conf.jinja
@@ -24,6 +24,7 @@ ETCD_PEER_TRUSTED_CA_FILE={{ pillar['ssl']['ca_file'] }}
 ETCD_PEER_CLIENT_CERT_AUTH="true"
 # ETCD_PEER_AUTO_TLS=on
 
+{# note on node removal: we cannot skip nodes with node_removal_in_progress #}
 ETCD_INITIAL_CLUSTER="{{ salt.caasp_etcd.get_endpoints(with_id=True, port=2380) }}"
 ETCD_INITIAL_CLUSTER_TOKEN="{{ pillar['etcd']['token'] }}"
 ETCD_INITIAL_ADVERTISE_PEER_URLS="https://{{ this_addr }}:2380"

--- a/salt/haproxy/haproxy.cfg.jinja
+++ b/salt/haproxy/haproxy.cfg.jinja
@@ -1,8 +1,15 @@
-{%- if "kube-master" in salt['grains.get']('roles', []) -%}
-{%- set bind_ip = "0.0.0.0" -%}
-{%- else -%}
-{%- set bind_ip = "127.0.0.1" -%}
-{%- endif -%}
+{%- set this_roles = salt['grains.get']('roles', [])%}
+
+{%- set bind_ip = "0.0.0.0" if "kube-master" in this_roles else "127.0.0.1" -%}
+
+{%- set masters = salt.caasp_nodes.get_with_expr('G@roles:kube-master',
+                                                 excluded_grains=['node_removal_in_progress'],
+                                                 grain='nodename') %}
+{% if not masters %}
+  {# fail early instead of generating a config file that is useless... #}
+  {% do salt.caasp_log.abort('No masters found when calculating backends for haproxy') %}
+{% endif %}
+
 global
         log /dev/log    local0
         log /dev/log    local1 notice
@@ -42,7 +49,7 @@ frontend kubernetes-master
 backend default-backend
         option forwardfor
         option httpchk GET /healthz
-{% for minion_id, nodename in salt['mine.get']('roles:kube-master', 'nodename', 'grain').items() %}
+{% for id, nodename in masters.items() %}
         server master-{{ nodename }} {{ nodename }}.{{ pillar['internal_infra_domain'] }}:{{ pillar['api']['int_ssl_port'] }} ssl crt {{ pillar['ssl']['kube_apiserver_proxy_bundle'] }} ca-file /etc/pki/ca.crt check check-ssl port {{ pillar['api']['int_ssl_port'] }} verify required
 {%- endfor %}
 
@@ -53,12 +60,12 @@ backend no-timeout-backend
         option httpchk GET /healthz
         timeout server 0
         timeout tunnel 0
-{% for minion_id, nodename in salt['mine.get']('roles:kube-master', 'nodename', 'grain').items() %}
+{% for id, nodename in masters.items() %}
         server master-{{ nodename }} {{ nodename }}.{{ pillar['internal_infra_domain'] }}:{{ pillar['api']['int_ssl_port'] }} ssl crt {{ pillar['ssl']['kube_apiserver_proxy_bundle'] }} ca-file /etc/pki/ca.crt check check-ssl port {{ pillar['api']['int_ssl_port'] }} verify required
 {%- endfor %}
 
 
-{% if "admin" in salt['grains.get']('roles', []) %}
+{% if "admin" in this_roles %}
 # Velum should be able to access Kube API and Dex service as well to get kubeconfig
 listen kubernetes-dex
         bind {{ bind_ip }}:{{ pillar['dex']['node_port'] }}
@@ -67,7 +74,7 @@ listen kubernetes-dex
         balance roundrobin
         option redispatch
         option httpchk GET /healthz
-{% for minion_id, nodename in salt['mine.get']('roles:kube-master', 'nodename', 'grain').items() %}
+{% for id, nodename in masters.items() %}
         server master-{{ nodename }} {{ nodename }}.{{ pillar['internal_infra_domain'] }}:{{ pillar['dex']['node_port'] }} check check-ssl port {{ pillar['dex']['node_port'] }} verify none
 {%- endfor %}
 

--- a/salt/orch/removal.sls
+++ b/salt/orch/removal.sls
@@ -325,8 +325,8 @@ highstate-affected:
 # remove the we-are-removing-some-node grain in the cluster
 remove-cluster-wide-removal-grain:
   salt.function:
-    - tgt: '{{ all_responsive_nodes_tgt }}'
-    - tgt_type: compound
+    - tgt: 'removal_in_progress:true'
+    - tgt_type: grain
     - name: grains.delval
     - arg:
       - removal_in_progress


### PR DESCRIPTION
Backport of #581.


* Fix targets when calculating a replacement. For example, when getting a replacement for a `kube-master`, we were looking for `G@roles:etcd`, when we should look for `G@roles:etcd and not G@roles:kube-master`.
* Do not include removed nodes when generating `haproxy.cfg`
* Refactorings in the `get_with_expr()` code
* Do not use unassigned nodes when looking for a replacement.
* Minor cleanups

See https://trello.com/c/eKXnJbzz and https://trello.com/c/mKb0nykK

