### PR TITLE
Remove mine information when removing a node

### DIFF
--- a/salt/orch/force-removal.sls
+++ b/salt/orch/force-removal.sls
@@ -39,6 +39,12 @@ remove-cluster-wide-removal-grain:
     - kwarg:
         destructive: True
 
+remove-target-mine:
+  salt.function:
+    - tgt: {{ target }}
+    - name: mine.flush
+    - fail_minions: {{ target }}
+
 remove-target-salt-key:
   salt.wheel:
     - name: key.reject

--- a/salt/orch/removal.sls
+++ b/salt/orch/removal.sls
@@ -271,6 +271,14 @@ remove-from-cluster-in-super-master:
     - require:
       - shutdown-target
 
+# remove target information from the mine
+remove-target-mine:
+  salt.function:
+    - tgt: '{{ target }}'
+    - name: mine.flush
+    - require:
+        - remove-from-cluster-in-super-master
+
 # remove the Salt key and the mine for the target
 remove-target-salt-key:
   salt.wheel:
@@ -278,10 +286,10 @@ remove-target-salt-key:
     - include_accepted: True
     - match: {{ target }}
     - require:
-      - remove-from-cluster-in-super-master
+      - remove-target-mine
 
 # remove target's data in the Salt Master's cache
-remove-target-mine:
+remove-target-mine-cache:
   salt.runner:
     - name: cache.clear_all
     - tgt: '{{ target }}'
@@ -316,7 +324,7 @@ sync-after-removal:
       - saltutil.clear_cache
       - mine.update
     - require:
-      - remove-target-mine
+      - remove-target-mine-cache
 
 update-modules-after-removal:
   salt.function:


### PR DESCRIPTION
This will avoid to render stale information about critical components,
like `etcd` endpoints in the `etcd` configuration.

`etcd` is very sensitive to this kind of misleading (stale) information,
if more endpoints are provided in `ETCD_INITIAL_CLUSTER` than the ones
that actually exist in the cluster, a new instance of etcd will refuse
to start.

Fixes: bsc#1097001
Fixes: bsc#1097147