### PR TITLE
Fix bsc#1101004 removes unsused pillars for transactional updates

### DIFF
--- a/pillar/params.sls
+++ b/pillar/params.sls
@@ -174,10 +174,6 @@ reboot:
   group:          'default'
   directory:      'opensuse.org/rebootmgr/locks'
 
-transactional-update:
-  timer:
-    on_calendar: 'daily' # See https://www.freedesktop.org/software/systemd/man/systemd.time.html#Calendar%20Events for syntax
-
 dex:
   node_port: '32000'
   client_secrets:


### PR DESCRIPTION
Transactional Update pillars where left behind after the removal of the configuration files.
There are not being used anymore hence the need to remove them.