### PR TITLE
Fix bsc#1111168: Do not expect masters to always need to be updated

### DIFF
--- a/salt/orch/update.sls
+++ b/salt/orch/update.sls
@@ -119,6 +119,7 @@ pre-orchestration-migration:
   salt.state:
     - tgt: '{{ is_updateable_node_tgt }}'
     - tgt_type: compound
+    - expect_minions: false
     - batch: 3
     - sls:
       - migrations.2-3.cni.pre-orchestration


### PR DESCRIPTION
If the masters already updated, but workers failed to update this state will
not have any minions to run on and fail if 'execpt_minions: false' is not set.

Signed-off-by: Maximilian Meister <mmeister@suse.de>

Follow up of https://github.com/kubic-project/salt/pull/669