### PR TITLE
[3.0] Fix bsc#1116005: Dex pods should run only on master nodes

### DIFF
--- a/salt/addons/dex/manifests/20-deployment.yaml
+++ b/salt/addons/dex/manifests/20-deployment.yaml
@@ -49,6 +49,13 @@ spec:
                   values:
                   - dex
               topologyKey: "kubernetes.io/hostname"
+      # ensure dex pods are running only on master nodes
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
 
       containers:
       - image: sles12/caasp-dex:2.7.1


### PR DESCRIPTION
Dex pods should run only on master nodes due to firewall/security policies that could be applied to workers nodes.

(cherry picked from commit 97f9dab742bd8250b790f67e2edd454f06ca2ed0)

Backport of https://github.com/kubic-project/salt/pull/688