### PR TITLE
[3.0] Early setup some services on updates

### DIFF
--- a/salt/addons/psp/manifests/10-podsecuritypolicy-privileged.yaml
+++ b/salt/addons/psp/manifests/10-podsecuritypolicy-privileged.yaml
@@ -38,7 +38,6 @@ spec:
     - azureDisk
     - azureFile
     - vsphereVolume
-  allowedFlexVolumes: []
   #allowedHostPaths: []
   readOnlyRootFilesystem: false
   # Users and groups

--- a/salt/addons/psp/manifests/10-podsecuritypolicy-unprivileged.yaml
+++ b/salt/addons/psp/manifests/10-podsecuritypolicy-unprivileged.yaml
@@ -38,7 +38,6 @@ spec:
     - azureDisk
     - azureFile
     - vsphereVolume
-  allowedFlexVolumes: []
   allowedHostPaths:
     # Note: We don't allow hostPath volumes above, but set this to a path we
     # control anyway as a belt+braces protection. /dev/null may be a better


### PR DESCRIPTION
Backport of #597 

We are currently upgrading the cluster in this way:

1) for each machine
  1.1) stop flannel and so 
  1.2) reboot into a new version with no flannel daemon, only a CNI&flannel image
2) after all nodes have been upgraded, load CNI

So we are loosing connectivity one by one until we restore it when we load the CNI manifest.

In conclusion, we cannot wait until all the machines are updated for loading these manifests (CNI and the PSP). But it is not a good idea to load them before doing the update because these manifests could be incompatible with the old cluster.

So the "best" solution is to load them before we start the masters update. This could be problematic in some cases (as the new  manifests will be verified by an old cluster), buut there is no other alternative...

bsc#1096992
