### PR TITLE
Fix etcd member addition on nodename changes

### DIFF
--- a/salt/_modules/caasp_etcd.py
+++ b/salt/_modules/caasp_etcd.py
@@ -27,7 +27,7 @@ class NoEtcdServersException(Exception):
 
 
 def api_version():
-    return __salt__['pillar.get']('etcd_version', 'etcd3')
+    return __salt__['pillar.get']('api:etcd_version', 'etcd3')
 
 
 def _optimal_etcd_number(num_nodes):

--- a/salt/_modules/caasp_etcd.py
+++ b/salt/_modules/caasp_etcd.py
@@ -507,6 +507,10 @@ def member_add(name=None, nodename=None, port=ETCD_PEER_PORT):
     '''
     this_id = name or __salt__['grains.get']('id')
     nodename_ = nodename or __salt__['caasp_net.get_nodename']()
+    aliases = __salt__['caasp_net.get_aliases'](nodename_)
+    if any([get_member_id(alias) for alias in aliases]):
+        # If this node is already registered in the cluster we pretend it was successfully added.
+        return True
     this_peer_url = 'https://{}:{}'.format(nodename_, port)
 
     __utils__['caasp_log.debug']('CaaS: adding etcd member %s', this_id)

--- a/salt/_modules/caasp_net.py
+++ b/salt/_modules/caasp_net.py
@@ -15,6 +15,34 @@ def __virtual__():
     return "caasp_net"
 
 
+def get_hosts():
+    """Wrapper around hosts.list_hosts that strips useless lines.
+
+    hosts.list_hosts includes comments as hosts - this function strips those out.
+
+    :return: Dict(ip_address -> [aliases])
+    """
+    hosts = __salt__['hosts.list_hosts']()  # type: dict
+    for key in hosts.keys():
+        if key.startswith("comment-"):
+            hosts.pop(key)
+    return hosts
+
+
+def get_aliases(hostname):
+    """Return the aliases for the given hostname
+
+    :param nodename:
+    :return: [string]
+    """
+    hosts = get_hosts()
+    for host, aliases in hosts.iteritems():
+        if hostname in aliases:
+            __utils__['caasp_log.debug']('CaaS: retrieved aliases %s for %s', aliases, hostname)
+            return aliases
+    return [hostname]
+
+
 def get_iface_ip(iface, host=None, ifaces=None):
     '''
     given an 'iface' (and an optional 'host' and list of 'ifaces'),


### PR DESCRIPTION
When the default nodename that is used by salt changes duplicates would be added to `etcd`.

This pull request checks if a given nodename might be known to the cluster by an alias.
If any of the aliases is already an `etcd` member, then no changes are performed.

This `PR` also fixes the wrong `key` used to get the current `etcd api version` from a `pillar`.