### PR TITLE
Salt 2018 compatibility

### DIFF
--- a/config/master.d/50-reactor.conf
+++ b/config/master.d/50-reactor.conf
@@ -6,3 +6,5 @@ reactor:
     - /usr/share/salt/kubernetes/reactor/etc-hosts.sls
   - 'salt/minion/*/start':
     - /usr/share/salt/kubernetes/reactor/etc-hosts.sls
+    - /usr/share/salt/kubernetes/reactor/sync-modules.sls
+    - /usr/share/salt/kubernetes/reactor/update-mine.sls

--- a/reactor/sync-modules.sls
+++ b/reactor/sync-modules.sls
@@ -1,0 +1,3 @@
+sync_modules:
+  local.saltutil.sync_modules:
+    - tgt: {{ data['id'] }}

--- a/reactor/update-mine.sls
+++ b/reactor/update-mine.sls
@@ -1,0 +1,3 @@
+update_mine:
+  local.mine.update:
+    - tgt: {{ data['id'] }}

--- a/salt/_beacons/default_network_interface_settings.py
+++ b/salt/_beacons/default_network_interface_settings.py
@@ -42,7 +42,12 @@ def beacon(config):
               promiscuity:
                 onvalue: 1
     '''
-
     default_interface = __salt__['network.default_route']()[0]['interface']
 
-    return network_settings.beacon({default_interface: config['watch']})
+    config = {default_interface: config['watch']}
+
+    if __salt__['test.version']() >= '2018.3.0':
+        config = [{'interfaces': config}]
+        log.debug("Newer salt version - adjusted config format: {0}".format(config))
+
+    return network_settings.beacon(config)

--- a/salt/_modules/caasp_filters.py
+++ b/salt/_modules/caasp_filters.py
@@ -3,6 +3,10 @@ from __future__ import absolute_import
 from salt._compat import ipaddress
 
 
+def __virtual__():
+    return "caasp_filters"
+
+
 def is_ip(ip):
     '''
     Returns a bool telling if the passed IP is a valid IPv4 or IPv6 address.

--- a/salt/_modules/caasp_http.py
+++ b/salt/_modules/caasp_http.py
@@ -22,6 +22,10 @@ import time
 import salt.utils.http
 
 
+def __virtual__():
+    return "caasp_http"
+
+
 def query(url, **kwargs):
     '''
     Query a resource, and decode the return data

--- a/salt/_modules/caasp_log.py
+++ b/salt/_modules/caasp_log.py
@@ -14,6 +14,10 @@ log = logging.getLogger('CaaS')
 _CAAS_PREFIX = '[CaaS]: '
 
 
+def __virtual__():
+    return "caasp_log"
+
+
 class ExecutionAborted(SaltException):
     pass
 

--- a/salt/_modules/caasp_nodes.py
+++ b/salt/_modules/caasp_nodes.py
@@ -22,6 +22,10 @@ IN_PROGRESS_GRAINS = ['bootstrap_in_progress',
 USE_UNASSIGNED = False
 
 
+def __virtual__():
+    return "caasp_nodes"
+
+
 def _get_prio_etcd(unassigned=False):
     '''
     Get the priorities for choosing new nodes for running

--- a/salt/addons/dex/init.sls
+++ b/salt/addons/dex/init.sls
@@ -16,6 +16,18 @@ include:
          cn = 'Dex',
          extra_alt_names = alt_master_names(dex_alt_names)) }}
 
+# This file needs to be explicitly copied over *before*
+# kubectL_apply_dir_templates run. Otherwise one of the templates attempts to
+# access the file, and it does not exist yet, breaking the orchestration.
+/etc/kubernetes/addons/dex/15-secret.yaml:
+  file.managed:
+    - source:   "salt://addons/dex/manifests/15-secret.yaml"
+    - user:     root
+    - group:    root
+    - mode:     0600
+    - template: jinja
+    - makedirs: true
+
 {{ kubectl_apply_dir_template("salt://addons/dex/manifests/",
                               "/etc/kubernetes/addons/dex/",
                               watch=[pillar['ssl']['dex_crt'], pillar['ssl']['dex_key']]) }}

--- a/salt/orch/update.sls
+++ b/salt/orch/update.sls
@@ -134,6 +134,7 @@ all-workers-2.0-pre-orchestration:
   salt.state:
     - tgt: '( {{ is_updateable_worker_tgt }} ) and G@osrelease:2.0'
     - tgt_type: compound
+    - expect_minions: false
     - batch: 3
     - sls:
         - migrations.2-3.kubelet.cordon
@@ -316,6 +317,7 @@ all-workers-2.0-pre-clean-shutdown:
   salt.state:
     - tgt: '( {{ is_updateable_worker_tgt }} ) and G@osrelease:2.0'
     - tgt_type: compound
+    - expect_minions: false
     - batch: 3
     - sls:
         - etc-hosts
@@ -333,6 +335,7 @@ all-workers-3.0-pre-clean-shutdown:
   salt.state:
     - tgt: '( {{ is_updateable_worker_tgt }} ) and G@osrelease:3.0'
     - tgt_type: compound
+    - expect_minions: false
     - batch: 3
     - sls:
         - etc-hosts


### PR DESCRIPTION
Changes required to make our salt states run with `salt 2018.3`.