### PR TITLE
Add support for OIDC connectors to dex configmap

### DIFF
--- a/salt/addons/dex/manifests/15-configmap.yaml
+++ b/salt/addons/dex/manifests/15-configmap.yaml
@@ -75,6 +75,17 @@ data:
 
           nameAttr: {{ con['group']['attr_map']['name'] | yaml_dquote }}
     {% endif %}
+    {% if con['type'] == 'oidc' %}
+    - type: oidc
+      id: {{ con['id'] | yaml_dquote }}
+      name: {{ con['name'] | yaml_dquote }}
+      config:
+        issuer: {{ con['provider_url'] | yaml_dquote }}
+        clientID: {{ con['client_id'] | yaml_dquote }}
+        clientSecret: {{ con['client_secret'] | yaml_dquote }}
+        basicAuthUnsupported: {{ 'false' if con.get('basic_auth',false) else 'true' }}
+        redirectURI: {{ con['callback_url'] | yaml_dquote }}
+    {% endif %}
     {% endfor %}
     oauth2:
       skipApprovalScreen: true


### PR DESCRIPTION
This complements the Velum PR at kubic-project/velum#665 by adding OIDC connector listing support to salt.

NOTE: Do not merge until kubic-project/velum#665 is merged, though, as it will cause orchestration to fail if the new database table (created in that PR) does not exist.  Marking as Work In Progress, since cross-project PR dependencies isn't a thing in GitHub yet. :)