### PR TITLE
3.0-backport: Add support for OIDC connectors to dex configmap (bsc#1116376)

### DIFF
--- a/salt/addons/dex/manifests/15-configmap.yaml
+++ b/salt/addons/dex/manifests/15-configmap.yaml
@@ -75,6 +75,17 @@ data:
 
           nameAttr: {{ con['group']['attr_map']['name'] | yaml_dquote }}
     {% endif %}
+    {% if con['type'] == 'oidc' %}
+    - type: oidc
+      id: {{ con['id'] | yaml_dquote }}
+      name: {{ con['name'] | yaml_dquote }}
+      config:
+        issuer: {{ con['provider_url'] | yaml_dquote }}
+        clientID: {{ con['client_id'] | yaml_dquote }}
+        clientSecret: {{ con['client_secret'] | yaml_dquote }}
+        basicAuthUnsupported: {{ 'false' if con.get('basic_auth',false) else 'true' }}
+        redirectURI: {{ con['callback_url'] | yaml_dquote }}
+    {% endif %}
     {% endfor %}
     oauth2:
       skipApprovalScreen: true


### PR DESCRIPTION
Backport OIDC support to 3.0 release.  WIP until I can get the 3.0 release to actually build, so creating the PR makes me feel like I've accomplished _something_.

(cherry picked from commit 9ef0f58a26a90eecbdb5a93425c0b94f8cc25581)