### PR TITLE
Reintroduce kubelet drain timeout and abort if draining fails

### DIFF
--- a/pillar/params.sls
+++ b/pillar/params.sls
@@ -128,6 +128,8 @@ kubelet:
   eviction-hard: ''
   # example:
   # eviction-hard: memory.available<500M
+  # Drain timeout, in seconds
+  drain-timeout: '600'
 
 proxy:
   http:           ''

--- a/salt/kubelet/stop.sls
+++ b/salt/kubelet/stop.sls
@@ -7,13 +7,10 @@ include:
 {% set should_uncordon = salt['cmd.run']("kubectl --request-timeout=1m --kubeconfig=" + pillar['paths']['kubeconfig'] + " get nodes " + grains['nodename'] + " -o=jsonpath='{.spec.unschedulable}' 2>/dev/null") != "true" %}
 {% set node_removal_in_progress = salt['grains.get']('node_removal_in_progress', False) %}
 
-# If this fails we should ignore it and proceed anyway as Kubernetes will recover
 drain-kubelet:
   cmd.run:
     - name: |
-        kubectl --request-timeout=1m --kubeconfig={{ pillar['paths']['kubeconfig'] }} drain {{ grains['nodename'] }} --force --delete-local-data=true --ignore-daemonsets
-    - check_cmd:
-      - /bin/true
+        kubectl --request-timeout=1m --kubeconfig={{ pillar['paths']['kubeconfig'] }} drain {{ grains['nodename'] }} --force --delete-local-data=true --ignore-daemonsets --timeout={{ pillar['kubelet']['drain-timeout'] }}s
     - require:
       - file: {{ pillar['paths']['kubeconfig'] }}
   {%- if not node_removal_in_progress %}


### PR DESCRIPTION
This is a partial revert of 03d371fc489f4bd0e15da348b60390aa558daf76. We reintroduce
the --timeout flag, leaving --grace-period unset (thus, inheriting from from the Pods
terminationGracePeriodSeconds value). Without this, kubectl drain can hang forever in
certain circumstances.

Additionally, should the drain fail, then fail the orchestration. This ensures that we
do not reboot a node which has, for example, SES/Ceph mounts active, which would in
turn cause systemd to hang as the machine is rebooted.

bsc#1104217