### PR TITLE
Create RoleBinding to allow dex discovery

### DIFF
--- a/salt/addons/dex/manifests/10-rolebinding.yaml
+++ b/salt/addons/dex/manifests/10-rolebinding.yaml
@@ -1,0 +1,19 @@
+---
+# Allow any authenticated *or* unauthenticated
+# user to look up Dex's service entry
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: suse:caasp:read-dex-service
+  namespace: kube-system
+subjects:
+- kind: Group
+  name: system:authenticated
+  apiGroup: rbac.authorization.k8s.io
+- kind: Group
+  name: system:unauthenticated
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: suse:caasp:read-dex-service
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
This RoleBinding allows unauthenticated users (such as those using caasp-cli)
to find the Dex service endpoint.

This was dropped in 3cdcfaedb2d029694a34fbcb147087eccea3e25a

bsc#1104658