### PR TITLE
[3.0] Add a whitelist for returned events so we only save events that we care about

### DIFF
--- a/config/master.d/50-master.conf
+++ b/config/master.d/50-master.conf
@@ -9,6 +9,13 @@ event_return: mysql
 presence_events: True
 timeout: 20
 
+event_return_whitelist:
+  - salt/auth
+  - salt/minion/*/start
+  - salt/run/*/new
+  - salt/run/*/ret
+  - salt/job/*/ret/*
+
 # performance tuning
 # see https://docs.saltstack.com/en/latest/ref/configuration/master.html#master-large-scale-tuning-settings
 worker_threads: 20


### PR DESCRIPTION
Fixes: bsc#1112967

Backport of https://github.com/kubic-project/salt/pull/678/