### PR TITLE
[3.0] Also stop `kubelet` on masters when performing an upgrade

### DIFF
--- a/salt/orch/update.sls
+++ b/salt/orch/update.sls
@@ -151,6 +151,7 @@ etcd-setup:
     - tgt: '{{ master_id }}'
     - sls:
       - container-feeder.stop
+      - kubelet.stop
       - kube-apiserver.stop
       - kube-controller-manager.stop
       - kube-scheduler.stop


### PR DESCRIPTION
If some important change lands between Kubernetes updates, it might
happen that since we don't disable the `kubelet` service on the master
nodes, when the machine gets rebooted, `systemd` will try to start the
`kubelet` service, failing in a burst mode.

This will prevent our salt states from trying to start it again, because
the service will be in a failed state. Stop the service and disable it
on the masters too when we are performing an upgrade, this way we are sure
that we'll try to start and enable it when we have performed the required
changes for it to succeed.

Fixes: bsc#1096768
(cherry picked from commit ec6238cb4d43983cce7c708b677c9e99e508d787)