### PR TITLE
Force `etc-hosts` sls to be run before `etcd`

### DIFF
--- a/salt/orch/update.sls
+++ b/salt/orch/update.sls
@@ -131,11 +131,16 @@ pre-orchestration-migration:
 #
 # Let's force etcd to refresh certificates on all machines, restarting the etcd service so we can
 # continue with the upgrade, as certificates will be valid for the old and the new SAN.
+#
+# We run the etc-hosts sls to make the machines refresh their references first (including old CaaSP
+# 2.0 and 3.0 naming). This way, etcd will be able to work with both namings during the upgrade
+# process.
 etcd-setup:
   salt.state:
     - tgt: '{{ is_etcd_tgt }}'
     - tgt_type: compound
     - sls:
+      - etc-hosts
       - etcd
     - batch: 1
     - require:


### PR DESCRIPTION
Before the real update orchestration happens we are updating etcd
certificates, so this machine isn't left isolated. However, in this
process, the configuration for etcd might refer to the new machine
names if this happens during the upgrade of 2.0 to 3.0. This might
leave the etcd instances in a state in which they cannot resolve
other etcd peer names (because their `/etc/hosts` file is outdated).

In order to prevent this, force the `etc-hosts` sls to be run before
we execute the `etcd` sls, so we are sure that `/etc/hosts` will
contain both the old and the new names during the upgrade, and etcd
will be able to refer to other peers using the new hostnames.

Fixes: bsc#1096750