### PR TITLE
Fix bsc#1101004 removes extra configuration for transactional updates

### DIFF
--- a/salt/transactional-update/10-increase-update-speed.conf.jinja
+++ b/salt/transactional-update/10-increase-update-speed.conf.jinja
@@ -1,2 +1,0 @@
-[Timer]
-OnCalendar={{ salt['pillar.get']('transactional-update:timer:on_calendar', 'OnCalendar=daily') }} 

--- a/salt/transactional-update/10-update-rebootmgr-options.conf
+++ b/salt/transactional-update/10-update-rebootmgr-options.conf
@@ -1,3 +1,0 @@
-[Service]
-ExecStart=
-ExecStart=/usr/sbin/transactional-update cleanup dup salt

--- a/salt/transactional-update/init.sls
+++ b/salt/transactional-update/init.sls
@@ -1,35 +1,9 @@
 {% if 'ca' not in salt['grains.get']('roles', []) %}
-/etc/systemd/system/transactional-update.service.d/10-update-rebootmgr-options.conf:
-  file.managed:
-    - makedirs: true
-    - source: salt://transactional-update/10-update-rebootmgr-options.conf
-    - user: root
-    - group: root
-    - mode: 644
-  module.run:
-    - name: service.systemctl_reload
-    - onchanges:
-      - file: /etc/systemd/system/transactional-update.service.d/10-update-rebootmgr-options.conf
-
-/etc/systemd/system/transactional-update.timer.d/10-increase-update-speed.conf:
-  file.managed:
-    - makedirs: true
-    - template: jinja
-    - source: salt://transactional-update/10-increase-update-speed.conf.jinja
-    - user: root
-    - group: root
-    - mode: 644
-  module.run:
-    - name: service.systemctl_reload
-    - onchanges:
-      - file: /etc/systemd/system/transactional-update.timer.d/10-increase-update-speed.conf
-
 transactional-update.timer:
   service.running:
     - name: transactional-update.timer
     - enable: True
     - watch:
-      - file: /etc/systemd/system/transactional-update.timer.d/10-increase-update-speed.conf
       - file: /etc/transactional-update.conf
 
 /etc/transactional-update.conf:


### PR DESCRIPTION
Admins want to override themselves how often the system updates, so removed the configuration files we where setting up.

Fix bsc#1101004

Signed-off-by: Vicente Zepeda Mas <vzepedamas@suse.com>