### PR TITLE
[3.0] fix for bsc#1111333

### DIFF
--- a/salt/crypto/init.sls
+++ b/salt/crypto/init.sls
@@ -1,6 +1,3 @@
-python-M2Crypto:
-  pkg.installed
-
 /etc/pki:
   file.directory:
     - user: root


### PR DESCRIPTION
we tried to run zypper from within the ca container which tried
to fetch from the sles repos

Signed-off-by: Maximilian Meister <mmeister@suse.de>