### PR TITLE
[3.0][k8s 1.10] don't run haproxy states when not really needed

### DIFF
--- a/salt/orch/update.sls
+++ b/salt/orch/update.sls
@@ -329,21 +329,6 @@ all-workers-2.0-pre-clean-shutdown:
 {%- for master_id in masters.keys() %}
       - {{ master_id }}-reboot-needed-grain
 {%- endfor %}
-
-# Sanity check. If an operator manually rebooted a machine when it had the 3.0
-# snapshot ready, we are already in 3.0 but with an unapplied haproxy config.
-# Apply the main haproxy sls to 3.0 workers (if any).
-all-workers-3.0-pre-clean-shutdown:
-  salt.state:
-    - tgt: '( {{ is_updateable_worker_tgt }} ) and G@osrelease:3.0'
-    - tgt_type: compound
-    - expect_minions: false
-    - batch: 3
-    - sls:
-        - etc-hosts
-        - haproxy
-    - require:
-        - all-workers-2.0-pre-clean-shutdown
 # END NOTE: Remove me for 4.0
 
 {%- set workers = salt.saltutil.runner('mine.get', tgt=is_updateable_worker_tgt, fun='network.interfaces', tgt_type='compound') %}
@@ -359,7 +344,7 @@ all-workers-3.0-pre-clean-shutdown:
       - migrations.2-3.kubelet.drain
       - kubelet.stop
     - require:
-      - all-workers-3.0-pre-clean-shutdown
+      - all-workers-2.0-pre-clean-shutdown
       # wait until all the masters have been updated
 {%- for master_id in masters.keys() %}
       - {{ master_id }}-reboot-needed-grain


### PR DESCRIPTION
in case of a kubernetes update from 1.9 to 1.10 we can't afford
to stop kubernetes through the haproxy states, because it will
not be able to restart as the --config file flag has changed
between those releases

the update orchestration fails in the sanity check of the state
all-workers-3.0-pre-clean-shutdown because the new kubelet
configuration is already applied, but the old kubernetes version
is still running before the reboot

This is a corner case and our other states would have to be adapted
as well to re-run configs when a node gets accidentally rebooted
and the config hasn't been applied yet.

Furthermore this is only an issue coming from v2 during migration
to v3 - so the case that this happens is even rarer.

Trying to run this state on each worker would require a check for
/etc/caasp/haproxy/haproxy.cfg to safely determine if it needs to
be run or not, but it is not possible to use salt runners with a
target to determine if this file exists on all worker nodes.

salt.runners.salt.cmd doesn't accept targets
salt.runners.salt.execute only exists since salt2017.7.0 which might
not be present yet for a user that hasn't installed the salt upgrade
yet.

bsc#1114645

Signed-off-by: Maximilian Meister <mmeister@suse.de>
(cherry picked from commit 11c82a549ea9284374507e86319a4d0c71fa6b78)