### PR TITLE
[3.0] Allow `etcd` to grow as required and shrink to optimal etcd cluster sizes on corner cases

### DIFF
--- a/pillar/params.sls
+++ b/pillar/params.sls
@@ -40,7 +40,7 @@ api:
   # port for listening for SSL connections (kube-api)
   int_ssl_port:   '6444'
   # etcd storage backend version for cluster
-  etcd_version:   'etcd3'
+  etcd_version:   'etcd2'
 
   server:
     # should be set from the UI

--- a/pillar/params.sls
+++ b/pillar/params.sls
@@ -40,7 +40,7 @@ api:
   # port for listening for SSL connections (kube-api)
   int_ssl_port:   '6444'
   # etcd storage backend version for cluster
-  etcd_version:   'etcd2'
+  etcd_version:   'etcd3'
 
   server:
     # should be set from the UI

--- a/salt/_modules/caasp_etcd.py
+++ b/salt/_modules/caasp_etcd.py
@@ -21,7 +21,7 @@ class NoEtcdServersException(Exception):
 
 
 def api_version():
-    return __salt__['pillar.get']('etcd_version', 'etcd3')
+    return __salt__['pillar.get']('etcd_version', 'etcd2')
 
 
 def _optimal_etcd_number(num_nodes):

--- a/salt/_modules/caasp_etcd.py
+++ b/salt/_modules/caasp_etcd.py
@@ -1,16 +1,21 @@
 from __future__ import absolute_import
 
+import re
 import subprocess
+
+from urlparse import urlparse
 
 # note: do not import caasp modules other than caasp_log
 from caasp_log import debug, error, warn
 
-# minimum number of etcd masters we recommend
+# minimum number of etcd members we recommend
 MIN_RECOMMENDED_MEMBER_COUNT = 3
 
 # port where etcd listens for clients
 ETCD_CLIENT_PORT = 2379
 
+# default etcd peer port
+ETCD_PEER_PORT = 2380
 
 def __virtual__():
     return "caasp_etcd"
@@ -65,7 +70,7 @@ def get_cluster_size(**kwargs):
 
         member_count = _optimal_etcd_number(num_masters)
         if member_count < MIN_RECOMMENDED_MEMBER_COUNT:
-            # Attempt to increase the number of etcd master to 3,
+            # Attempt to increase the number of etcd members to 3,
             # however, if we don't have 3 nodes in total,
             # then match the number of nodes we have.
             increased_member_count = len(masters) + len(minions)
@@ -95,6 +100,46 @@ def get_cluster_size(**kwargs):
     return member_count
 
 
+def get_surplus_etcd_members(num_wanted=None, targets=[], **kwargs):
+    '''
+    Taking into account
+
+      1) the current number of etcd members, and
+      2) the number of etcd nodes we should be running in the
+         cluster (obtained with `get_cluster_size()`)
+      3) the `targets` to be removed overall
+
+    get a list of surplus nodes (IDs) that should not run `etcd`, not included
+    in `targets`
+    '''
+    excluded = kwargs.get('excluded', [])
+
+    current_etcd_members = __salt__['caasp_nodes.get_from_args_or_with_expr'](
+        'etcd_members', kwargs, 'G@roles:etcd')
+    num_current_etcd_members = len(current_etcd_members)
+
+    targets_and_etcd_members = set(targets).intersection(set(current_etcd_members))
+
+    # the number of etcd members that should be in the cluster
+    num_wanted_etcd_members = num_wanted or get_cluster_size(**kwargs)
+    # ... and the number we are passing
+    num_surplus_etcd_members = num_current_etcd_members - num_wanted_etcd_members
+
+    if num_surplus_etcd_members <= 0:
+        debug('get_surplus_etcd_members: we dont need to remove etcd members')
+        return []
+
+    debug('get_surplus_etcd_members: curr:%d wanted:%d -> %d surplus',
+          num_current_etcd_members, num_wanted_etcd_members, num_surplus_etcd_members)
+
+    result = __salt__['caasp_nodes.get_with_prio_for_role'](
+        num_surplus_etcd_members, 'etcd-removal',
+        unassigned=False,
+        excluded=targets + excluded)
+
+    return result[:-len(targets_and_etcd_members)]
+
+
 def get_additional_etcd_members(num_wanted=None, **kwargs):
     '''
     Taking into account
@@ -116,7 +161,7 @@ def get_additional_etcd_members(num_wanted=None, **kwargs):
         'etcd_members', kwargs, 'G@roles:etcd')
     num_current_etcd_members = len(current_etcd_members)
 
-    # the number of etcd masters that should be in the cluster
+    # the number of etcd members that should be in the cluster
     num_wanted_etcd_members = num_wanted or get_cluster_size(**kwargs)
     # ... and the number we are missing
     num_additional_etcd_members = num_wanted_etcd_members - num_current_etcd_members
@@ -151,24 +196,43 @@ def get_additional_etcd_members(num_wanted=None, **kwargs):
     return new_etcd_members
 
 
-def get_endpoints(with_id=False, skip_this=False, skip_removed=False, port=ETCD_CLIENT_PORT, sep=','):
+def get_endpoints_expr(skip_this=False, skip_removed=False, only_bootstrapped=True):
     '''
-    Build a comma-separated list of etcd endpoints
+    Returns the salt matcher to target the expected minions
 
-    It will skip
+    Arguments:
 
-      * current node, when `skip_this=True`
-      * nodes with G@node_removal_in_progress=true, when `skip_removed=True`
-
+    * `skip_this`: Skip this machine from being included in the results.
+    * `skip_removed`: Skip the machines that are currently in the process of being removed.
+    * `only_boostrapped`: Only include machines that have been successfully bootstrapped in the past.
     '''
-    expr = 'G@roles:etcd'
+    expr = ['G@roles:etcd']
+
+    if skip_this:
+        expr.append('not ' + __salt__['grains.get']('id'))
     if skip_removed:
-        expr += ' and not G@node_removal_in_progress:true'
+        expr.append('not G@node_removal_in_progress:true')
+    if only_bootstrapped and not __salt__['caasp_nodes.is_first_bootstrap']():
+        expr.append('( G@bootstrap_complete:true or ' + __salt__['grains.get']('id') + ' )')
 
+    return ' and '.join(expr)
+
+
+def get_endpoints_raw(with_id=False, skip_this=False, skip_removed=False, only_bootstrapped=True, port=ETCD_CLIENT_PORT):
+    '''
+    Build a list of cached etcd endpoints as seen by salt.
+
+    Arguments:
+
+    * `with_id`: Return the nodename of each endpoint along with the endpoint itself (form `nodename=endpoint`).
+    * `skip_this`: Skip this machine from being included in the result.
+    * `skip_removed`: Skip the machines that are currently in the process of being removed.
+    * `only_boostrapped`: Only include machines that have been successfully bootstrapped in the past.
+    * `port`: The port to be used in the endpoints.
+    '''
+    expr = get_endpoints_expr(skip_this, skip_removed, only_bootstrapped)
     etcd_members_lst = []
     for (node_id, name) in __salt__['caasp_grains.get'](expr).items():
-        if skip_this and name == __salt__['caasp_net.get_nodename']():
-            continue
         member_endpoint = 'https://{}:{}'.format(name, port)
         if with_id:
             member_endpoint = "{}={}".format(node_id, member_endpoint)
@@ -179,14 +243,123 @@ def get_endpoints(with_id=False, skip_this=False, skip_removed=False, port=ETCD_
         raise NoEtcdServersException()
 
     etcd_members_lst.sort()
-    return sep.join(etcd_members_lst)
+    return etcd_members_lst
+
+
+def get_endpoints(with_id=False, skip_this=False, skip_removed=False, only_bootstrapped=True, port=ETCD_CLIENT_PORT, sep=','):
+    '''
+    Retrieve the list of cached etcd endpoints as seen by salt as a string, separated by `sep`.
+
+    Arguments:
+
+    * `with_id`: Return the nodename of each endpoint along with the endpoint itself (form `nodename=endpoint`).
+    * `skip_this`: Skip this machine from being included in the result.
+    * `skip_removed`: Skip the machines that are currently in the process of being removed.
+    * `only_boostrapped`: Only include machines that have been successfully bootstrapped in the past.
+    * `port`: The port to be used in the endpoints.
+    * `sep`: The separator to be used to convert the list in a string.
+    '''
+    return sep.join(get_endpoints_raw(with_id, skip_this, skip_removed, only_bootstrapped, port))
+
+
+def get_current_endpoints_raw(with_id=False, port=ETCD_CLIENT_PORT):
+    '''
+    Build a list of current etcd endpoints (as currently seen by the etcd cluster).
+
+    Arguments:
+
+    * `with_id`: (optional) Return the nodename of each endpoint along with the endpoint itself (form `nodename=endpoint`).
+    * `port`: (optional) The port to be used for the endpoints.
+
+    This requires etcd to be responding. Otherwise, `subprocess.CalledProcessError` will be raised.
+    '''
+    etcd_members_lst = []
+    for member in member_list()['active']:
+        member_endpoint = urlparse(member['peer_urls'])
+        member_endpoint = member_endpoint._replace(netloc=member_endpoint.netloc.replace(str(member_endpoint.port), str(port)))
+        member_endpoint = member_endpoint.geturl()
+        if with_id:
+            member_endpoint = "{}={}".format(member['name'], member_endpoint)
+        etcd_members_lst.append(member_endpoint)
+
+    etcd_members_lst.sort()
+    return etcd_members_lst
+
+
+def this_endpoint(with_id=True, port=ETCD_CLIENT_PORT):
+    '''
+    Retrieve this endpoint as a string.
+
+    Arguments:
+
+    * `with_id`: (optional) Whether to include the node id in the endpoint (not the member id).
+    * `port`: (optional) The port to be used in this endpoint.
+    '''
+    endpoint = 'https://{}:{}'.format(__salt__['grains.get']('nodename'), port)
+    if with_id:
+        return '{}={}'.format(__salt__['grains.get']('id'), endpoint)
+
+    return endpoint
+
+
+def get_current_endpoints(with_id=False, port=ETCD_CLIENT_PORT, sep=','):
+    '''
+    Retrieve the list of current endpoints as seen by the etcd cluster as a string, separated by `sep`.
+
+    This requires etcd to be responding. Otherwise, `subprocess.CalledProcessError` will be raised.
+    '''
+    return sep.join(get_current_endpoints_raw(with_id, port))
+
+
+def get_current_endpoints_with_self(port=ETCD_CLIENT_PORT, with_id=True, sep=','):
+    '''
+    Retrieve the list of current endpoints as seen by the etcd cluster as a string, separated by
+    `sep`, also including the local endpoint.
+
+    First, we try to retrieve this list from the live etcd cluster. This allows us to easily write
+    the real configuration for other etcd instances if we are growing the cluster or modifying it,
+    since `etcd` is very sensitive with endpoints, and they should match what etcd has in its
+    cluster information at the moment. This is usually the case when we are growing/shrinking the
+    cluster.
+
+    If we cannot retrieve the endpoints from the etcd cluster, we fallback to a salt 'cached'
+    result, using grains. Depending on the state of the cluster, this might be used during upgrades,
+    for example. It's fine to use our 'cache' in this case, because at that time we don't expect the
+    `etcd` cluster to change.
+
+    Arguments:
+
+    * `port`: The port to be used on the endpoints.
+    * `with_id`: Whether the endpoints should also include the name of the member (not the member id).
+    * `sep`: The separator to use when joining the list of current endpoints into a single string.
+    '''
+    try:
+        current_endpoints = get_current_endpoints_raw(with_id=with_id, port=port)
+    except subprocess.CalledProcessError:
+        debug('Could not retrieve endpoints from the etcd cluster, falling back to cached results')
+        try:
+            current_endpoints = get_endpoints_raw(with_id=with_id, skip_this=True, skip_removed=True, only_bootstrapped=True, port=port)
+        except NoEtcdServersException:
+            # In a 1+1 deployment since we are doing `skip_this` a `NoEtcdServersException` might be raised, in that case we are going
+            # to add this endpoint later on here, so don't worry about it.
+            current_endpoints = []
+
+    this_endpoint_ = this_endpoint(with_id=with_id, port=port)
+    if this_endpoint_ not in current_endpoints:
+        current_endpoints.append(this_endpoint_)
+        current_endpoints.sort()
+
+    return sep.join(current_endpoints)
 
 
 def get_etcdctl_args(skip_this=False):
     '''
-    Build the list of args for 'etcdctl'
+    Build the list of args for etcdctl.
+
+    This will include all current etcd members endpoints.
     '''
     etcdctl_args = []
+
     if api_version() == 'etcd2':
         etcdctl_args += ["--ca-file", __salt__['pillar.get']('ssl:ca_file')]
         etcdctl_args += ["--key-file", __salt__['pillar.get']('ssl:key_file')]
@@ -203,15 +376,14 @@ def get_etcdctl_args(skip_this=False):
 
 def get_etcdctl_args_str(**kwargs):
     '''
-    Get the 'etcdctl' arguments (as a string)
+    Get the etcdctl arguments (as a string)
     '''
     return " ".join(get_etcdctl_args(**kwargs))
 
 
 def get_member_id(nodename=None):
     '''
-    Return the member ID (different from the node ID) for
-    a etcd member of the cluster.
+    Return the member ID (different from the node ID) for an etcd member of the cluster.
 
     Arguments:
 
@@ -219,19 +391,12 @@ def get_member_id(nodename=None):
                   want the ID for. if no name is provided (or empty),
                   the local node will be used.
     '''
-    command = ["etcdctl"] + get_etcdctl_args() + ["member", "list"]
-    if api_version() == 'etcd2':
-        command.insert(0, "ETCDCTL_API=2")
-    else:
-        command.insert(0, "ETCDCTL_API=3")
-
     target_nodename = nodename or __salt__['caasp_net.get_nodename']()
 
-    debug("getting etcd member ID with: %s", command)
     members_output = ''
     try:
         target_url = 'https://{}:{}'.format(target_nodename, ETCD_CLIENT_PORT)
-        members_output = subprocess.check_output(command)
+        members_output = etcdctl(["member", "list"])
         for member_line in members_output.splitlines():
             if target_url in member_line:
                 return member_line.split(':')[0]
@@ -241,3 +406,138 @@ def get_member_id(nodename=None):
         error('output: %s', members_output)
 
     return ''
+
+
+def is_member_registered(nodename=None, port=ETCD_CLIENT_PORT):
+    '''
+    Returns whether the provided `nodename` using `port` is already registered as an etcd member.
+
+    This requires etcd to be responding.
+    '''
+    target_nodename = nodename or __salt__['caasp_net.get_nodename']()
+    target_url = 'https://{}:{}'.format(target_nodename, port)
+    member_list_ = member_list()
+
+    for group in member_list_.keys():
+        if target_url in map(lambda member: member['peer_urls'], member_list_[group]):
+            return True
+
+    return False
+
+
+def should_register_etcd_member(nodename=None, port=ETCD_CLIENT_PORT):
+    '''
+    Returns whether a `nodename` with `port` should be registered in etcd or not.
+
+    This is called by machines having the `etcd` role, to find out if they should call to
+    `member_add` or not.
+
+    If `nodename` is `None`, the local `nodename` grain will be used.
+
+    The rationale is that we need to add an etcd member only if it's not the first bootstrap
+    (no etcd members will be joining a cluster, they'll be creating a new one), the cluster needs
+    to be in a healthy state, and the member should not be already registered.
+    '''
+    return not __salt__['caasp_nodes.is_first_bootstrap']() and healthy() and not is_member_registered(nodename=nodename, port=port)
+
+
+def healthy():
+    '''
+    Returns whether the etcd cluster is healthy or not.
+    '''
+    try:
+        if api_version() == 'etcd2':
+            etcdctl(['cluster-health'])
+        else:
+            etcdctl(['endpoint', 'health'])
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+def member_list():
+    '''
+    Returns the member list as seen by the etcd cluster.
+
+    The result is a hash with `active` and `unstarted` keys. `active` members are those which
+    actually has ever registered against etcd. `unstarted` members are those that have been
+    added to `etcd` (by using `member_add`), but did not yet start `etcd` on that machine, so
+    `etcd` is aware of it, but it's not yet active.
+
+    This requires etcd to be responding.
+    '''
+    result = {'active': [], 'unstarted': []}
+    etcdctl_output = etcdctl(["member", "list"])
+    etcdctl_output_active_matcher = re.compile('([^:]+):\s+name=([^\s]+)\s+peerURLs=([^\s]+)\s+clientURLs=([^\s]+)\s+isLeader=(true|false)')
+    etcdctl_output_unstarted_matcher = re.compile('([^\[]+)\[unstarted\]:\s+peerURLs=([^\s]+)')
+    for member_line in etcdctl_output.splitlines():
+        matches = etcdctl_output_active_matcher.match(member_line)
+        if matches:
+            matches = matches.groups()
+            result['active'].append({'member_id': matches[0], 'name': matches[1], 'peer_urls': matches[2], 'client_urls': matches[3], 'is_leader': (matches[4] == 'true')})
+        matches = etcdctl_output_unstarted_matcher.match(member_line)
+        if matches:
+            matches = matches.groups()
+            result['unstarted'].append({'member_id': matches[0], 'peer_urls': matches[1]})
+
+    return result
+
+
+def member_add(name=None, nodename=None, port=ETCD_PEER_PORT):
+    '''
+    Adds `nodename` with `port` as an etcd member with name `name`.
+
+    This just raises awareness of a new member coming. etcd needs to be started with the proper
+    arguments in order for that member to actually register.
+
+    If `name` is None the local `id` grain of this machine will be used.
+    If `nodename` is None the local `nodename` grain of this machine will be used.
+
+    This requires etcd to be responding.
+    '''
+    this_id = name or __salt__['grains.get']('id')
+    nodename_ = nodename or __salt__['caasp_net.get_nodename']()
+    this_peer_url = 'https://{}:{}'.format(nodename_, port)
+
+    debug('CaaS: adding etcd member %s', this_id)
+    if api_version() == 'etcd2':
+        return etcdctl(['member', 'add', this_id, this_peer_url], skip_this=True)
+    else:
+        return etcdctl(['member', 'add', this_id, '--peer-urls="{}"'.format(this_peer_url)], skip_this=True)
+
+
+def member_remove(nodename=None):
+    '''
+    Remove `nodename` as an etcd member.
+
+    If `nodename` is none the local `nodename` grain of this machine will be used to identify the
+    member ID of this machine in the etcd cluster.
+
+    This requires etcd to be responding.
+    '''
+    nodename_ = nodename or __salt__['caasp_net.get_nodename']()
+    target_member_id = get_member_id(nodename=nodename_)
+    if not target_member_id:
+        return False
+
+    debug('CaaS: removing etcd member %s', target_member_id)
+    return etcdctl(['member', 'remove', target_member_id])
+
+
+def etcdctl(command, skip_this=False):
+    '''
+    Execute `command` as an etcdctl command.
+
+    We will pass to etcdctl command the list of all the endpoints we are aware are running `etcd`
+    at the time of running this command.
+
+    Arguments:
+
+    * `command`: is a list of arguments to be passed to etcdctl.
+    * `skip_this`: do not include this endpoint in the list of endpoints to pass to etcdctl.
+    '''
+    if api_version() == 'etcd2':
+        etcdctl_version = {"ETCDCTL_API": "2"}
+    else:
+        etcdctl_version = {"ETCDCTL_API": "3"}
+    return subprocess.check_output(["etcdctl"] + get_etcdctl_args(skip_this) + command, env=etcdctl_version)

--- a/salt/_modules/caasp_etcd.py
+++ b/salt/_modules/caasp_etcd.py
@@ -3,7 +3,10 @@ from __future__ import absolute_import
 import re
 import subprocess
 
-from urlparse import urlparse
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
 
 # note: do not import caasp modules other than caasp_log
 from caasp_log import debug, error, warn
@@ -16,6 +19,7 @@ ETCD_CLIENT_PORT = 2379
 
 # default etcd peer port
 ETCD_PEER_PORT = 2380
+
 
 def __virtual__():
     return "caasp_etcd"
@@ -381,7 +385,7 @@ def get_etcdctl_args_str(**kwargs):
     return " ".join(get_etcdctl_args(**kwargs))
 
 
-def get_member_id(nodename=None):
+def get_member_id(nodename):
     '''
     Return the member ID (different from the node ID) for an etcd member of the cluster.
 
@@ -391,24 +395,22 @@ def get_member_id(nodename=None):
                   want the ID for. if no name is provided (or empty),
                   the local node will be used.
     '''
-    target_nodename = nodename or __salt__['caasp_net.get_nodename']()
-
     members_output = ''
     try:
-        target_url = 'https://{}:{}'.format(target_nodename, ETCD_CLIENT_PORT)
+        target_url = 'https://{}:{}'.format(nodename, ETCD_CLIENT_PORT)
         members_output = etcdctl(["member", "list"])
         for member_line in members_output.splitlines():
             if target_url in member_line:
                 return member_line.split(':')[0]
 
     except Exception as e:
-        error('cannot get member ID for "%s": %s', e, target_nodename)
+        error('cannot get member ID for "%s": %s', e, nodename)
         error('output: %s', members_output)
 
     return ''
 
 
-def is_member_registered(nodename=None, port=ETCD_CLIENT_PORT):
+def is_member_registered(nodename=None, port=ETCD_PEER_PORT):
     '''
     Returns whether the provided `nodename` using `port` is already registered as an etcd member.
 
@@ -449,7 +451,7 @@ def healthy():
         if api_version() == 'etcd2':
             etcdctl(['cluster-health'])
         else:
-            etcdctl(['endpoint', 'health'])
+            etcdctl(['endpoint', 'health', '--cluster'])
         return True
     except subprocess.CalledProcessError:
         return False
@@ -468,13 +470,17 @@ def member_list():
     '''
     result = {'active': [], 'unstarted': []}
     etcdctl_output = etcdctl(["member", "list"])
-    etcdctl_output_active_matcher = re.compile('([^:]+):\s+name=([^\s]+)\s+peerURLs=([^\s]+)\s+clientURLs=([^\s]+)\s+isLeader=(true|false)')
-    etcdctl_output_unstarted_matcher = re.compile('([^\[]+)\[unstarted\]:\s+peerURLs=([^\s]+)')
+    if api_version() == 'etcd2':
+        etcdctl_output_active_matcher = re.compile('([^:]+):\s+name=([^\s]+)\s+peerURLs=([^\s]+)\s+clientURLs=([^\s]+)')
+        etcdctl_output_unstarted_matcher = re.compile('([^\[]+)\[unstarted\]:\s+peerURLs=([^\s]+)')
+    else:
+        etcdctl_output_active_matcher = re.compile('([^,]+), started,\s+([^,]+),\s+([^,]+),\s+([^,]+)')
+        etcdctl_output_unstarted_matcher = re.compile('([^,]+), unstarted,[^,]+,([^,]+)')
     for member_line in etcdctl_output.splitlines():
         matches = etcdctl_output_active_matcher.match(member_line)
         if matches:
             matches = matches.groups()
-            result['active'].append({'member_id': matches[0], 'name': matches[1], 'peer_urls': matches[2], 'client_urls': matches[3], 'is_leader': (matches[4] == 'true')})
+            result['active'].append({'member_id': matches[0], 'name': matches[1], 'peer_urls': matches[2], 'client_urls': matches[3]})
         matches = etcdctl_output_unstarted_matcher.match(member_line)
         if matches:
             matches = matches.groups()
@@ -503,10 +509,10 @@ def member_add(name=None, nodename=None, port=ETCD_PEER_PORT):
     if api_version() == 'etcd2':
         return etcdctl(['member', 'add', this_id, this_peer_url], skip_this=True)
     else:
-        return etcdctl(['member', 'add', this_id, '--peer-urls="{}"'.format(this_peer_url)], skip_this=True)
+        return etcdctl(['member', 'add', this_id, '--peer-urls={}'.format(this_peer_url)], skip_this=True)
 
 
-def member_remove(nodename=None):
+def member_remove(nodename):
     '''
     Remove `nodename` as an etcd member.
 
@@ -515,8 +521,7 @@ def member_remove(nodename=None):
 
     This requires etcd to be responding.
     '''
-    nodename_ = nodename or __salt__['caasp_net.get_nodename']()
-    target_member_id = get_member_id(nodename=nodename_)
+    target_member_id = get_member_id(nodename=nodename)
     if not target_member_id:
         return False
 

--- a/salt/_modules/caasp_nodes.py
+++ b/salt/_modules/caasp_nodes.py
@@ -319,7 +319,7 @@ def get_replacement_for(target, replacement='', **kwargs):
         # check if the replacement provided is valid
         if etcd_replacement:
             bootstrapped_etcd_members = get_from_args_or_with_expr(
-                'booted_etcd_members', kwargs, 'G@roles:kube-master', booted=True)
+                'booted_etcd_members', kwargs, 'G@roles:etcd', booted=True)
 
             if etcd_replacement in bootstrapped_etcd_members:
                 warn_or_abort_on_replacement_provided('the replacement for the etcd server %s cannot be %s: another etcd server is already running there',

--- a/salt/_modules/tests/test_caasp_etcd.py
+++ b/salt/_modules/tests/test_caasp_etcd.py
@@ -1,9 +1,10 @@
 from __future__ import absolute_import
 
 import unittest
+import subprocess
 
 import caasp_etcd
-from caasp_etcd import ETCD_CLIENT_PORT, get_endpoints
+from caasp_etcd import ETCD_CLIENT_PORT, get_endpoints, get_current_endpoints, get_current_endpoints_with_self
 
 try:
     from mock import patch, MagicMock
@@ -18,37 +19,134 @@ caasp_etcd.__salt__ = {}
 
 class TestGetEndpoints(unittest.TestCase):
     '''
-    Some basic tests for get_from_args_or_with_expr()
+    Some basic tests for get_endpoints()
     '''
 
-    def test_get_endpoints(self):
-        nodes = {
+    def nodes(self):
+        return {
             'AAA': 'node1',
             'BBB': 'node2',
             'CCC': 'node3'
         }
 
-        mock = MagicMock(return_value=nodes)
-        with patch.dict(caasp_etcd.__salt__, {'caasp_grains.get': mock}):
-            res = get_endpoints()
-            mock.assert_called_once_with('G@roles:etcd')
+    def patch_salt(self, mock):
+        return {
+            'caasp_nodes.is_first_bootstrap': lambda: True,
+            'caasp_grains.get': mock
+        }
 
-            for i in nodes.values():
-                self.assertIn('https://{}:{}'.format(i, ETCD_CLIENT_PORT), res,
-                              'did not get the expected list of etcd endpoints: {}'.format(res))
+    def setUp(self):
+        self.mock = MagicMock(return_value=self.nodes())
+        patcher = patch.dict(caasp_etcd.__salt__, self.patch_salt(self.mock))
+        patcher.start()
+        self.addCleanup(patcher.stop)
 
-            mock.reset_mock()
+    def test_get_endpoints(self):
+        res = get_endpoints()
+        self.mock.assert_called_once_with('G@roles:etcd')
 
-            res = get_endpoints(with_id=True)
-            mock.assert_called_once_with('G@roles:etcd')
+        for i in self.nodes().values():
+            self.assertIn('https://{}:{}'.format(i, ETCD_CLIENT_PORT), res,
+                          'did not get the expected list of etcd endpoints: {}'.format(res))
 
-            for (j, k) in nodes.items():
-                self.assertIn('{}=https://{}:{}'.format(j, k, ETCD_CLIENT_PORT), res,
-                              'did not get the expected list of etcd endpoints: {}'.format(res))
+    def test_get_endpoints_with_id(self):
+        res = get_endpoints(with_id=True)
+        self.mock.assert_called_once_with('G@roles:etcd')
 
-            mock.reset_mock()
+        for (j, k) in self.nodes().items():
+            self.assertIn('{}=https://{}:{}'.format(j, k, ETCD_CLIENT_PORT), res,
+                          'did not get the expected list of etcd endpoints: {}'.format(res))
 
-            res = get_endpoints(skip_removed=True)
-            mock.assert_called_once_with('G@roles:etcd and not G@node_removal_in_progress:true')
+    def test_get_endpoints_with_skip_removed(self):
+        get_endpoints(skip_removed=True)
+        self.mock.assert_called_once_with('G@roles:etcd and not G@node_removal_in_progress:true')
 
-            mock.reset_mock()
+
+class TestGetCurrentEndpoints(unittest.TestCase):
+    '''
+    Some basic tests for get_current_endpoints()
+    '''
+
+    def grains_get(self, grain):
+        if grain == 'nodename':
+            return 'new_nodename'
+        elif grain == 'id':
+            return 'new_id'
+
+    def patch_salt(self):
+        return {
+            'grains.get': lambda grain: self.grains_get(grain)
+        }
+
+    def setUp(self):
+        patcher = patch.dict(caasp_etcd.__salt__, self.patch_salt())
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def member_item(self, member_id, name, peer_urls, client_urls, is_leader):
+        return {
+            'member_id': member_id,
+            'name': name,
+            'peer_urls': peer_urls,
+            'client_urls': client_urls,
+            'is_leader': is_leader
+        }
+
+    def member_list(self, port=ETCD_CLIENT_PORT):
+        return {
+            'active': [
+                self.member_item('member_id_1', 'id_1', 'https://nodename_1:{}'.format(port), 'https://nodename_1:2379', 'true'),
+                self.member_item('member_id_2', 'id_2', 'https://nodename_2:{}'.format(port), 'https://nodename_2:2379', 'false'),
+                self.member_item('member_id_3', 'id_3', 'https://nodename_3:{}'.format(port), 'https://nodename_3:2379', 'false')
+            ]
+        }
+
+    def nodes(self, port=ETCD_CLIENT_PORT):
+        result = {}
+
+        for i, member in enumerate(self.member_list(port=port)['active']):
+            result['id_{}'.format(i + 1)] = 'nodename_{}'.format(i + 1)
+
+        return result
+
+    def mapped_member_list(self, with_id=False, extra_items=[], port=ETCD_CLIENT_PORT):
+        result = []
+        for peer in self.member_list(port=port)['active'] + extra_items:
+            peer_urls = peer['peer_urls']
+            if with_id:
+                peer_urls = '{}={}'.format(peer['name'], peer['peer_urls'])
+            result.append(peer_urls)
+
+        return result
+
+    def new_member_item(self):
+        return self.member_item('new_member_id', 'new_id', 'https://new_nodename:2380', 'https://new_nodename:2379', 'false')
+
+    @patch.object(caasp_etcd, 'member_list', autospec=True)
+    def test_get_current_endpoints(self, mock_member_list):
+        mock_member_list.return_value = self.member_list()
+        res = get_current_endpoints()
+        self.assertEqual(res, ','.join(self.mapped_member_list()))
+
+    @patch.object(caasp_etcd, 'member_list', autospec=True)
+    def test_get_current_endpoints_with_port(self, mock_member_list):
+        mock_member_list.return_value = self.member_list(port=2222)
+        res = get_current_endpoints(port=2222)
+        self.assertEqual(res, ','.join(self.mapped_member_list(port=2222)))
+
+    @patch.object(caasp_etcd, 'member_list', autospec=True)
+    def test_get_current_endpoints_with_self(self, mock_member_list):
+        mock_member_list.return_value = self.member_list(port=2380)
+        res = get_current_endpoints_with_self(port=2380)
+        self.assertEqual(res, ','.join(self.mapped_member_list(with_id=True, port=2380, extra_items=[self.new_member_item()])))
+
+    @patch.object(caasp_etcd, 'get_current_endpoints_raw', autospec=True)
+    def test_get_current_endpoints_with_self_failing_current_endpoints(self, mock_get_current_endpoints_raw):
+        '''
+        When `get_current_endpoints_with_self` fails to retrieve the result from
+        `etcdctl member list`, we fallback to `get_endpoints`
+        '''
+        with patch.dict(caasp_etcd.__salt__, {'caasp_nodes.is_first_bootstrap': lambda: False, 'caasp_grains.get': lambda expr: self.nodes(port=2380)}):
+            mock_get_current_endpoints_raw.side_effect = subprocess.CalledProcessError(returncode=1, cmd='cmd', output='')
+            res = get_current_endpoints_with_self(port=2380)
+            self.assertEqual(res, ','.join(self.mapped_member_list(with_id=True, port=2380, extra_items=[self.new_member_item()])))

--- a/salt/_states/caasp_etcd.py
+++ b/salt/_states/caasp_etcd.py
@@ -13,8 +13,10 @@ DEFAULT_ATTEMPTS_INTERVAL = 2
 # default etcd peer port
 ETCD_PEER_PORT = 2380
 
+
 def api_version():
     return __salt__['caasp_etcd.api_version']()
+
 
 def etcdctl(name, retry={}, **kwargs):
     '''

--- a/salt/_states/caasp_etcd.py
+++ b/salt/_states/caasp_etcd.py
@@ -13,10 +13,8 @@ DEFAULT_ATTEMPTS_INTERVAL = 2
 # default etcd peer port
 ETCD_PEER_PORT = 2380
 
-
 def api_version():
     return __salt__['caasp_etcd.api_version']()
-
 
 def etcdctl(name, retry={}, **kwargs):
     '''
@@ -52,10 +50,18 @@ def etcdctl(name, retry={}, **kwargs):
 
 def healthy(name, **kwargs):
     log.debug('CaaS: checking etcd health')
-    if api_version() == 'etcd2':
-        return etcdctl(name='cluster-health', **kwargs)
-    else:
-        return etcdctl(name='endpoint health', **kwargs)
+    result = {'name': "healthy.{0}".format(name),
+              'result': True,
+              'comment': "Cluster is healthy",
+              'changes': {}}
+
+    if not __salt__['caasp_etcd.healthy'](**kwargs):
+        result.update({
+            'result': False,
+            'comment': "Cluster is not healthy"
+        })
+
+    return result
 
 
 def member_add(name, **kwargs):
@@ -64,21 +70,20 @@ def member_add(name, **kwargs):
     '''
     port = kwargs.pop('port', ETCD_PEER_PORT)
 
-    this_id = __salt__['grains.get']('id')
-    this_nodename = __salt__['caasp_net.get_nodename']()
-    this_peer_url = 'https://{}:{}'.format(this_nodename, port)
+    result = {'name': "member_add.{0}".format(name), 'changes': {}}
 
-    if api_version() == 'etcd2':
-        name = 'member add {} {}'.format(this_id, this_peer_url)
+    if __salt__['caasp_etcd.member_add'](port=port):
+        result.update({
+            'result': True,
+            'comment': "Member {0} added.".format(name)
+        })
     else:
-        name = 'member add {} --peer-urls="{}"'.format(this_id, this_peer_url)
-    log.debug('CaaS: adding etcd member')
-    return etcdctl(name=name, skip_this=True, **kwargs)
+        result.update({
+            'result': False,
+            'comment': "Member {0} not added.".format(name)
+        })
 
-    # once the member has been added to the cluster, we
-    # must make sure etcd joins an "existing" cluster.
-    # so we must set ETCD_INITIAL_CLUSTER_STATE=existing
-    # or, otherwise, etcd will refuse to join... (facepalm)
+    return result
 
 
 def member_remove(name, nodename=None, **kwargs):
@@ -91,15 +96,17 @@ def member_remove(name, nodename=None, **kwargs):
                   want the ID for. if no name is provided (or empty),
                   the local node will be used.
     '''
-    target_member_id = __salt__['caasp_etcd.get_member_id'](nodename=nodename)
-    if not target_member_id:
-        return {
-            'name': "member_remove.{0}".format(name),
-            'result': False,
-            'comment': "Could not obtain member id.",
-            'changes': {}
-        }
+    result = {'name': "member_remove.{0}".format(name), 'changes': {}}
 
-    name = 'member remove {}'.format(target_member_id)
-    log.debug('CaaS: removing etcd member %s', target_member_id)
-    return etcdctl(name=name, **kwargs)
+    if __salt__['caasp_etcd.member_remove'](nodename):
+        result.update({
+            'result': True,
+            'comment': "Member {0} removed.".format(name)
+        })
+    else:
+        result.update({
+            'result': False,
+            'comment': "Member {0} not removed.".format(name)
+        })
+
+    return result

--- a/salt/cleanup/etcd.sls
+++ b/salt/cleanup/etcd.sls
@@ -1,0 +1,27 @@
+{%- set forced = salt.caasp_pillar.get('forced', False) %}
+
+{% if 'etcd' in salt['grains.get']('roles', []) %}
+
+# We could have shrank `etcd` only on this node, so make sure we clean the cached
+# content in case this node rejoins the `etcd` cluster in the future
+etcd-remove-cache-directory:
+  cmd.run:
+    - name: rm -rf /var/lib/etcd/*
+
+etcd-remove-grain:
+  module.run:
+    - name: grains.remove
+    - key: roles
+    - val: etcd
+{% if not forced %}
+    - require:
+        - etcd-remove-cache-directory
+{% endif %}
+
+{% else %}
+
+cleanup-etcd:
+  cmd.run:
+    - name: echo "No etcd cleanup required"
+
+{% endif %}

--- a/salt/etcd/etcd.conf.jinja
+++ b/salt/etcd/etcd.conf.jinja
@@ -25,12 +25,17 @@ ETCD_PEER_CLIENT_CERT_AUTH="true"
 # ETCD_PEER_AUTO_TLS=on
 
 {# note on node removal: we cannot skip nodes with node_removal_in_progress #}
-ETCD_INITIAL_CLUSTER="{{ salt.caasp_etcd.get_endpoints(with_id=True, port=2380) }}"
+{%- if salt.caasp_nodes.is_first_bootstrap() %}
+ETCD_INITIAL_CLUSTER="{{ salt.caasp_etcd.get_endpoints(with_id=True, only_bootstrapped=False, port=2380) }}"
+{%- else %}
+ETCD_INITIAL_CLUSTER="{{ salt.caasp_etcd.get_current_endpoints_with_self(port=2380) }}"
+{%- endif %}
+
 ETCD_INITIAL_CLUSTER_TOKEN="{{ pillar['etcd']['token'] }}"
 ETCD_INITIAL_ADVERTISE_PEER_URLS="https://{{ this_addr }}:2380"
 
-{#- we will not use "existing" unless we are adding a new node to the cluster  #}
-{%- if salt['grains.get']('node_addition_in_progress', False) %}
+{#- we will use "existing" except for the very first bootstrap #}
+{%- if not salt.caasp_nodes.is_first_bootstrap() %}
 ETCD_INITIAL_CLUSTER_STATE="existing"
 {%- endif %}
 

--- a/salt/etcd/etcdctl.conf.jinja
+++ b/salt/etcd/etcdctl.conf.jinja
@@ -18,4 +18,4 @@ ETCDCTL_CACERT={{ pillar['ssl']['ca_file'] }}
 ETCDCTL_CERT={{ pillar['ssl']['crt_file'] }}
 ETCDCTL_KEY={{ pillar['ssl']['key_file'] }}
 
-ETCDCTL_API=3
+ETCDCTL_API=2

--- a/salt/etcd/etcdctl.conf.jinja
+++ b/salt/etcd/etcdctl.conf.jinja
@@ -17,3 +17,5 @@ ETCDCTL_KEY_FILE={{ pillar['ssl']['key_file'] }}
 ETCDCTL_CACERT={{ pillar['ssl']['ca_file'] }}
 ETCDCTL_CERT={{ pillar['ssl']['crt_file'] }}
 ETCDCTL_KEY={{ pillar['ssl']['key_file'] }}
+
+ETCDCTL_API=3

--- a/salt/etcd/init.sls
+++ b/salt/etcd/init.sls
@@ -2,8 +2,9 @@ include:
   - ca-cert
   - cert
 
-{%- set node_addition_in_progress = salt['grains.get']('node_addition_in_progress', False) %}
-{%- if node_addition_in_progress %}
+{% set should_register_etcd_member = salt.caasp_etcd.should_register_etcd_member(port=2380) %}
+
+{%- if should_register_etcd_member %}
 
 # add the member to the cluster _before_ `etcd` is started
 # then `etcd` will have to be started with the `existing` flag
@@ -70,7 +71,7 @@ etcd:
       - {{ pillar['ssl']['key_file'] }}
       - {{ pillar['ssl']['ca_file'] }}
       - file: /etc/sysconfig/etcd
-    {%- if node_addition_in_progress %}
+    {%- if should_register_etcd_member %}
       - add-etcd-to-cluster
     {%- endif %}
   # wait until etcd is actually up and running

--- a/salt/etcd/remove-pre-orchestration.sls
+++ b/salt/etcd/remove-pre-orchestration.sls
@@ -1,0 +1,3 @@
+etcd:
+  # check the etcd cluster is healthy
+  caasp_etcd.healthy

--- a/salt/etcd/remove.sls
+++ b/salt/etcd/remove.sls
@@ -1,0 +1,17 @@
+{%- set target = salt.caasp_pillar.get('target') %}
+{%- set forced = salt.caasp_pillar.get('forced', False) %}
+
+{%- set nodename = salt.caasp_net.get_nodename(host=target) %}
+
+###############
+# etcd cluster
+###############
+
+{%- set etcd_members = salt.caasp_nodes.get_with_expr('G@roles:etcd', booted=True) %}
+{%- if forced or target in etcd_members %}
+
+etcd-remove-member:
+  caasp_etcd.member_remove:
+    - nodename: {{ nodename }}
+
+{%- endif %}

--- a/salt/etcd/remove.sls
+++ b/salt/etcd/remove.sls
@@ -14,4 +14,10 @@ etcd-remove-member:
   caasp_etcd.member_remove:
     - nodename: {{ nodename }}
 
+{%- else %}
+
+etcd-remove-member-dummy:
+  cmd.run:
+    - name: echo "No etcd member, skipping"
+
 {%- endif %}

--- a/salt/kube-apiserver/remove-pre-orchestration.sls
+++ b/salt/kube-apiserver/remove-pre-orchestration.sls
@@ -1,0 +1,40 @@
+include:
+  - kubectl-config
+
+{%- set target          = salt.caasp_pillar.get('target') %}
+{%- set target_nodename = salt.caasp_net.get_nodename(host=target) %}
+
+# Check the local ("internal") API server is reachable, and
+# then the API-through-haproxy is working fine too.
+
+{%- set api_server = 'api.' + pillar['internal_infra_domain'] %}
+
+{%- for port in ['int_ssl_port', 'ssl_port'] %}
+
+check-kube-apiserver-wait-port-{{ port }}:
+  caasp_retriable.retry:
+    - target:     caasp_http.wait_for_successful_query
+    - name:       {{ 'https://' + api_server + ':' + pillar['api'][port] }}/healthz
+    - wait_for:   300
+    # retry just in case the API server returns a transient error
+    - retry:
+        attempts: 3
+    - ca_bundle:  {{ pillar['ssl']['ca_file'] }}
+    - status:     200
+    - opts:
+        http_request_timeout: 30
+
+{% endfor %}
+
+{%- from '_macros/kubectl.jinja' import kubectl with context %}
+
+# A simple check: we can do a simple query (a `get nodes`)
+# to the API server
+{{ kubectl("check-kubectl-get-nodes", "get nodes") }}
+
+# Try to describe the target.
+# If kubectl cannot describe the node, we should abort before trying
+# to go further and maybe fail and leave the cluster in a unstable state.
+# Users should force-remove the node then...
+{{ kubectl("check-kubectl-describe-target",
+           "describe nodes " + target_nodename) }}

--- a/salt/kubelet/remove-post-orchestration.sls
+++ b/salt/kubelet/remove-post-orchestration.sls
@@ -18,25 +18,10 @@ include:
 {{ kubectl("remove-node",
            "delete node " + nodename) }}
 
-{% endif %}
+{% else %}
 
-###############
-# etcd node
-###############
-
-{%- set etcd_members = salt.caasp_nodes.get_with_expr('G@roles:etcd', booted=True) %}
-{%- if forced or target in etcd_members %}
-
-etcd-remove-member:
-  caasp_etcd.member_remove:
-  - nodename: {{ nodename }}
-
-{%- endif %}
-
-
-{%- if not (forced or target in k8s_nodes + etcd_members) %}
-{# Make suse we do not generate an empty file if target is not a etcd/master #}
 remove-post-orchestration-dummy:
   cmd.run:
     - name: "echo saltstack bug 14553"
-{%- endif %}
+
+{% endif %}

--- a/salt/orch/force-removal.sls
+++ b/salt/orch/force-removal.sls
@@ -43,6 +43,7 @@ cleanup-{{ target }}:
     - sls:
         - cleanup.etcd
     - fail_minions: {{ target }}
+    - expect_minions: False
     - pillar:
         forced: True
 
@@ -60,6 +61,7 @@ remove-target-mine:
     - tgt: {{ target }}
     - name: mine.flush
     - fail_minions: {{ target }}
+    - expect_minions: False
 
 remove-target-salt-key:
   salt.wheel:

--- a/salt/orch/force-removal.sls
+++ b/salt/orch/force-removal.sls
@@ -11,23 +11,39 @@ set-cluster-wide-removal-grain:
       - force_removal_in_progress
       - true
 
-sync-all:
+update-modules:
   salt.function:
     - tgt: '*'
     - names:
       - saltutil.refresh_pillar
       - saltutil.refresh_grains
       - mine.update
-      - saltutil.sync_all
+
+sync-all:
+  salt.function:
+    - tgt: '*'
+    - name: saltutil.sync_all
+    - kwarg:
+        refresh: True
 
 unregister-{{ target }}:
   salt.state:
     - tgt: {{ super_master }}
     - sls:
-        - cleanup.remove-post-orchestration
+        - etcd.remove
+        - kubelet.remove-post-orchestration
     - fail_minions: {{ super_master }}
     - pillar:
         target: {{ target }}
+        forced: True
+
+cleanup-{{ target }}:
+  salt.state:
+    - tgt: {{ target }}
+    - sls:
+        - cleanup.etcd
+    - fail_minions: {{ target }}
+    - pillar:
         forced: True
 
 remove-cluster-wide-removal-grain:

--- a/salt/orch/removal.sls
+++ b/salt/orch/removal.sls
@@ -40,7 +40,26 @@
                                                                               etcd_members=etcd_members,
                                                                               excluded=nodes_down) %}
 
-# Ensure we mark all nodes with the "as node is being removed" grain.
+# Detect if we need to shrink the etcd cluster in order to keep etcd's
+# golden ratio: this happens on corner cases (e.g. a 1+2 deployment
+# that gets removed a worker should have one etcd instance, not two). This
+# happens only if there are no replacements for the `etcd` role.
+{%- if target not in etcd_members or (replacement and 'etcd' in replacement_roles) %}
+{%- set surplus_etcd_members = [] %}
+{%- else %}
+# FIXME: use masters|difference([target]) filter -- included in 2017.7.0 version
+{%- set future_masters = salt.saltutil.runner('mine.get', tgt='G@roles:kube-master and not ' + target, fun='network.interfaces', tgt_type='compound').keys() %}
+{%- set future_minions = salt.saltutil.runner('mine.get', tgt='G@roles:kube-minion and not ' + target, fun='network.interfaces', tgt_type='compound').keys() %}
+{%- set num_etcd_members = salt.caasp_etcd.get_cluster_size(masters=future_masters,
+                                                            minions=future_minions) %}
+{%- set surplus_etcd_members = salt.caasp_etcd.get_surplus_etcd_members(num_wanted=num_etcd_members,
+                                                                        etcd_members=etcd_members,
+                                                                        targets=[target],
+                                                                        excluded=nodes_down) %}
+{%- endif %}
+{%- set is_etcd_cluster_shrinking = surplus_etcd_members|length > 0 %}
+
+# Ensure we mark all nodes with the "a node is being removed" grain.
 # This will ensure the update-etc-hosts orchestration is not run.
 set-cluster-wide-removal-grain:
   salt.function:
@@ -70,6 +89,54 @@ update-config:
     - require:
       - set-cluster-wide-removal-grain
 
+pre-removal-checks:
+  salt.state:
+    - tgt: '{{ super_master_tgt }}'
+    - sls:
+      - etcd.remove-pre-orchestration
+      - kube-apiserver.remove-pre-orchestration
+    - pillar:
+        target: {{ target }}
+    - require:
+      - update-config
+
+{% if is_etcd_cluster_shrinking %}
+# Unregister etcd before stopping the service. Very important
+# to make sure `etcd` knows what's coming (specially in corner
+# cases)
+{% for member in surplus_etcd_members %}
+etcd-remove-member-{{ member }}:
+  salt.state:
+    - tgt: '{{ super_master_tgt }}'
+    - pillar:
+        target: {{ member }}
+    - sls:
+      - etcd.remove
+    - require:
+      - pre-removal-checks
+
+etcd-cleanup-member-{{ member }}:
+  salt.state:
+    - tgt: '{{ member }}'
+    - sls:
+        - cleanup.etcd
+    - require:
+      - etcd-remove-member-{{ member }}
+{% endfor %}
+
+enforce-etcd-consistency:
+  salt.state:
+    - tgt: 'P@roles:etcd and {{ all_responsive_nodes_tgt }}'
+    - tgt_type: compound
+    - batch: 1
+    - sls:
+        - etcd
+    - require:
+{% for member in surplus_etcd_members %}
+      - etcd-cleanup-member-{{ member }}
+{% endfor %}
+{% endif %}
+
 {##############################
  # set grains
  #############################}
@@ -82,7 +149,10 @@ assign-removal-grain:
       - node_removal_in_progress
       - true
     - require:
-      - update-config
+      - pre-removal-checks
+{% if is_etcd_cluster_shrinking %}
+      - enforce-etcd-consistency
+{% endif %}
 
 {%- if replacement %}
 
@@ -188,6 +258,31 @@ remove-addition-grain:
  # removal & cleanups
  #############################}
 
+# Unregister etcd before stopping the service. Very important
+# to make sure `etcd` knows what's coming (specially in corner
+# cases)
+
+etcd-removal:
+  salt.state:
+    - tgt: '{{ super_master_tgt }}'
+    - pillar:
+        target: {{ target }}
+    - sls:
+      - etcd.remove
+    - require:
+      - update-modules
+  {%- if replacement %}
+      - remove-addition-grain
+  {%- endif %}
+
+etcd-cleanup:
+  salt.state:
+    - tgt: {{ target }}
+    - sls:
+        - cleanup.etcd
+    - require:
+        - etcd-removal
+
 # the replacement should be ready at this point:
 # we can remove the old node running in {{ target }}
 
@@ -197,7 +292,7 @@ early-stop-services-in-target:
     - sls:
       - kubelet.stop
     - require:
-      - update-modules
+      - etcd-cleanup
   {%- if replacement %}
       - remove-addition-grain
   {%- endif %}
@@ -263,7 +358,7 @@ remove-from-cluster-in-super-master:
     - pillar:
         target: {{ target }}
     - sls:
-      - cleanup.remove-post-orchestration
+      - kubelet.remove-post-orchestration
     - require:
       - shutdown-target
 


### PR DESCRIPTION
- [x] Fix documentation everywhere
- [x] Add test cases

Improve `etcd` configuration handling to allow it to grow as needed. This
change includes:

* Adding several masters at the same time
  * `etcd` will grow instance by instance still, as recommended by the `etcd` administration best practices.

* Try to use the current endpoints reported by `etcd`. This makes much
  easier to grow several instances one by one without having to relay
  on internal hacks to properly set up `ETCD_INITIAL_CLUSTER` environment
  variable.

* Add helper methods that allow us to list current members (active and
  unstarted)

* Differentiate between the first bootstrap (`ETCD_INITIAL_CLUSTER_STATE`
  defaults to `new`) and *any* other run, where `ETCD_INITIAL_CLUSTER_STATE`
  will be `existing`, as the `etcd` cluster is already running.

When we grow, we take into account the golden ratio; however, when shrinking
the cluster we don't. It might happen that a cluster ends up with not
recommended etcd number of nodes (2, 4, 6...) depending on how it grew before
and how it shrank.

This logic makes sure that we are always on an etcd golden ratio, also
on corner cases when removing nodes.

Fixes: bsc#1098433
Fixes: bsc#1098064
Fixes: bsc#1098161

Backport of https://github.com/kubic-project/salt/pull/614