### PR TITLE
Fix bsc#1116005: Dex pods should run only on master nodes

### DIFF
--- a/salt/addons/dex/manifests/20-deployment.yaml
+++ b/salt/addons/dex/manifests/20-deployment.yaml
@@ -49,6 +49,13 @@ spec:
                   values:
                   - dex
               topologyKey: "kubernetes.io/hostname"
+      # ensure dex pods are running only on master nodes
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
 
       containers:
       - image: {{ salt.caasp_registry.base_image_url() }}/caasp-dex:2.7.1


### PR DESCRIPTION
Dex pods should run only on master nodes due to firewall/security policies that could be applied to workers nodes.