### PR TITLE
Python 3/SLE-15 compatibility for salt states

### DIFF
--- a/config/master.d/50-master.conf
+++ b/config/master.d/50-master.conf
@@ -32,8 +32,7 @@ pillar_roots:
 # `module_dirs` is like `extension_modules`, but a list of
 # extra directories to search for Salt modules.
 module_dirs:
-  - /usr/share/salt/kubernetes/salt/_modules
-  - /usr/share/salt/kubernetes/salt/_pillar
+  - /usr/share/salt/kubernetes/salt/
 
 ext_pillar:
   - velum:

--- a/config/master.d/50-reactor.conf
+++ b/config/master.d/50-reactor.conf
@@ -7,4 +7,5 @@ reactor:
   - 'salt/minion/*/start':
     - /usr/share/salt/kubernetes/reactor/etc-hosts.sls
     - /usr/share/salt/kubernetes/reactor/sync-modules.sls
+    - /usr/share/salt/kubernetes/reactor/sync-grains.sls
     - /usr/share/salt/kubernetes/reactor/update-mine.sls

--- a/pillar/cni.sls
+++ b/pillar/cni.sls
@@ -1,6 +1,6 @@
 # the flannel backend ('udp', 'vxlan', 'host-gw', etc)
 flannel:
-  image:          'sles12/flannel:0.9.1'
+  image:          '{{ salt.caasp_registry.base_image_url() }}/flannel:0.9.1'
   backend:        'vxlan'
   port:           '8472'    # UDP port to use for sending encapsulated packets. Defaults to kernel default, currently 8472.
   healthz_port:   '8471'    # TCP port used for flannel healthchecks

--- a/pillar/params.sls
+++ b/pillar/params.sls
@@ -198,4 +198,4 @@ ldap:
   mail_attribute: ''
 
 # infra container to use instead of downloading gcr.io/google_containers/pause
-pod_infra_container_image: sles12/pause:1.0.0
+pod_infra_container_image: {{ salt.caasp_registry.base_image_url() }}/pause:1.0.0

--- a/reactor/sync-grains.sls
+++ b/reactor/sync-grains.sls
@@ -1,0 +1,3 @@
+sync_grains:
+  local.saltutil.sync_grains:
+    - tgt: {{ data['id'] }}

--- a/salt/_grains/caasp_nodename.py
+++ b/salt/_grains/caasp_nodename.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 import platform
 
 import salt.grains.core

--- a/salt/_macros/certs.jinja
+++ b/salt/_macros/certs.jinja
@@ -65,7 +65,7 @@
 {{ crt }}:
   caasp_retriable.retry:
     - target: x509.certificate_managed
-    - ca_server: {{ salt['mine.get']('roles:ca', 'ca.crt', expr_form='grain').keys()[0] }}
+    - ca_server: {{ salt['mine.get']('roles:ca', 'ca.crt', expr_form='grain').keys()|first }}
     - signing_policy: minion
     - public_key: {{ key }}
   {%- if cn %}

--- a/salt/_modules/caasp_docker.py
+++ b/salt/_modules/caasp_docker.py
@@ -2,8 +2,6 @@ from __future__ import absolute_import
 
 from salt.ext.six.moves.urllib.parse import urlparse
 
-from caasp_log import debug, error
-
 
 def __virtual__():
     return "caasp_docker"
@@ -23,7 +21,7 @@ def _get_hostname_and_port(url, default_port=None):
             port = None
 
     res = (hostname, port or default_port)
-    debug("%s parsed as %s", url, res)
+    __utils__['caasp_log.debug']("%s parsed as %s", url, res)
     return res
 
 
@@ -37,7 +35,7 @@ def get_registries_certs(lst, default_port=5000):
     '''
     certs = {}
 
-    debug('Finding certificates in: %s', lst)
+    __utils__['caasp_log.debug']('Finding certificates in: %s', lst)
     for registry in lst:
         try:
             url = registry.get('url')
@@ -51,7 +49,7 @@ def get_registries_certs(lst, default_port=5000):
                 if port:
                     host_port += ":" + str(port)
 
-                debug('Adding certificate for: %s', host_port)
+                __utils__['caasp_log.debug']('Adding certificate for: %s', host_port)
                 certs[host_port] = cert
 
                 if port:
@@ -64,28 +62,28 @@ def get_registries_certs(lst, default_port=5000):
                         # as he/she could just access "docker pull my-registry/some/image",
                         # and Docker would fail to find "my-registry/ca.crt"
                         name = hostname
-                        debug(
+                        __utils__['caasp_log.debug'](
                             'Using default port: adding certificate for "%s" too', name)
                         certs[name] = cert
                 else:
                     # the same happens if the user introduced a certificate for
                     # "my-registry": we must fix the "docker pull my-registry:5000/some/image" case...
                     name = hostname + ':' + str(default_port)
-                    debug(
+                    __utils__['caasp_log.debug'](
                         'Adding certificate for default port, "%s", too', name)
                     certs[name] = cert
 
         except Exception as e:
-            error('Could not parse certificate: %s', e)
+            __utils__['caasp_log.error']('Could not parse certificate: %s', e)
 
         try:
             mirrors = registry.get('mirrors', [])
             if mirrors:
-                debug('Looking recursively for certificates in mirrors')
+                __utils__['caasp_log.debug']('Looking recursively for certificates in mirrors')
                 certs_mirrors = get_registries_certs(mirrors,
                                                      default_port=default_port)
                 certs.update(certs_mirrors)
         except Exception as e:
-            error('Could not parse mirrors: %s', e)
+            __utils__['caasp_log.error']('Could not parse mirrors: %s', e)
 
     return certs

--- a/salt/_modules/caasp_etcd.py
+++ b/salt/_modules/caasp_etcd.py
@@ -75,7 +75,7 @@ def get_cluster_size(**kwargs):
             member_count = _optimal_etcd_number(increased_member_count)
 
             __utils__['caasp_log.warn']("etcd member count too low (%d), increasing to %d",
-                           num_masters, increased_member_count)
+                                        num_masters, increased_member_count)
 
             # TODO: go deeper and look for candidates in nodes with
             #       no role (as get_replacement_for_member() does)
@@ -86,7 +86,7 @@ def get_cluster_size(**kwargs):
 
         if member_count < MIN_RECOMMENDED_MEMBER_COUNT:
             __utils__['caasp_log.warn']("etcd member count too low (%d), consider increasing "
-                           "to %d", member_count, MIN_RECOMMENDED_MEMBER_COUNT)
+                                        "to %d", member_count, MIN_RECOMMENDED_MEMBER_COUNT)
 
     member_count = max(1, member_count)
     __utils__['caasp_log.debug']("using member count = %d", member_count)
@@ -124,7 +124,7 @@ def get_additional_etcd_members(num_wanted=None, **kwargs):
         return []
 
     __utils__['caasp_log.debug']('get_additional_etcd_members: curr:%d wanted:%d -> %d missing',
-                    num_current_etcd_members, num_wanted_etcd_members, num_additional_etcd_members)
+                                 num_current_etcd_members, num_wanted_etcd_members, num_additional_etcd_members)
 
     # Get a list of `num_additional_etcd_members` nodes that could be used
     # for running etcd. A valid node is a node that:
@@ -144,7 +144,7 @@ def get_additional_etcd_members(num_wanted=None, **kwargs):
 
     if len(new_etcd_members) < num_additional_etcd_members:
         __utils__['caasp_log.error']('get_additional_etcd_members: cannot satisfy the %s members missing',
-                        num_additional_etcd_members)
+                                     num_additional_etcd_members)
 
     return new_etcd_members
 

--- a/salt/_modules/caasp_etcd.py
+++ b/salt/_modules/caasp_etcd.py
@@ -2,8 +2,6 @@ from __future__ import absolute_import
 
 import subprocess
 
-# note: do not import caasp modules other than caasp_log
-from caasp_log import debug, error, warn
 
 # minimum number of etcd masters we recommend
 MIN_RECOMMENDED_MEMBER_COUNT = 3
@@ -76,8 +74,8 @@ def get_cluster_size(**kwargs):
             # (otherwise we could have some leader election problems)
             member_count = _optimal_etcd_number(increased_member_count)
 
-            warn("etcd member count too low (%d), increasing to %d",
-                 num_masters, increased_member_count)
+            __utils__['caasp_log.warn']("etcd member count too low (%d), increasing to %d",
+                           num_masters, increased_member_count)
 
             # TODO: go deeper and look for candidates in nodes with
             #       no role (as get_replacement_for_member() does)
@@ -87,11 +85,11 @@ def get_cluster_size(**kwargs):
         member_count = int(member_count)
 
         if member_count < MIN_RECOMMENDED_MEMBER_COUNT:
-            warn("etcd member count too low (%d), consider increasing "
-                 "to %d", member_count, MIN_RECOMMENDED_MEMBER_COUNT)
+            __utils__['caasp_log.warn']("etcd member count too low (%d), consider increasing "
+                           "to %d", member_count, MIN_RECOMMENDED_MEMBER_COUNT)
 
     member_count = max(1, member_count)
-    debug("using member count = %d", member_count)
+    __utils__['caasp_log.debug']("using member count = %d", member_count)
     return member_count
 
 
@@ -122,11 +120,11 @@ def get_additional_etcd_members(num_wanted=None, **kwargs):
     num_additional_etcd_members = num_wanted_etcd_members - num_current_etcd_members
 
     if num_additional_etcd_members <= 0:
-        debug('get_additional_etcd_members: we dont need more etcd members')
+        __utils__['caasp_log.debug']('get_additional_etcd_members: we dont need more etcd members')
         return []
 
-    debug('get_additional_etcd_members: curr:%d wanted:%d -> %d missing',
-          num_current_etcd_members, num_wanted_etcd_members, num_additional_etcd_members)
+    __utils__['caasp_log.debug']('get_additional_etcd_members: curr:%d wanted:%d -> %d missing',
+                    num_current_etcd_members, num_wanted_etcd_members, num_additional_etcd_members)
 
     # Get a list of `num_additional_etcd_members` nodes that could be used
     # for running etcd. A valid node is a node that:
@@ -145,8 +143,8 @@ def get_additional_etcd_members(num_wanted=None, **kwargs):
         excluded=current_etcd_members + excluded)
 
     if len(new_etcd_members) < num_additional_etcd_members:
-        error('get_additional_etcd_members: cannot satisfy the %s members missing',
-              num_additional_etcd_members)
+        __utils__['caasp_log.error']('get_additional_etcd_members: cannot satisfy the %s members missing',
+                        num_additional_etcd_members)
 
     return new_etcd_members
 
@@ -172,10 +170,10 @@ def get_endpoints(with_id=False, skip_this=False, skip_removed=False, port=ETCD_
         member_endpoint = 'https://{}:{}'.format(name, port)
         if with_id:
             member_endpoint = "{}={}".format(node_id, member_endpoint)
-        etcd_members_lst.append(member_endpoint)
+            etcd_members_lst.append(member_endpoint)
 
     if len(etcd_members_lst) == 0:
-        error('no etcd members available!!')
+        __utils__['caasp_log.error']('no etcd members available!!')
         raise NoEtcdServersException()
 
     etcd_members_lst.sort()
@@ -227,7 +225,7 @@ def get_member_id(nodename=None):
 
     target_nodename = nodename or __salt__['caasp_net.get_nodename']()
 
-    debug("getting etcd member ID with: %s", command)
+    __utils__['caasp_log.debug']("getting etcd member ID with: %s", command)
     members_output = ''
     try:
         target_url = 'https://{}:{}'.format(target_nodename, ETCD_CLIENT_PORT)
@@ -240,7 +238,7 @@ def get_member_id(nodename=None):
                     return member_line.split(',')[0]
 
     except Exception as e:
-        error('cannot get member ID for "%s": %s', e, target_nodename)
-        error('output: %s', members_output)
+        __utils__['caasp_log.error']('cannot get member ID for "%s": %s', e, target_nodename)
+        __utils__['caasp_log.error']('output: %s', members_output)
 
     return ''

--- a/salt/_modules/caasp_etcd.py
+++ b/salt/_modules/caasp_etcd.py
@@ -170,7 +170,7 @@ def get_endpoints(with_id=False, skip_this=False, skip_removed=False, port=ETCD_
         member_endpoint = 'https://{}:{}'.format(name, port)
         if with_id:
             member_endpoint = "{}={}".format(node_id, member_endpoint)
-            etcd_members_lst.append(member_endpoint)
+        etcd_members_lst.append(member_endpoint)
 
     if len(etcd_members_lst) == 0:
         __utils__['caasp_log.error']('no etcd members available!!')

--- a/salt/_modules/caasp_hosts.py
+++ b/salt/_modules/caasp_hosts.py
@@ -6,9 +6,6 @@ import os
 from salt.ext import six
 from salt.utils.odict import OrderedDict
 
-# note: do not import caasp modules other than caasp_log
-from caasp_log import debug, info, warn
-
 try:
     from salt.exceptions import InvalidConfigError
 except ImportError:
@@ -79,7 +76,7 @@ def _concat(lst1, lst2):
 
 
 def _load_lines(filename):
-    debug('hosts: loading %s', filename)
+    __utils__['caasp_log.debug']('hosts: loading %s', filename)
     with open(filename, 'r') as f:
         lines = [x.strip().replace('\n', '') for x in f.readlines()]
 
@@ -87,7 +84,7 @@ def _load_lines(filename):
     while not lines[-1]:
         del lines[-1]
 
-    debug('hosts: %d lines loaded from %s', len(lines), filename)
+    __utils__['caasp_log.debug']('hosts: %d lines loaded from %s', len(lines), filename)
     return lines
 
 
@@ -110,12 +107,12 @@ def _load_hosts(hosts, lines, marker_start=None, marker_end=None):
             continue
 
         if marker_start and line.startswith(marker_start):
-            debug('hosts: start of skipped block')
+            __utils__['caasp_log.debug']('hosts: start of skipped block')
             blocked = True
             continue
 
         if marker_end and line.startswith(marker_end):
-            debug('hosts: end of skipped block')
+            __utils__['caasp_log.debug']('hosts: end of skipped block')
             blocked = False
             continue
 
@@ -151,7 +148,7 @@ def _add_names(hosts, ips, names):
         ips = [ips]
 
     for ip in ips:
-        debug('hosts: adding %s -> %s', ip, names)
+        __utils__['caasp_log.debug']('hosts: adding %s -> %s', ip, names)
         if ip not in hosts:
             hosts[ip] = _concat([], names)
         else:
@@ -241,7 +238,7 @@ def managed(name=HOSTS_FILE,
     # copy the /etc/hosts to caasp_hosts_file the first time we run this
     if caasp_hosts_file:
         if not os.path.exists(caasp_hosts_file):
-            info('hosts: saving %s in %s', orig_etc_hosts, caasp_hosts_file)
+            __utils__['caasp_log.info']('hosts: saving %s in %s', orig_etc_hosts, caasp_hosts_file)
             _write_lines(caasp_hosts_file, orig_etc_hosts_contents)
             # TODO remove this file if something goes wrong...
 
@@ -253,11 +250,11 @@ def managed(name=HOSTS_FILE,
                                               content='',
                                               backup=False)
             except Exception as e:
-                warn('could not remove old blocks in {}: {}'.format(caasp_hosts_file, e))
+                __utils__['caasp_log.warn']('could not remove old blocks in {}: {}'.format(caasp_hosts_file, e))
 
         assert os.path.exists(caasp_hosts_file)
 
-        info('hosts: loading entries in "%s" file', caasp_hosts_file)
+        __utils__['caasp_log.info']('hosts: loading entries in "%s" file', caasp_hosts_file)
         if not os.path.isfile(caasp_hosts_file):
             raise EtcHostsRuntimeException(
                 '{} cannot be loaded: it is not a file'.format(caasp_hosts_file))
@@ -266,9 +263,9 @@ def managed(name=HOSTS_FILE,
                          caasp_hosts_file,
                          marker_start=marker_start,
                          marker_end=marker_end)
-        debug('hosts: custom /etc/hosts entries:')
+        __utils__['caasp_log.debug']('hosts: custom /etc/hosts entries:')
         for k, v in hosts.items():
-            debug('hosts:    %s %s', k, v)
+            __utils__['caasp_log.debug']('hosts:    %s %s', k, v)
 
     # get the admin, masters and workers
     def get_with_expr(expr):
@@ -304,7 +301,7 @@ def managed(name=HOSTS_FILE,
         _add_names(hosts, ['127.0.0.1', '::1'],
                    [this_hostname, fqdn(this_hostname)])
 
-        debug('hosts: adding entry for the API server at 127.0.0.1')
+        __utils__['caasp_log.debug']('hosts: adding entry for the API server at 127.0.0.1')
         _add_names(hosts, '127.0.0.1', ['api', fqdn('api')])
 
     except Exception as e:
@@ -323,7 +320,7 @@ def managed(name=HOSTS_FILE,
         new_etc_hosts_contents.sort()
         new_etc_hosts_contents = preface + new_etc_hosts_contents
 
-        info('hosts: writting new content to %s', orig_etc_hosts)
+        __utils__['caasp_log.info']('hosts: writting new content to %s', orig_etc_hosts)
         _write_lines(orig_etc_hosts, new_etc_hosts_contents)
 
     except Exception as e:

--- a/salt/_modules/caasp_log.py
+++ b/salt/_modules/caasp_log.py
@@ -3,6 +3,8 @@
 #       will break python3. This module only exists so it can be called from
 #       salt-states directly and will forward directly to the utils-module.
 #
+
+
 def abort(msg, *args, **kwargs):
     __utils__['caasp_log.abort'](msg, *args, **kwargs)
 

--- a/salt/_modules/caasp_log.py
+++ b/salt/_modules/caasp_log.py
@@ -1,58 +1,23 @@
-# note: this module can be directly imported from other
-#       Salt modules. Do not do the same for other modules:
-#       use __salt__['caasp_module.function'](args)
+# note: this module is a simple proxy to the '_utils/caasp_log.py' Utility
+#       module. *All* modules must use the _utils/caasp_log.py' module or it
+#       will break python3. This module only exists so it can be called from
+#       salt-states directly and will forward directly to the utils-module.
 #
-from __future__ import absolute_import
-
-import logging
-
-from salt.exceptions import SaltException
-
-log = logging.getLogger('CaaS')
-
-
-_CAAS_PREFIX = '[CaaS]: '
-
-
-def __virtual__():
-    return "caasp_log"
-
-
-class ExecutionAborted(SaltException):
-    pass
-
-
 def abort(msg, *args, **kwargs):
-    '''
-    Abort the Salt execution with an error
-    '''
-    error(msg, *args, **kwargs)
-    raise ExecutionAborted(msg % args)
+    __utils__['caasp_log.abort'](msg, *args, **kwargs)
 
 
 def error(msg, *args, **kwargs):
-    '''
-    Log a error message
-    '''
-    log.error(_CAAS_PREFIX + msg % args, **kwargs)
+    __utils__['caasp_log.error'](msg, *args, **kwargs)
 
 
 def warn(msg, *args, **kwargs):
-    '''
-    Log a warning message
-    '''
-    log.warn(_CAAS_PREFIX + msg % args, **kwargs)
+    __utils__['caasp_log.warn'](msg, *args, **kwargs)
 
 
 def info(msg, *args, **kwargs):
-    '''
-    Log an info message
-    '''
-    log.info(_CAAS_PREFIX + msg % args, **kwargs)
+    __utils__['caasp_log.info'](msg, *args, **kwargs)
 
 
 def debug(msg, *args, **kwargs):
-    '''
-    Log a debug message
-    '''
-    log.debug(_CAAS_PREFIX + msg % args, **kwargs)
+    __utils__['caasp_log.debug'](msg, *args, **kwargs)

--- a/salt/_modules/caasp_net.py
+++ b/salt/_modules/caasp_net.py
@@ -6,10 +6,6 @@
 from __future__ import absolute_import
 
 
-# note: do not import caasp modules other than caasp_log
-from caasp_log import error
-
-
 DEFAULT_INTERFACE = 'eth0'
 
 NODENAME_GRAIN = 'nodename'
@@ -35,7 +31,7 @@ def get_iface_ip(iface, host=None, ifaces=None):
         ipv4addr = iface.get('inet', [{}])
         return ipv4addr[0].get('address')
     except Exception as e:
-        error('could not get IP for interface %s: %s', iface, e)
+        __utils__['caasp_log.error']('could not get IP for interface %s: %s', iface, e)
         return ''
 
 
@@ -52,7 +48,7 @@ def get_primary_iface(host=None):
             all_routes = __salt__['caasp_grains.get'](host, 'network.default_route', type='glob')
             return all_routes[host][0]['interface']
     except Exception as e:
-        error('could not get the primary interface: %s', e)
+        __utils__['caasp_log.error']('could not get the primary interface: %s', e)
         return __salt__['caasp_pillar.get']('hw:netiface', DEFAULT_INTERFACE)
 
 
@@ -73,7 +69,7 @@ def get_primary_ips_for(compound, **kwargs):
         all_ifaces = __salt__['caasp_grains.get'](compound, 'network.interfaces')
         return [get_primary_ip(host=host, **kwargs) for host in all_ifaces.keys()]
     except Exception as e:
-        error('could not get primary IPs for %s: %s', compound, e)
+        __utils__['caasp_log.error']('could not get primary IPs for %s: %s', compound, e)
         return []
 
 
@@ -90,5 +86,5 @@ def get_nodename(host=None, **kwargs):
             all_nodenames = __salt__['caasp_grains.get'](host, grain=NODENAME_GRAIN, type='glob')
             return all_nodenames[host]
     except Exception as e:
-        error('could not get nodename: %s', e)
+        __utils__['caasp_log.error']('could not get nodename: %s', e)
         return ''

--- a/salt/_modules/caasp_nodes.py
+++ b/salt/_modules/caasp_nodes.py
@@ -201,7 +201,7 @@ def get_with_prio(num, description, prio_rules, **kwargs):
     remaining = num
     for expr in prio_rules:
         __utils__['caasp_log.debug']('trying to find candidates for "%s" with "%s"',
-                        description, expr)
+                                     description, expr)
         # get all the nodes matching the priority expression,
         # but filtering out all the nodes we already have
         candidates = get_with_expr(expr,
@@ -215,7 +215,7 @@ def get_with_prio(num, description, prio_rules, **kwargs):
             new_nodes = new_nodes + new_ids
             remaining -= len(new_ids)
             __utils__['caasp_log.debug']('... %d new candidates (%s) for %s: %d remaining',
-                            len(ids), str(ids), description, remaining, )
+                                         len(ids), str(ids), description, remaining, )
         else:
             __utils__['caasp_log.debug']('... no new candidates found with "%s"', expr)
 
@@ -223,7 +223,7 @@ def get_with_prio(num, description, prio_rules, **kwargs):
             break
 
     __utils__['caasp_log.info']('we were looking for %d candidates for %s and %d found',
-                   num, description, len(new_nodes))
+                                num, description, len(new_nodes))
     return new_nodes[:num]
 
 
@@ -268,13 +268,13 @@ def get_replacement_for(target, replacement='', **kwargs):
         'forbidden', kwargs, 'P@roles:(admin|ca)')
     if target in forbidden:
         __utils__['caasp_log.abort']('%s cannot be removed: it has a "ca" or "admin" role',
-                        target)
+                                     target)
     elif replacement_provided and replacement in forbidden:
         __utils__['caasp_log.abort']('%s cannot be replaced by %s: the replacement has a "ca" or "admin" role',
-                        target, replacement)
+                                     target, replacement)
     elif replacement_provided and replacement in excluded:
         __utils__['caasp_log.abort']('%s cannot be replaced by %s: the replacement is in the list of nodes excluded',
-                        target, replacement)
+                                     target, replacement)
 
     masters = get_from_args_or_with_expr(
         'masters', kwargs, 'G@roles:kube-master')
@@ -308,7 +308,7 @@ def get_replacement_for(target, replacement='', **kwargs):
 
         if etcd_replacement:
             __utils__['caasp_log.debug']('setting %s as the replacement for the etcd member %s',
-                            etcd_replacement, target)
+                                         etcd_replacement, target)
             replacement = etcd_replacement
             replacement_roles.append('etcd')
 
@@ -316,10 +316,10 @@ def get_replacement_for(target, replacement='', **kwargs):
             if len(etcd_members) <= _MIN_ETCD_MEMBERS_AFTER_REMOVAL:
                 # we need at least one etcd server
                 __utils__['caasp_log.abort']('cannot remove etcd member %s: too few etcd members, and no replacement found or provided',
-                                target)
+                                             target)
             else:
                 __utils__['caasp_log.warn']('number of etcd members will be reduced to %d, as no replacement for etcd server in %s has been found (or provided)',
-                               len(etcd_members), target)
+                                            len(etcd_members), target)
 
     #
     # replacement for k8s masters
@@ -363,22 +363,22 @@ def get_replacement_for(target, replacement='', **kwargs):
             assert len(replacement) > 0
             if replacement == master_replacement:
                 __utils__['caasp_log.debug']('setting %s as replacement for the kubernetes master %s',
-                                replacement, target)
+                                             replacement, target)
                 replacement_roles.append('kube-master')
             else:
                 __utils__['caasp_log.warn']('the k8s master replacement (%s) is not the same as the current replacement (%s) ' +
-                               '(it will run %s) so we cannot use it for running the k8s master too',
-                               master_replacement, replacement, ','.join(replacement_roles))
+                                            '(it will run %s) so we cannot use it for running the k8s master too',
+                                            master_replacement, replacement, ','.join(replacement_roles))
 
         if 'kube-master' not in replacement_roles:
             # stability check: check if it is ok not to run the k8s master in the replacement
             if len(masters) <= _MIN_MASTERS_AFTER_REMOVAL:
                 # we need at least one master (for runing the k8s API at all times)
                 __utils__['caasp_log.abort']('cannot remove k8s master %s: too few k8s masters, and no replacement found or provided',
-                                target)
+                                             target)
             else:
                 __utils__['caasp_log.warn']('number of k8s masters will be reduced to %d, as no replacement for the k8s master in %s has been found (or provided)',
-                               len(masters), target)
+                                            len(masters), target)
 
     #
     # replacement for k8s minions
@@ -418,22 +418,22 @@ def get_replacement_for(target, replacement='', **kwargs):
             assert len(replacement) > 0
             if replacement == minion_replacement:
                 __utils__['caasp_log.debug']('setting %s as replacement for the k8s minion %s',
-                                replacement, target)
+                                             replacement, target)
                 replacement_roles.append('kube-minion')
             else:
                 __utils__['caasp_log.warn']('the k8s minion replacement (%s) is not the same as the current replacement (%s) ' +
-                               '(it will run %s) so we cannot use it for running the k8s minion too',
-                               minion_replacement, replacement, ','.join(replacement_roles))
+                                            '(it will run %s) so we cannot use it for running the k8s minion too',
+                                            minion_replacement, replacement, ','.join(replacement_roles))
 
         if 'kube-minion' not in replacement_roles:
             # stability check: check if it is ok not to run the k8s minion in the replacement
             if len(minions) <= _MIN_MINIONS_AFTER_REMOVAL:
                 # we need at least one minion (for running dex, kube-dns, etc..)
                 __utils__['caasp_log.abort']('cannot remove k8s minion %s: too few k8s minions, and no replacement found or provided',
-                                target)
+                                             target)
             else:
                 __utils__['caasp_log.warn']('number of k8s minions will be reduced to %d, as no replacement for the k8s minion in %s has been found (or provided)',
-                               len(masters), target)
+                                            len(masters), target)
 
     # other consistency checks...
     if replacement:

--- a/salt/_modules/caasp_registry.py
+++ b/salt/_modules/caasp_registry.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+"""Determine which container images to use.
+
+Either use the images provided by container-feeder or download them
+directly from a registry.
+
+Returns multiple grains related to the images:
+
+- use_registry_images: True if registry images should be used.
+- base_image_url: prefix for the container-images: <prefix>/<image>:<tag>
+"""
+import sys
+
+
+UNKNOWN_VERSION = (0, 0)
+
+
+def __virtual__():
+    return "caasp_registry"
+
+
+def _use_registry_images():
+    """Return whether registry or packaged images are used."""
+    return False if sys.version_info < (3,) else True
+
+
+def _registry():
+    """Registry to download images from."""
+    return "registry.suse.de"
+
+
+def _namespace():
+    """Base namespace the images can be found in the registry"""
+    return "devel/casp/3.0/controllernode/images_container_base/sles12"
+
+
+def caasp_version():
+    # Python 3 does not allow comparing list & tuples, so force a tuple:
+    version = tuple(__salt__['grains.get']('osrelease_info', UNKNOWN_VERSION))
+    return version
+
+
+def use_registry_images():
+    return _use_registry_images()
+
+
+def base_image_url():
+    """Return the prefix of the container image to use.
+
+    <prefix>/<image>:<tag>
+    """
+    if _use_registry_images():
+        return "{0}/{1}".format(_registry(), _namespace())
+    else:
+        return "sles12"

--- a/salt/_modules/tests/__init__.py
+++ b/salt/_modules/tests/__init__.py
@@ -1,6 +1,23 @@
+import importlib
+import os
+import sys
+sys.path.append(os.path.abspath(os.path.join(__file__, "../../../")))
+
+
 def setUpModule():
     print('Starting tests.')
 
 
 def tearDownModule():
     print('Tests done.')
+
+
+class Utils(object):
+    """Proxy module to simulate the __utils__[*] dictionary used in salt-code.
+
+    Needed to test the salt-modules in isolation."""
+    def __getitem__(self, key):
+        package, function = key.rsplit(".")
+        full_path_package = "_utils.{0}".format(package)
+        module = importlib.import_module(full_path_package)
+        return getattr(module, function)

--- a/salt/_modules/tests/test_caasp_etcd.py
+++ b/salt/_modules/tests/test_caasp_etcd.py
@@ -4,6 +4,7 @@ import unittest
 
 import caasp_etcd
 from caasp_etcd import ETCD_CLIENT_PORT, get_endpoints
+from . import Utils
 
 try:
     from mock import patch, MagicMock
@@ -14,6 +15,7 @@ else:
 
 
 caasp_etcd.__salt__ = {}
+caasp_etcd.__utils__ = Utils()
 
 
 class TestGetEndpoints(unittest.TestCase):

--- a/salt/_modules/tests/test_caasp_hosts.py
+++ b/salt/_modules/tests/test_caasp_hosts.py
@@ -6,6 +6,7 @@ import random
 import unittest
 
 from salt.utils.odict import OrderedDict
+from . import Utils
 
 try:
     from mock import patch, MagicMock
@@ -13,7 +14,6 @@ except ImportError:
     _mocking_lib_available = False
 else:
     _mocking_lib_available = True
-
 
 log = logging.getLogger()
 log.level = logging.DEBUG
@@ -53,6 +53,7 @@ class TestEtcHosts(unittest.TestCase):
     def _generate(self, etc_hosts_filename, caasp_etc_hosts_filename, role='kube-master'):
         import caasp_hosts
         caasp_hosts.__salt__ = dict()
+        caasp_hosts.__utils__ = Utils()
 
         ips = {
             'admin': '10.10.10.1',
@@ -95,7 +96,7 @@ class TestEtcHosts(unittest.TestCase):
             'caasp_pillar.get': mock_get_pillar,
             'caasp_net.get_primary_ip': mock_get_primary_ip,
             'caasp_net.get_nodename': mock_get_nodename,
-            'caasp_filters.is_ip': MagicMock(return_value=False)
+            'caasp_filters.is_ip': MagicMock(return_value=False),
         }
 
         with patch.dict(caasp_hosts.__salt__, salt_mocks):
@@ -148,6 +149,7 @@ ff02::3         ipv6-allhosts
 
         from tempfile import NamedTemporaryFile as ntf
         import caasp_hosts
+        caasp_hosts.__utils__ = Utils()
 
         with ntf(mode='w+', prefix=TEMP_PREFIX) as etc_hosts:
             try:

--- a/salt/_modules/tests/test_caasp_nodes.py
+++ b/salt/_modules/tests/test_caasp_nodes.py
@@ -2,9 +2,11 @@ from __future__ import absolute_import
 
 import unittest
 
-import caasp_log
+import caasp_nodes
 from caasp_nodes import (get_expr_affected_by, get_from_args_or_with_expr,
                          get_replacement_for, get_with_prio)
+from _utils import caasp_log
+from . import Utils
 
 try:
     from mock import patch, MagicMock
@@ -12,6 +14,8 @@ except ImportError:
     _mocking_lib_available = False
 else:
     _mocking_lib_available = True
+
+caasp_nodes.__utils__ = Utils()
 
 
 class TestGetFromArgsOrWithExpr(unittest.TestCase):

--- a/salt/_modules/tests/test_caasp_nodes.py
+++ b/salt/_modules/tests/test_caasp_nodes.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import unittest
 
-from caasp_log import ExecutionAborted
+import caasp_log
 from caasp_nodes import (get_expr_affected_by, get_from_args_or_with_expr,
                          get_replacement_for, get_with_prio)
 
@@ -189,7 +189,7 @@ class TestGetReplacementFor(unittest.TestCase):
 
         # however, we can migrate only the etcd role to another minion
         # (as it is a user provided replacement, it will raise an exception)
-        with self.assertRaises(ExecutionAborted):
+        with self.assertRaises(caasp_log.ExecutionAborted):
             replacement, roles = get_replacement_for(self.minion_1,
                                                      replacement=self.minion_3,
                                                      **kwargs)
@@ -214,7 +214,7 @@ class TestGetReplacementFor(unittest.TestCase):
                       'kube-minion role not found in replacement')
 
         # check we cannot use an excluded node
-        with self.assertRaises(ExecutionAborted):
+        with self.assertRaises(caasp_log.ExecutionAborted):
             replacement, roles = get_replacement_for(self.minion_1,
                                                      replacement=self.minion_3,
                                                      excluded=[self.minion_3],
@@ -226,7 +226,7 @@ class TestGetReplacementFor(unittest.TestCase):
         is not a valid replacement for a master & etcd.
         '''
         # the master role cannot be migrated to a minion
-        with self.assertRaises(ExecutionAborted):
+        with self.assertRaises(caasp_log.ExecutionAborted):
             replacement, roles = get_replacement_for(self.master_2,
                                                      replacement=self.minion_3,
                                                      **self.get_replacement_for_kwargs)
@@ -237,7 +237,7 @@ class TestGetReplacementFor(unittest.TestCase):
         is not a valid replacement.
         '''
         # the master role cannot be migrated to a CA
-        with self.assertRaises(ExecutionAborted):
+        with self.assertRaises(caasp_log.ExecutionAborted):
             replacement, roles = get_replacement_for(self.master_2,
                                                      replacement=self.ca,
                                                      **self.get_replacement_for_kwargs)
@@ -247,7 +247,7 @@ class TestGetReplacementFor(unittest.TestCase):
         Check get_replacement_for() realizes the CA
         cannot be removed
         '''
-        with self.assertRaises(ExecutionAborted):
+        with self.assertRaises(caasp_log.ExecutionAborted):
             replacement, roles = get_replacement_for(self.ca,
                                                      replacement=self.minion_3,
                                                      **self.get_replacement_for_kwargs)

--- a/salt/_modules/tests/test_caasp_pillar.py
+++ b/salt/_modules/tests/test_caasp_pillar.py
@@ -4,6 +4,7 @@ import unittest
 
 import caasp_pillar
 from caasp_pillar import get as get_pillar
+from . import Utils
 
 try:
     from mock import patch, MagicMock
@@ -14,6 +15,7 @@ else:
 
 
 caasp_pillar.__salt__ = {}
+caasp_pillar.__utils__ = Utils()
 
 
 class TestGetPillar(unittest.TestCase):

--- a/salt/_states/caasp_cmd.py
+++ b/salt/_states/caasp_cmd.py
@@ -142,10 +142,10 @@ def run(name,
 
             getpip:
               caasp_cmd.run:
-                - name: /usr/bin/python /usr/local/sbin/get-pip.py
+                - name: /usr/bin/python3 /usr/local/sbin/get-pip.py
                 - unless: which pip
                 - require:
-                  - pkg: python
+                  - pkg: python3
                   - file: /usr/local/sbin/get-pip.py
                 - reload_modules: True
 

--- a/salt/_states/caasp_cri.py
+++ b/salt/_states/caasp_cri.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
 
-from caasp_log import debug
-
 
 def stop_container_and_wait(name, namespace, timeout=60, **kwargs):
     '''
@@ -36,7 +34,7 @@ def stop_container_and_wait(name, namespace, timeout=60, **kwargs):
     stopped = __salt__['caasp_cri.stop_container'](name, namespace, **kwargs)
 
     if not stopped:
-        debug('CaaS: {namespace}.{name} container was not found running'.format(
+        __utils__['caasp_log.debug']('CaaS: {namespace}.{name} container was not found running'.format(
               namespace=namespace,
               name=name))
 

--- a/salt/_states/caasp_cri.py
+++ b/salt/_states/caasp_cri.py
@@ -35,8 +35,8 @@ def stop_container_and_wait(name, namespace, timeout=60, **kwargs):
 
     if not stopped:
         __utils__['caasp_log.debug']('CaaS: {namespace}.{name} container was not found running'.format(
-              namespace=namespace,
-              name=name))
+            namespace=namespace,
+            name=name))
 
     return wait_for_container(name, namespace, timeout, **kwargs)
 

--- a/salt/_utils/caasp_log.py
+++ b/salt/_utils/caasp_log.py
@@ -1,0 +1,58 @@
+# note: this module can be directly imported from other
+#       Salt modules. Do not do the same for other modules:
+#       use __salt__['caasp_module.function'](args)
+#
+from __future__ import absolute_import
+
+import logging
+
+from salt.exceptions import SaltException
+
+log = logging.getLogger('CaaS')
+
+
+_CAAS_PREFIX = '[CaaS]: '
+
+
+def __virtual__():
+    return "caasp_log"
+
+
+class ExecutionAborted(SaltException):
+    pass
+
+
+def abort(msg, *args, **kwargs):
+    '''
+    Abort the Salt execution with an error
+    '''
+    error(msg, *args, **kwargs)
+    raise ExecutionAborted(msg % args)
+
+
+def error(msg, *args, **kwargs):
+    '''
+    Log a error message
+    '''
+    log.error(_CAAS_PREFIX + msg % args, **kwargs)
+
+
+def warn(msg, *args, **kwargs):
+    '''
+    Log a warning message
+    '''
+    log.warn(_CAAS_PREFIX + msg % args, **kwargs)
+
+
+def info(msg, *args, **kwargs):
+    '''
+    Log an info message
+    '''
+    log.info(_CAAS_PREFIX + msg % args, **kwargs)
+
+
+def debug(msg, *args, **kwargs):
+    '''
+    Log a debug message
+    '''
+    log.debug(_CAAS_PREFIX + msg % args, **kwargs)

--- a/salt/addons/dex/init.sls
+++ b/salt/addons/dex/init.sls
@@ -16,12 +16,21 @@ include:
          cn = 'Dex',
          extra_alt_names = alt_master_names(dex_alt_names)) }}
 
-# This file needs to be explicitly copied over *before*
-# kubectL_apply_dir_templates run. Otherwise one of the templates attempts to
-# access the file, and it does not exist yet, breaking the orchestration.
+# The following files need to be explicitly copied over *before*
+# kubectl_apply_dir_templates runs. Otherwise one of the templates attempts to
+# access the files, and it does not exist yet, breaking the orchestration.
 /etc/kubernetes/addons/dex/15-secret.yaml:
   file.managed:
     - source:   "salt://addons/dex/manifests/15-secret.yaml"
+    - user:     root
+    - group:    root
+    - mode:     0600
+    - template: jinja
+    - makedirs: true
+
+/etc/kubernetes/addons/dex/15-configmap.yaml:
+  file.managed:
+    - source:   "salt://addons/dex/manifests/15-configmap.yaml"
     - user:     root
     - group:    root
     - mode:     0600

--- a/salt/addons/dex/manifests/20-deployment.yaml
+++ b/salt/addons/dex/manifests/20-deployment.yaml
@@ -51,7 +51,7 @@ spec:
               topologyKey: "kubernetes.io/hostname"
 
       containers:
-      - image: sles12/caasp-dex:2.7.1
+      - image: {{ salt.caasp_registry.base_image_url() }}/caasp-dex:2.7.1
         name: dex
         command: ["/usr/bin/caasp-dex", "serve", "/etc/dex/cfg/config.yaml"]
 

--- a/salt/addons/dns/manifests/20-deployment.yaml
+++ b/salt/addons/dns/manifests/20-deployment.yaml
@@ -48,7 +48,7 @@ spec:
           name: kube-dns
       containers:
       - name: kubedns
-        image: sles12/kubedns:1.0.0
+        image: {{  salt.caasp_registry.base_image_url() }}/kubedns:1.0.0
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -99,7 +99,7 @@ spec:
         - name: kube-dns-config
           mountPath: /kube-dns-config
       - name: dnsmasq
-        image: sles12/dnsmasq-nanny:1.0.0 
+        image: {{ salt.caasp_registry.base_image_url() }}/dnsmasq-nanny:1.0.0 
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -137,7 +137,7 @@ spec:
         - name: kube-dns-config
           mountPath: /etc/k8s/dns/dnsmasq-nanny
       - name: sidecar
-        image: sles12/sidecar:1.0.0
+        image: {{ salt.caasp_registry.base_image_url() }}/sidecar:1.0.0
         livenessProbe:
           httpGet:
             path: /metrics

--- a/salt/addons/tiller/manifests/20-deployment.yaml
+++ b/salt/addons/tiller/manifests/20-deployment.yaml
@@ -46,7 +46,7 @@ spec:
       - env:
         - name: TILLER_NAMESPACE
           value: kube-system
-        image: sles12/tiller:2.8.2
+        image: {{ salt.caasp_registry.base_image_url() }}/tiller:2.8.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/salt/ca-cert/init.sls
+++ b/salt/ca-cert/init.sls
@@ -1,6 +1,8 @@
 include:
   - crypto
 
+{%- set ca_crt = salt['mine.get']('roles:ca', 'ca.crt', expr_form='grain').values()|first %}
+
 {{ pillar['ssl']['ca_dir'] }}:
   file.directory:
     - makedirs: True
@@ -10,7 +12,7 @@ include:
 
 {{ pillar['ssl']['ca_file'] }}:
   x509.pem_managed:
-    - text: {{ salt['mine.get']('roles:ca', 'ca.crt', expr_form='grain').values()[0]['/etc/pki/ca.crt']|replace('\n', '') }}
+    - text: {{ ca_crt['/etc/pki/ca.crt']|replace('\n', '') }}
     - user: root
     - group: root
     - mode: 644

--- a/salt/cleanup/remove-post-orchestration.sls
+++ b/salt/cleanup/remove-post-orchestration.sls
@@ -7,7 +7,7 @@
 # k8s cluster
 ###############
 
-{%- set k8s_nodes = salt.caasp_nodes.get_with_expr('P@roles:(kube-master|kube-minion)', booted=True) %}
+{%- set k8s_nodes = salt.caasp_nodes.get_with_expr('P@roles:(kube-master|kube-minion)', booted=True)|list %}
 {%- if forced or target in k8s_nodes %}
 
 include:
@@ -24,7 +24,7 @@ include:
 # etcd node
 ###############
 
-{%- set etcd_members = salt.caasp_nodes.get_with_expr('G@roles:etcd', booted=True) %}
+{%- set etcd_members = salt.caasp_nodes.get_with_expr('G@roles:etcd', booted=True)|list %}
 {%- if forced or target in etcd_members %}
 
 etcd-remove-member:

--- a/salt/container-feeder/init.sls
+++ b/salt/container-feeder/init.sls
@@ -19,15 +19,6 @@ container-feeder:
   service.running:
     - enable: True
     - require:
-      {% if not salt.caasp_nodes.is_admin_node() %}
-      # the admin node uses docker as CRI, requiring its state
-      # will cause the docker daemon to be restarted, which will
-      # lead to the premature termination of the orchestration.
-      # Hence let's not require docker on the admin node.
-      # This is not a big deal because the admin node has already
-      # working since the boot time.
-      - pkg: {{ pillar['cri'][salt.caasp_cri.cri_name()]['package'] }}
-      {% endif %}
       - file: /etc/containers/storage.conf
       - file: /etc/sysconfig/container-feeder
       - file: /etc/container-feeder.json

--- a/salt/cri/init.sls
+++ b/salt/cri/init.sls
@@ -14,15 +14,9 @@
     - makedirs: True
 {% endif %}
 
-podman:
-  pkg:
-    - installed
-
 /etc/cni/net.d/87-podman-bridge.conflist:
-  file.absent:
+  file.absent
     # Has to be removed, otherwise kubernetes will use this CNI driver
     # instead of the flannel one.
     # Moreover, by doing that podman containers will be attached to the
     # flannel network, which is useful for debugging.
-    - require:
-      - pkg: podman

--- a/salt/crio/init.sls
+++ b/salt/crio/init.sls
@@ -1,6 +1,8 @@
 include:
   - kubelet
+  {%- if not salt.caasp_registry.use_registry_images() %}
   - container-feeder
+  {%- endif %}
 
 crio:
   pkg.installed:
@@ -25,8 +27,10 @@ crio:
     - makedirs: True
     - require_in:
       - kubelet
+    {%- if not salt.caasp_registry.use_registry_images() %}
     - require:
       - service: container-feeder
+    {%- endif %}
   module.run:
     - name: service.systemctl_reload
     - onchanges:

--- a/salt/crio/init.sls
+++ b/salt/crio/init.sls
@@ -5,9 +5,6 @@ include:
   {%- endif %}
 
 crio:
-  pkg.installed:
-    - name: cri-o
-    - install_recommends: False
   file.managed:
     - name: /etc/crio/crio.conf
     - source: salt://crio/crio.conf.jinja
@@ -18,7 +15,6 @@ crio:
     - name: crio
     - reload: True
     - watch:
-      - pkg: crio
       - file: /etc/crio/crio.conf
 
 /etc/systemd/system/kubelet.service.d/kubelet.conf:

--- a/salt/crypto/init.sls
+++ b/salt/crypto/init.sls
@@ -1,7 +1,3 @@
-python-M2Crypto:
-  pkg.installed:
-    - install_recommends: False
-
 /etc/pki:
   file.directory:
     - user: root

--- a/salt/docker/init.sls
+++ b/salt/docker/init.sls
@@ -60,9 +60,6 @@
     - makedirs: True
 
 docker:
-  pkg.installed:
-    - name: {{ salt.caasp_pillar.get('docker:pkg', 'docker') }}
-    - install_recommends: False
   file.replace:
     # remove any DOCKER_OPTS in the sysconfig file, as we will be
     # using the "daemon.json". In fact, we don't want any DOCKER_OPS
@@ -73,12 +70,9 @@ docker:
     - repl: 'DOCKER_OPTS=""'
     - flags: ['IGNORECASE', 'MULTILINE']
     - append_if_not_found: True
-    - require:
-      - pkg: docker
   service.running:
     - enable: True
     - watch:
-      - pkg: docker
       - file: /etc/sysconfig/docker
 
 docker-proxy-config:

--- a/salt/etcd/create-or-update-etcd-pillar.jinja
+++ b/salt/etcd/create-or-update-etcd-pillar.jinja
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python3
 
 import json
 import subprocess

--- a/salt/etcd/init.sls
+++ b/salt/etcd/init.sls
@@ -8,9 +8,6 @@ include:
 # add the member to the cluster _before_ `etcd` is started
 # then `etcd` will have to be started with the `existing` flag
 add-etcd-to-cluster:
-  pkg.installed:
-    - name: etcdctl
-    - install_recommends: False
   caasp_etcd.member_add:
     - retry:
         interval: 4
@@ -35,12 +32,6 @@ etcd:
       - etcd
     - require:
       - group: etcd
-  pkg.installed:
-    - pkgs:
-      - iptables
-      - etcdctl
-      - etcd
-    - install_recommends: False
   caasp_retriable.retry:
     - name: iptables-etcd
     - target: iptables.append
@@ -65,7 +56,6 @@ etcd:
     - enable: True
     - require:
       - sls: ca-cert
-      - pkg: etcd
       - caasp_retriable: iptables-etcd
     - watch:
       - {{ pillar['ssl']['crt_file'] }}
@@ -88,7 +78,6 @@ etcd:
     - group: etcd
     - mode: 644
     - require:
-      - pkg: etcd
       - user: etcd
       - group: etcd
 
@@ -101,6 +90,5 @@ etcd:
     - group: etcd
     - mode: 644
     - require:
-      - pkg: etcd
       - user: etcd
       - group: etcd

--- a/salt/haproxy/haproxy.yaml.jinja
+++ b/salt/haproxy/haproxy.yaml.jinja
@@ -20,7 +20,7 @@ spec:
       operator: "Exists"
   containers:
     - name: haproxy
-      image: sles12/haproxy:1.6.0
+      image: {{ salt.caasp_registry.base_image_url() }}/haproxy:1.6.0
       resources:
         requests:
           memory: 128Mi

--- a/salt/haproxy/init.sls
+++ b/salt/haproxy/init.sls
@@ -11,7 +11,9 @@ include:
 # failing orchestrations.
   - kubelet
   - {{ salt['pillar.get']('cri:chosen', 'docker') }}
+  {%- if not salt.caasp_registry.use_registry_images() %}
   - container-feeder
+  {%- endif %}
 {% endif %}
 
 /etc/caasp/haproxy:
@@ -83,7 +85,9 @@ haproxy-restart:
 {% if not salt.caasp_nodes.is_admin_node() %}
     - require:
       - service: kubelet
+      {%- if not salt.caasp_registry.use_registry_images() %}
       - service: container-feeder
+      {%- endif %}
 {% endif %}
 
 

--- a/salt/kube-apiserver/init.sls
+++ b/salt/kube-apiserver/init.sls
@@ -13,11 +13,6 @@ include:
          o = pillar['certificate_information']['subject_properties']['O']) }}
 
 kube-apiserver:
-  pkg.installed:
-    - pkgs:
-      - iptables
-      - kubernetes-master
-    - install_recommends: False
   caasp_retriable.retry:
     - name: iptables-kube-apiserver
     - target: iptables.append
@@ -61,8 +56,6 @@ kube-apiserver:
     - group: kube
     - dirmode: 755
     - filemode: 644
-    - require:
-      - pkg: kube-apiserver
 
 /etc/kubernetes/audit-policy.yaml:
   file.managed:

--- a/salt/kube-controller-manager/init.sls
+++ b/salt/kube-controller-manager/init.sls
@@ -3,10 +3,6 @@ include:
   - kubernetes-common.serviceaccount-key
 
 kube-controller-manager:
-  pkg.installed:
-    - pkgs:
-      - kubernetes-master
-    - install_recommends: False
   file.managed:
     - name:       /etc/kubernetes/controller-manager
     - source:     salt://kube-controller-manager/controller-manager.jinja
@@ -31,7 +27,6 @@ kube-controller-mgr-config:
     - source: salt://kubeconfig/kubeconfig.jinja
     - template: jinja
     - require:
-      - pkg: kubernetes-common
       - caasp_retriable: {{ pillar['ssl']['kube_controller_mgr_crt'] }}
     - defaults:
         user: 'default-admin'

--- a/salt/kube-proxy/init.sls
+++ b/salt/kube-proxy/init.sls
@@ -12,7 +12,6 @@ include:
     - source: salt://kubeconfig/kubeconfig.jinja
     - template: jinja
     - require:
-      - pkg: kubernetes-common
       - caasp_retriable: {{ pillar['ssl']['kube_proxy_crt'] }}
     - defaults:
         user: 'default-admin'
@@ -20,12 +19,6 @@ include:
         client_key: {{ pillar['ssl']['kube_proxy_key'] }}
 
 kube-proxy:
-  pkg.installed:
-    - pkgs:
-      - iptables
-      - conntrack-tools
-      - kubernetes-node
-    - install_recommends: False
   file.managed:
     - name: /etc/kubernetes/proxy
     - source: salt://kube-proxy/proxy.jinja

--- a/salt/kube-scheduler/init.sls
+++ b/salt/kube-scheduler/init.sls
@@ -3,10 +3,6 @@ include:
   - kubernetes-common
 
 kube-scheduler:
-  pkg.installed:
-    - pkgs:
-      - kubernetes-master
-    - install_recommends: False
   file.managed:
     - name: /etc/kubernetes/scheduler
     - source: salt://kube-scheduler/scheduler.jinja
@@ -29,7 +25,6 @@ kube-scheduler-config:
     - source: salt://kubeconfig/kubeconfig.jinja
     - template: jinja
     - require:
-      - pkg: kubernetes-common
       - caasp_retriable: {{ pillar['ssl']['kube_scheduler_crt'] }}
     - defaults:
         user: 'default-admin'

--- a/salt/kubectl-config/init.sls
+++ b/salt/kubectl-config/init.sls
@@ -15,7 +15,6 @@ include:
     - source: salt://kubeconfig/kubeconfig.jinja
     - template: jinja
     - require:
-      - pkg: kubernetes-common
       - /etc/pki/kubectl-client-cert.crt
     - defaults:
         user: 'cluster-admin'

--- a/salt/kubelet/init.sls
+++ b/salt/kubelet/init.sls
@@ -31,7 +31,6 @@ kubeconfig:
     - source: salt://kubeconfig/kubeconfig.jinja
     - template: jinja
     - require:
-      - pkg: kubernetes-common
       - caasp_retriable: {{ pillar['ssl']['kubelet_crt'] }}
     - defaults:
         user: 'default-admin'
@@ -62,12 +61,6 @@ kubelet-config:
       - sls:    kubernetes-common
 
 kubelet:
-  pkg.installed:
-    - pkgs:
-      - iptables
-      - kubernetes-client
-      - kubernetes-node
-    - install_recommends: False
   file.managed:
     - name:     /etc/kubernetes/kubelet
     - source:   salt://kubelet/kubelet.jinja

--- a/salt/kubernetes-common/init.sls
+++ b/salt/kubernetes-common/init.sls
@@ -1,21 +1,11 @@
-kubernetes-common:
-  pkg.installed:
-    - pkgs:
-      - kubernetes-common
-    - install_recommends: False
-
 /etc/kubernetes/config:
   file.managed:
     - source:     salt://kubernetes-common/config.jinja
     - template:   jinja
-    - require:
-      - pkg: kubernetes-common
 
 {% if pillar['cloud']['provider'] == 'openstack' %}
 /etc/kubernetes/openstack-config:
   file.managed:
     - source:     salt://kubernetes-common/openstack-config.jinja
     - template:   jinja
-    - require:
-      - pkg:      kubernetes-common
 {% endif %}

--- a/salt/kubernetes-common/serviceaccount-key.sls
+++ b/salt/kubernetes-common/serviceaccount-key.sls
@@ -1,6 +1,8 @@
+{%- set ca_crt = salt['mine.get']('roles:ca', 'sa.key', expr_form='grain').values()|first %}
+
 {{ pillar['paths']['service_account_key'] }}:
   x509.pem_managed:
-    - text: {{ salt['mine.get']('roles:ca', 'sa.key', expr_form='grain').values()[0]['/etc/pki/sa.key']|replace('\n', '') }}
+    - text: {{ ca_crt['/etc/pki/sa.key']|replace('\n', '') }}
     - user: root
     - group: root
     - mode: 0444

--- a/salt/orch/removal.sls
+++ b/salt/orch/removal.sls
@@ -217,7 +217,9 @@ stop-services-in-target:
   salt.state:
     - tgt: '{{ target }}'
     - sls:
+  {%- if not salt.caasp_registry.use_registry_images() %}
       - container-feeder.stop
+  {%- endif %}
   {%- if target in masters %}
       - kube-apiserver.stop
       - kube-controller-manager.stop

--- a/salt/orch/update.sls
+++ b/salt/orch/update.sls
@@ -201,7 +201,9 @@ early-services-setup:
   salt.state:
     - tgt: '{{ master_id }}'
     - sls:
+      {%- if not salt.caasp_registry.use_registry_images() %}
       - container-feeder.stop
+      {%- endif %}
       - kube-apiserver.stop
       - kube-controller-manager.stop
       - kube-scheduler.stop
@@ -367,7 +369,9 @@ all-workers-3.0-pre-clean-shutdown:
   salt.state:
     - tgt: '{{ worker_id }}'
     - sls:
+      {%- if not salt.caasp_registry.use_registry_images() %}
       - container-feeder.stop
+      {%- endif %}
       - kube-proxy.stop
       - cri.stop
       - etcd.stop

--- a/salt/reboot/init.sls
+++ b/salt/reboot/init.sls
@@ -24,9 +24,6 @@
 
 # Initialize the `mutex` key as expected by the reboot manager.
 set_max_holders_mutex:
-  pkg.installed:
-    - name: curl
-    - install_recommends: False
   cmd.run:
     - name: curl -L -X PUT {{ curl_args}} {{ reboot_uri }}/mutex?prevExist=false -d value="0"
     - onlyif: curl {{ curl_args}} {{ reboot_uri }}/mutex?prevExist=false | grep -i "key not found"
@@ -34,9 +31,6 @@ set_max_holders_mutex:
 # Initialize the `data` key, which is JSON data with: the maximum number of
 # holders, and a list of current holders.
 set_max_holders_data:
-  pkg.installed:
-    - name: curl
-    - install_recommends: False
   cmd.run:
     - name:
         curl -L -X PUT {{ curl_args}} {{ reboot_uri }}/data?prevExist=false -d value='{ "max":"{{ max_holders }}", "holders":[] }'

--- a/salt/swap/init.sls
+++ b/salt/swap/init.sls
@@ -1,7 +1,3 @@
-coreutils:
-  pkg:
-    - installed
-
 unmount-swaps:
   cmd.run:
     - name: /sbin/swapoff -a

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -6,7 +6,9 @@ base:
     - match: grain_pcre
     - ca-cert
     - cri
+    {%- if not salt.caasp_registry.use_registry_images() %}
     - container-feeder
+    {%- endif %}
     {% if not salt.caasp_nodes.is_admin_node() %}
       # the admin node uses docker as CRI, requiring its state
       # will cause the docker daemon to be restarted, which will

--- a/tox.ini
+++ b/tox.ini
@@ -66,7 +66,8 @@ builtins =
     __salt__,
     __opts__,
     __states__,
-    __pillar__
+    __pillar__,
+    __utils__
 
 # E501: line too long (NN > 79 characters)
 ignore = E501


### PR DESCRIPTION
These changes make the the salt-states run on `sle15` using `python3` and keep working on `sle12` using `python2`.

Right now for `sle15` they hard-code images from registry.suse.de that have to be replaced with more stable ones, once the tagging strategy is finalized.

The PR also includes the changes from #616, as without those changes the cluster will break, once a node is rebooted.