### PR TITLE
[WIP] Use the EXISTING flag for etcd when some members have already been bootstrapped

### DIFF
--- a/salt/_modules/caasp_etcd.py
+++ b/salt/_modules/caasp_etcd.py
@@ -228,3 +228,12 @@ def get_member_id(nodename=None):
         error('output: %s', members_output)
 
     return ''
+
+
+def is_existing_cluster():
+    '''
+    Return True if a etcd cluster already exists (and it is running)
+    '''
+    current_etcd_members = __salt__['caasp_nodes.get_with_expr']('G@roles:etcd', booted=True)
+    debug("current list of bootstrapped etcd servers: %s", current_etcd_members)
+    return len(current_etcd_members) > 0

--- a/salt/etcd/etcd.conf.jinja
+++ b/salt/etcd/etcd.conf.jinja
@@ -30,7 +30,7 @@ ETCD_INITIAL_CLUSTER_TOKEN="{{ pillar['etcd']['token'] }}"
 ETCD_INITIAL_ADVERTISE_PEER_URLS="https://{{ this_addr }}:2380"
 
 {#- we will not use "existing" unless we are adding a new node to the cluster  #}
-{%- if salt['grains.get']('node_addition_in_progress', False) %}
+{%- if salt['caasp_etcd.is_existing_cluster']() or salt['grains.get']('node_addition_in_progress', False) %}
 ETCD_INITIAL_CLUSTER_STATE="existing"
 {%- endif %}
 


### PR DESCRIPTION
Use the `EXISTING` flag for etcd when some members have already been boostrapped.

bsc#1098161