### PR TITLE
[3.0] Enable `ExperimentalCriticalPodAnnotation` feature gate in the kubelet

### DIFF
--- a/salt/kubelet/kubelet-config.jinja
+++ b/salt/kubelet/kubelet-config.jinja
@@ -47,6 +47,8 @@ evictionHard:
   nodefs.inodesFree: 5%
 evictionPressureTransitionPeriod: 5m0s
 enableControllerAttachDetach: true
+featureGates:
+  ExperimentalCriticalPodAnnotation: true
 makeIPTablesUtilChains: true
 iptablesMasqueradeBit: 14
 iptablesDropBit: 15


### PR DESCRIPTION
Fixes: bsc#1114812
Fixes: bsc#1123650
(cherry picked from commit 7776b4b237d6bb3776a579d74e8294017b82f1a8)

Backport of https://github.com/kubic-project/salt/pull/681