### PR TITLE
Pass `ETCDCTL_API` version as an envvar instead of at the command name.

### DIFF
--- a/salt/_states/caasp_etcd.py
+++ b/salt/_states/caasp_etcd.py
@@ -71,7 +71,7 @@ def member_add(name, **kwargs):
     if api_version() == 'etcd2':
         name = 'member add {} {}'.format(this_id, this_peer_url)
     else:
-        name = 'member add {} --peer-urls="{}"'.format(this_id, this_peer_url)
+        name = 'member add {} --peer-urls={}'.format(this_id, this_peer_url)
     log.debug('CaaS: adding etcd member')
     return etcdctl(name=name, skip_this=True, **kwargs)
 


### PR DESCRIPTION
This would not work as what is fork + exec'ed is the `ETCDCTL_API=version`,
what is not found in the `PATH`, causing the whole command to fail.

Besides, each version produces a different output, and the parsing needs to
be updated in order to properly get the member id.

Follow up of https://github.com/kubic-project/salt/pull/622