### PR TITLE
[3.0] HAProxy will refuse to start if it cannot resolve any name.

### DIFF
--- a/salt/haproxy/init.sls
+++ b/salt/haproxy/init.sls
@@ -1,6 +1,7 @@
 include:
   - ca-cert
   - cert
+  - etc-hosts
 {% if not salt.caasp_nodes.is_admin_node() %}
 # This state is executed also on the admin node. On the admin
 # node we cannot require the kubelet state otherwise the node will


### PR DESCRIPTION
In a context in which cloud-init could be updating the hostnames after
machines are continuing with the update orchestration, we could be
writing one thing to `/etc/hosts` and another one in the `haproxy`
configuration, refusing this one to start because it cannot resolve
the new name.

This easily fixable in a newer HAProxy version by using the `init-addr`
configuration, so HAProxy won't refuse to start if it cannot resolve
any backend -- it will just ignore it --.

For now, let's make the temporal window as small as possible, making
the `haproxy` init.sls depend on the `etc-hosts` SLS, as it's *so*
dependant on it.

However, this is not in any way an ideal fix; rather a way to make
this problematic window as small as possible.

Fixes: bsc#1097478
(cherry picked from commit 6fd96da5bd49dce4f8636afb940ce75721d2d186)

Backport of https://github.com/kubic-project/salt/pull/635
Please, refer to https://bugzilla.suse.com/show_bug.cgi?id=1097478#c22 for more information.