### PR TITLE
[3.0] CAdvisor is publicly exposed on the kubernetes nodes(:::4194) (bsc#1105910)

### DIFF
--- a/salt/kubelet/kubelet.jinja
+++ b/salt/kubelet/kubelet.jinja
@@ -18,6 +18,7 @@ KUBELET_HOSTNAME="--hostname-override={{ grains['nodename'] }}"
 # Add your own!
 KUBELET_ARGS="\
     --cadvisor-port=0 \
+    --read-only-port=0 \
     --cgroups-per-qos \
     --cgroup-driver=cgroupfs \
     --cgroup-root=/ \

--- a/salt/kubelet/kubelet.jinja
+++ b/salt/kubelet/kubelet.jinja
@@ -17,6 +17,7 @@ KUBELET_HOSTNAME="--hostname-override={{ grains['nodename'] }}"
 
 # Add your own!
 KUBELET_ARGS="\
+    --cadvisor-port=0 \
     --cgroups-per-qos \
     --cgroup-driver=cgroupfs \
     --cgroup-root=/ \


### PR DESCRIPTION
This PR disables CAdvisor in kubelet.

(Cherry picked from commit 985323ba9f9912c1493053f9f95a630ab48112ef)