### PR TITLE
During upgrade, ensure masters always have the correct taints

### DIFF
--- a/salt/kubelet/update-pre-orchestration.sh
+++ b/salt/kubelet/update-pre-orchestration.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 
 OLD_NODE_NAME="$1"
 NEW_NODE_NAME="$2"
+ROLE="$3"
 
 ##########################################################
 
@@ -66,6 +67,14 @@ spec:
   externalID: ${NEW_NODE_NAME}
   podCIDR: $(get_node_data .spec.podCIDR)
 EOF
+
+if [[ "$ROLE" == "master" ]]; then
+  cat << EOF >> /tmp/k8s-node-migration.yaml
+  taints:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master
+EOF
+fi
 
 kubectl --request-timeout=1m create -f /tmp/k8s-node-migration.yaml 2>/dev/null
 

--- a/salt/kubelet/update-pre-orchestration.sls
+++ b/salt/kubelet/update-pre-orchestration.sls
@@ -11,7 +11,11 @@ include:
     - source: salt://kubelet/update-pre-orchestration.sh
     - mode: 0755
   cmd.run:
-    - name: /tmp/kubelet-update-pre-orchestration.sh {{ grains['machine_id'] + "." + pillar['internal_infra_domain'] }} {{ grains['nodename'] }}
+{% if "kube-master" in salt['grains.get']('roles', []) %}
+    - name: /tmp/kubelet-update-pre-orchestration.sh {{ grains['machine_id'] + "." + pillar['internal_infra_domain'] }} {{ grains['nodename'] }} master
+{% else %}
+    - name: /tmp/kubelet-update-pre-orchestration.sh {{ grains['machine_id'] + "." + pillar['internal_infra_domain'] }} {{ grains['nodename'] }} worker
+{% endif %}
     - stateful: True
     - env:
       - KUBECONFIG: {{ pillar['paths']['kubeconfig'] }}


### PR DESCRIPTION
When migrating from the "old" to "new" names for the kubelets, we pre-create
the new node so that we can clone the network config. This means the kubelet
is NOT self-registering, and the "single use options" like --register-with-taints
are ignored. This means the kubelet is connected from the period of time where it
starts, to where salt later forcefully adds the taint. Any pods created during
this window could end up scheduled to the master.

bsc#1098383

Backport of https://github.com/kubic-project/salt/pull/608