### PR TITLE
Fix bsc#1105910 CAdvisor is publicly exposed on the kubernetes nodes(:::4194)

### DIFF
--- a/salt/kubelet/kubelet.jinja
+++ b/salt/kubelet/kubelet.jinja
@@ -19,6 +19,7 @@ KUBELET_HOSTNAME="--hostname-override={{ grains['nodename'] }}"
 
 # Add your own!
 KUBELET_ARGS="\
+    --cadvisor-port=0 \
     --config=/etc/kubernetes/kubelet-config.yaml \
 {%- if salt.caasp_pillar.get_kubelet_reserved_resources('kube') %}
     --kube-reserved={{ salt.caasp_pillar.get_kubelet_reserved_resources('kube') }} \


### PR DESCRIPTION
This PR disables CAdvisor in kubelet.