### PR TITLE
[3.0] Move the early services setup before updating the masters

### DIFF
--- a/salt/addons/init.sls
+++ b/salt/addons/init.sls
@@ -1,7 +1,5 @@
 include:
-  - kube-apiserver
   - kubectl-config
-  - cri
 
 /etc/kubernetes/addons:
   file.directory:
@@ -9,8 +7,6 @@ include:
     - group:    root
     - dir_mode: 755
     - makedirs: True
-    - require:
-      - file: /etc/cni/net.d/87-podman-bridge.conflist
 
 {% from '_macros/kubectl.jinja' import kubectl_apply_template with context %}
 

--- a/salt/addons/psp/init.sls
+++ b/salt/addons/psp/init.sls
@@ -1,10 +1,9 @@
 {% if salt.caasp_pillar.get('addons:psp', True) %}
 
 include:
-  - kube-apiserver
   - kubectl-config
 
-{% from '_macros/kubectl.jinja' import kubectl, kubectl_apply_template, kubectl_apply_dir_template with context %}
+{% from '_macros/kubectl.jinja' import kubectl_apply_dir_template with context %}
 
 {{ kubectl_apply_dir_template("salt://addons/psp/manifests/",
                               "/etc/kubernetes/addons/psp/") }}

--- a/salt/cni/init.sls
+++ b/salt/cni/init.sls
@@ -1,5 +1,4 @@
 include:
-  - kube-apiserver
   - addons
   - kubectl-config
 
@@ -24,7 +23,6 @@ include:
     - env:
       - KUBECONFIG: {{ pillar['paths']['kubeconfig'] }}
     - require:
-      - kube-apiserver
       - file:      {{ pillar['paths']['kubeconfig'] }}
     - watch:
       - file:       /etc/kubernetes/addons/kube-flannel-rbac.yaml
@@ -42,7 +40,6 @@ include:
     - env:
       - KUBECONFIG: {{ pillar['paths']['kubeconfig'] }}
     - require:
-      - kube-apiserver
       - file:      {{ pillar['paths']['kubeconfig'] }}
     - watch:
       - /etc/kubernetes/addons/kube-flannel-rbac.yaml
@@ -69,7 +66,6 @@ include:
     - env:
       - KUBECONFIG: {{ pillar['paths']['kubeconfig'] }}
     - require:
-      - kube-apiserver
       - file:      {{ pillar['paths']['kubeconfig'] }}
     - watch:
       - file:       /etc/kubernetes/addons/cilium-config.yaml
@@ -87,7 +83,6 @@ include:
     - env:
       - KUBECONFIG: {{ pillar['paths']['kubeconfig'] }}
     - require:
-      - kube-apiserver
       - file:      {{ pillar['paths']['kubeconfig'] }}
     - watch:
       - file:       /etc/kubernetes/addons/cilium-rbac.yaml

--- a/salt/cni/update-post-reboot.sls
+++ b/salt/cni/update-post-reboot.sls
@@ -1,0 +1,7 @@
+
+/etc/cni/net.d/87-podman-bridge.conflist:
+  file.absent
+    # Has to be removed, otherwise kubernetes will use this CNI driver
+    # instead of the flannel one.
+    # Moreover, by doing that podman containers will be attached to the
+    # flannel network, which is useful for debugging.


### PR DESCRIPTION
Move the early services setup even before updating the masters (we can do this by removing some
unnecessary dependencies).

bsc#1096992