### PR TITLE
Uncordon node in a explicit sls action

### DIFF
--- a/salt/kubelet/init.sls
+++ b/salt/kubelet/init.sls
@@ -98,25 +98,6 @@ kubelet:
     - require:
       - service: kubelet
 
-{% if salt['grains.get']('kubelet:should_uncordon', false) %}
-uncordon-node:
-  caasp_cmd.run:
-    - name: |
-        kubectl --request-timeout=1m uncordon {{ grains['nodename'] }}
-    - retry:
-        attempts: 10
-        interval: 3
-        until: |
-          test "$(kubectl --request-timeout=1m --kubeconfig={{ pillar['paths']['kubeconfig'] }} get nodes {{ grains['nodename'] }} -o=jsonpath='{.spec.unschedulable}' 2>/dev/null)" != "true"
-    - require:
-      - file: {{ pillar['paths']['kubeconfig'] }}
-  grains.absent:
-    - name: kubelet:should_uncordon
-    - destructive: True
-    - require:
-      - caasp_cmd: uncordon-node
-{% endif %}
-
 #######################
 # config files
 #######################

--- a/salt/kubelet/update-post-start-services.sls
+++ b/salt/kubelet/update-post-start-services.sls
@@ -1,6 +1,36 @@
 # invoked by the "update" orchestration after starting
 # all the services after rebooting
 
+include:
+  - kubectl-config
+
+{% if salt['grains.get']('kubelet:should_uncordon', false) %}
+
+uncordon-node:
+  caasp_cmd.run:
+    - name: |
+        kubectl --request-timeout=1m uncordon {{ grains['nodename'] }}
+    - retry:
+        attempts: 10
+        interval: 3
+        until: |
+          test "$(kubectl --request-timeout=1m --kubeconfig={{ pillar['paths']['kubeconfig'] }} get nodes {{ grains['nodename'] }} -o=jsonpath='{.spec.unschedulable}' 2>/dev/null)" != "true"
+    - require:
+      - file: {{ pillar['paths']['kubeconfig'] }}
+  grains.absent:
+    - name: kubelet:should_uncordon
+    - destructive: True
+    - require:
+      - caasp_cmd: uncordon-node
+
+{% else %}
+
+uncordon-node:
+  cmd.run:
+    - name: "echo {{ grains['nodename'] }} should not be uncordoned. Skipping."
+
+{% endif %}
+
 remove-old-node-entry:
   cmd.run:
     - name: kubectl --request-timeout=1m delete node {{ grains['machine_id'] + "." + pillar['internal_infra_domain'] }}


### PR DESCRIPTION
This way we don't try to uncordon the node in the `kubelet/init.sls` file,
required for example by `haproxy`, that will end up in the machine trying
to early uncordon itself (when `haproxy` configuration hasn't been written
yet, and leading to early failure).

Splitting this action and called only when required (this is: the update
process) is safer.

Fixes: bsc#1080978