### PR TITLE
[3.0] Workaround bsc#1116933: remove /var/lib/container on crio installation

### DIFF
--- a/salt/_modules/caasp_cri.py
+++ b/salt/_modules/caasp_cri.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import json
 import time
+import subprocess
 from salt.exceptions import CommandExecutionError
 
 try:
@@ -40,6 +41,21 @@ def cri_name():
         return 'docker'
 
     return __salt__['pillar.get']('cri:chosen', 'docker').lower()
+
+
+def cri_version():
+    '''Return the version of the chosen platform.
+    '''
+    output = subprocess.check_output(["{0}".format(cri_name()), "--version"])
+    try:
+        version = output.split()[2]
+        if cri_name() == "docker":
+            # Docker has a comma added to the version in the default line:
+            # Docker version 17.09.1-ce, build f4ffd2511ce9
+            version = version[:-1]
+    except IndexError:
+        version = "UNKNOWN VERSION"
+    return version
 
 
 def get_container_id(name, namespace):

--- a/salt/migrations/cri/clean-up-crio-pods.sh
+++ b/salt/migrations/cri/clean-up-crio-pods.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+for c in $(runc list -q); do
+    output=$(runc state $c | grep io.kubernetes.cri-o.ContainerType)
+    if [[ "$output" =~ "container" ]]; then
+        runc delete -f $c
+    fi
+    for m in $(mount | grep $c | awk '{print $3}'); do
+        umount -R $m
+    done
+done
+
+for c in $(runc list -q); do
+    output=$(runc state $c | grep io.kubernetes.cri-o.ContainerType)
+    if [[ "$output" =~ "sandbox" ]]; then
+        runc delete -f $c
+    fi
+    for m in $(mount | grep $c | awk '{print $3}'); do
+        umount -R $m
+    done
+done
+
+# Remove the btrfs subvolumes under /var/lib/containers/storage/
+for m in $(btrfs subvolume list / | grep /var/lib/containers/storage/btrfs/subvolumes | awk '{print $9}'); do
+    # The subvolumes will have the @ prefix which we have to remove to delete them
+    btrfs subvolume delete ${m#@}
+done
+
+umount -R /var/lib/containers/storage/btrfs
+rm -rf /var/lib/containers/storage/*
+
+# We nuke the /var/lib/containers/* here as the file.absent file module will
+# fail on the read-only root folder /var/lib/containers/
+rm -rf /var/lib/containers/*

--- a/salt/migrations/cri/pre-update.sls
+++ b/salt/migrations/cri/pre-update.sls
@@ -1,0 +1,17 @@
+# This state will completely remove /var/lib/container before a reboot.
+# Otherwise a cri-o update might spin up a huge number of pause-containers,
+# that will put this node into an unusable state.
+
+# To remove the folder we have to:
+# - Delete the btrfs subvolumes
+# - Unmount the tmpfs filesystems
+# - Unmount the btrfs storage pool
+# - Remove the contents of the folder (the folder itself is readonly and can't be removed on our systems)
+
+{% if salt.caasp_cri.cri_version().startswith("1.9.") %}
+
+Cleanup crio pods:
+  cmd.script:
+    - source: salt://migrations/cri/clean-up-crio-pods.sh
+
+{% endif %}

--- a/salt/orch/update.sls
+++ b/salt/orch/update.sls
@@ -217,6 +217,14 @@ early-services-setup:
     - tgt: '{{ master_id }}'
     - sls:
       - etc-hosts.update-pre-reboot
+      # If we are running a cri-o based cluster this is a workaround for bsc#1116933
+      # cri-o would consume all CPU and spin up a huge number of pause containers, breaking
+      # the node.
+      # Using caasp_cri.cri_name will not work here, as it would run on the salt-master which
+      # will always return 'docker'.
+      {% if salt['pillar.get']('cri:chosen') == "crio" %}
+      - migrations.cri.pre-update
+      {% endif %}
       - migrations.2-3.cni.pre-reboot
       - migrations.2-3.etcd.pre-reboot
     - require:
@@ -366,6 +374,14 @@ all-workers-2.0-pre-clean-shutdown:
   salt.state:
     - tgt: '{{ worker_id }}'
     - sls:
+      # If we are running a cri-o based cluster this is a workaround for bsc#1116933
+      # cri-o would consume all CPU and spin up a huge number of pause containers, breaking
+      # the node.
+      # Using caasp_cri.cri_name will not work here, as it would run on the salt-master which
+      # will always return 'docker'.
+      {% if salt['pillar.get']('cri:chosen') == "crio" %}
+      - migrations.cri.pre-update
+      {% endif %}
       - etc-hosts.update-pre-reboot
       - migrations.2-3.cni.pre-reboot
     - require:


### PR DESCRIPTION
Backport of #693 

(cherry picked from commit 0d30835a426e7d3caa8e1b096552122b21d2d014)