### PR TITLE
[CPI] Option to ignore OpenStack Cinder availability zone, bsc#1095572

### DIFF
--- a/pillar/params.sls
+++ b/pillar/params.sls
@@ -158,6 +158,9 @@ cloud:
     lb_mon_retries: '3'
     # OpenStack Cinder Block Storage API version
     bs_version:     'v2'
+    # Ignore OpenStack Cinder avability zone when attaching volumes. 
+    # When Nova and Cinder have different availability zones, this should be set to true.
+    ignore_vol_az:  'false'
 
 # Configuration for the reboot manager (https://github.com/SUSE/rebootmgr).
 # notes:

--- a/salt/kubernetes-common/openstack-config.jinja
+++ b/salt/kubernetes-common/openstack-config.jinja
@@ -24,3 +24,4 @@ monitor-max-retries={{ pillar['cloud']['openstack']['lb_mon_retries'] }}
 [BlockStorage]
 trust-device-path=false
 bs-version={{ pillar['cloud']['openstack']['bs_version'] }}
+ignore-volume-az={{ pillar['cloud']['openstack']['ignore_vol_az'] }}


### PR DESCRIPTION

Ignore OpenStack Cinder avability zone when attaching volumes.
When Nova and Cinder have different availability zones,
this should be set to true. Default is false.