### PR TITLE
Stop kubelet before any other services

### DIFF
--- a/salt/orch/removal.sls
+++ b/salt/orch/removal.sls
@@ -202,6 +202,17 @@ remove-addition-grain:
 # the replacement should be ready at this point:
 # we can remove the old node running in {{ target }}
 
+early-stop-services-in-target:
+  salt.state:
+    - tgt: '{{ target }}'
+    - sls:
+      - kubelet.stop
+    - require:
+      - update-modules
+  {%- if replacement %}
+      - remove-addition-grain
+  {%- endif %}
+
 stop-services-in-target:
   salt.state:
     - tgt: '{{ target }}'
@@ -212,17 +223,13 @@ stop-services-in-target:
       - kube-controller-manager.stop
       - kube-scheduler.stop
   {%- endif %}
-      - kubelet.stop
       - kube-proxy.stop
       - cri.stop
   {%- if target in etcd_members %}
       - etcd.stop
   {%- endif %}
     - require:
-      - update-modules
-  {%- if replacement %}
-      - remove-addition-grain
-  {%- endif %}
+      - early-stop-services-in-target
 
 # remove any other configuration in the machines
 cleanups-in-target-before-rebooting:


### PR DESCRIPTION
Explicitly stop kubelet before any other services. If cri.stop is ran in parallel
to or before kubelet.stop, kubelet will be unable to successfully drain.

bsc#1085980