### PR TITLE
[2.1] explicitly pass unix_socket

### DIFF
--- a/config/master.d/50-returner.conf
+++ b/config/master.d/50-returner.conf
@@ -1,11 +1,10 @@
 mysql:
-  # salt does not support specifying the UNIX socket location here - as a workaround,
-  # use the MYSQL_UNIX_PORT environment variable used by libmysqlclient
   # you still need the 'host' value here, or it will use the defaults and try to connect
   # on a host named 'salt'
   host: 'localhost'
   user: 'salt'
   db: 'velum_production'
+  unix_socket: '/var/run/mysql/mysql.sock'
 
 ext_pillar:
   - mysql:


### PR DESCRIPTION
this affects only kubic for now where we use PyMySQL

we cant use the MYSQL_UNIX_PORT workaround anymore as we could
do with MySQLdb

salt#mysql-unix-socket

Signed-off-by: Maximilian Meister <mmeister@suse.de>
(cherry picked from commit 45b8f7b54511f38135d7fdbbd36cc262349f9d45)