### PR TITLE
[3.0] Configure addon pod affinity

### DIFF
--- a/salt/addons/dns/manifests/20-deployment.yaml
+++ b/salt/addons/dns/manifests/20-deployment.yaml
@@ -29,6 +29,18 @@ spec:
         effect: NoSchedule
       - key: "CriticalAddonsOnly"
         operator: "Exists"
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              topologyKey: "kubernetes.io/hostname"
+              labelSelector:
+                matchExpressions:
+                - key: k8s-app
+                  operator: In
+                  values:
+                  - kube-dns
       volumes:
       - name: kube-dns-config
         configMap:

--- a/salt/addons/tiller/manifests/20-deployment.yaml
+++ b/salt/addons/tiller/manifests/20-deployment.yaml
@@ -30,6 +30,18 @@ spec:
         effect: NoSchedule
       - key: "CriticalAddonsOnly"
         operator: "Exists"
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              topologyKey: "kubernetes.io/hostname"
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - tiller
       containers:
       - env:
         - name: TILLER_NAMESPACE


### PR DESCRIPTION
Sometimes, Kubernetes will schedule all replicas of an addon to the same
machine. Defeating much of the purpose of running multiple replicas.

Configure all addons with affinity rules to encourage Kubernetes to spread
these pods around the available machines.

bsc#1101805

Backport of https://github.com/kubic-project/salt/pull/632