### PR TITLE
[3.0] Fix bsc#1111168: Do not expect masters to always need to be updated

### DIFF
--- a/salt/orch/update.sls
+++ b/salt/orch/update.sls
@@ -277,6 +277,7 @@ all-masters-post-start-services:
   salt.state:
     - tgt: '{{ is_updateable_master_tgt }}'
     - tgt_type: compound
+    - expect_minions: false
     - batch: 3
     - sls:
       - migrations.2-3.cni.post-start-services


### PR DESCRIPTION
If the masters already updated, but workers failed to update this state will
not have any minions to run on and fail if 'execpt_minions: false' is not set.

(cherry picked from commit 9786217d2e68d9d130522eb3aa8a43d4007f685e)