### PR TITLE
Call to `mine.update` after `saltutil.sync_pillar` has been called.

### DIFF
--- a/salt/orch/update.sls
+++ b/salt/orch/update.sls
@@ -57,9 +57,19 @@ update-data:
     - names:
       - saltutil.refresh_pillar
       - saltutil.refresh_grains
-      - mine.update
     - require:
       - sync-pillar
+
+# This needs to be a separate step from `update-data`, so `saltutil.refresh_pillar` has been
+# called before this, discovering new mine functions defined in the pillar, before publishing
+# them on the mine.
+update-mine:
+  salt.function:
+    - tgt: '{{ is_responsive_node_tgt }}'
+    - tgt_type: compound
+    - name: mine.update
+    - require:
+      - update-data
 
 update-modules:
   salt.function:
@@ -69,7 +79,7 @@ update-modules:
     - kwarg:
         refresh: True
     - require:
-      - update-data
+      - update-mine
 
 # Generate sa key (we should refactor this as part of the ca highstate along with its counterpart
 # in orch/kubernetes.sls)


### PR DESCRIPTION
During an upgrade we want to call to `mine.update` after `saltutil.sync_pillar`
has been called, because the `mine_functions` reside on the pillar, we first want
to make sure to sync that, and update the mine afterwards. Otherwise, we risk
doing this in a race condition when the salt minion starts, and it could or
could not lead to update orchestration failure.

Fixes: bsc#1097478