### PR TITLE
[WIP] Fix 2 to 3 upgrades when draining nodes before rebooting

### DIFF
--- a/pillar/params.sls
+++ b/pillar/params.sls
@@ -78,8 +78,9 @@ addons:
 paths:
   service_account_key: '/etc/pki/sa.key'
 
-  var_kubelet:    '/var/lib/kubelet'
-  kubeconfig:     '/var/lib/kubelet/kubeconfig'
+  var_kubelet:      '/var/lib/kubelet'
+  kubeconfig:       '/var/lib/kubelet/kubeconfig'
+  kubeconfig_local: '/var/lib/kubelet/kubeconfig-local'
 
   kube_scheduler_config: '/var/lib/kubelet/kube-scheduler-config'
 

--- a/salt/kubeconfig/kubeconfig_local.jinja
+++ b/salt/kubeconfig/kubeconfig_local.jinja
@@ -1,0 +1,23 @@
+{% set api_server = "api." + pillar['internal_infra_domain']  -%}
+{% set api_ssl_port = salt['pillar.get']('api:int_ssl_port', '6444') -%}
+{% set api_server_url = 'https://' + api_server + ':' + api_ssl_port -%}
+
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority: {{ pillar['ssl']['ca_file'] }}
+    server: {{ api_server_url }}
+  name: default-cluster
+contexts:
+- context:
+    cluster: default-cluster
+    user: {{ user }}
+  name: default-system
+current-context: default-system
+kind: Config
+preferences: {}
+users:
+- name: {{ user }}
+  user:
+    client-certificate: {{ client_certificate }}
+    client-key: {{ client_key }}

--- a/salt/kubectl-config/init.sls
+++ b/salt/kubectl-config/init.sls
@@ -21,6 +21,18 @@ include:
         client_certificate: {{ pillar['ssl']['kubectl_crt'] }}
         client_key: {{ pillar['ssl']['kubectl_key'] }}
 
+{{ pillar['paths']['kubeconfig_local'] }}:
+# this kubeconfig file is used by kubectl for administrative functions
+  file.managed:
+    - source: salt://kubeconfig/kubeconfig_local.jinja
+    - template: jinja
+    - require:
+      - /etc/pki/kubectl-client-cert.crt
+    - defaults:
+        user: 'cluster-admin'
+        client_certificate: {{ pillar['ssl']['kubectl_crt'] }}
+        client_key: {{ pillar['ssl']['kubectl_key'] }}
+
 /root/.kube/config:
   # this creates a symlink that sets the default kubeconfig location
   file.symlink:

--- a/salt/migrations/2-3/kubelet/stop.sls
+++ b/salt/migrations/2-3/kubelet/stop.sls
@@ -1,0 +1,41 @@
+# Stop and disable the Kubernetes minion daemons, ensuring pods have been drained
+# and the node is marked as unschedulable.
+
+include:
+  - kubectl-config
+
+{% set should_uncordon = salt['cmd.run']("kubectl --request-timeout=1m --kubeconfig=" + pillar['paths']['kubeconfig_local'] + " get nodes " + grains['nodename'] + " -o=jsonpath='{.spec.unschedulable}' 2>/dev/null") != "true" %}
+{% set node_removal_in_progress = salt['grains.get']('node_removal_in_progress', False) %}
+
+drain-kubelet:
+  cmd.run:
+    - name: |
+        kubectl --request-timeout=1m --kubeconfig={{ pillar['paths']['kubeconfig_local'] }} drain {{ grains['nodename'] }} --force --delete-local-data=true --ignore-daemonsets --timeout={{ pillar['kubelet']['drain-timeout'] }}s
+    - require:
+      - file: {{ pillar['paths']['kubeconfig_local'] }}
+  {%- if not node_removal_in_progress %}
+  grains.present:
+    - name: kubelet:should_uncordon
+    - value: {{ should_uncordon }}
+    - force: True
+  {%- endif %}
+
+kubelet:
+  service.dead:
+    - enable: False
+    - require:
+      - cmd: drain-kubelet
+  caasp_retriable.retry:
+    - name: iptables-kubelet
+    - target: iptables.append
+    - retry:
+        attempts: 2
+    - table:     filter
+    - family:    ipv4
+    - chain:     INPUT
+    - jump:      ACCEPT
+    - match:     state
+    - connstate: NEW
+    - dports:
+      - {{ pillar['kubelet']['port'] }}
+    - proto:     tcp

--- a/salt/orch/update.sls
+++ b/salt/orch/update.sls
@@ -189,13 +189,32 @@ early-services-setup:
 
 # Kubelet needs other services, e.g. the cri, up + running. This provide a way
 # to ensure kubelet is stopped before any other services.
+#
+# This will only apply on 2.0 machines, as the drain process needs to target
+# the local apiserver in the master, instead of HAProxy.
+{{ master_id }}-early-clean-shutdown-2.0:
+  salt.state:
+    - tgt: '{{ master_id }} and G@osrelease:2.0'
+    - tgt_type: compound
+    - expect_minions: false
+    - sls:
+      - migrations.2-3.kubelet.stop
+    - require:
+      - early-services-setup
+
+# Kubelet needs other services, e.g. the cri, up + running. This provide a way
+# to ensure kubelet is stopped before any other services.
+#
+# This will apply to any non 2.0 case, the general case.
 {{ master_id }}-early-clean-shutdown:
   salt.state:
-    - tgt: '{{ master_id }}'
+    - tgt: '{{ master_id }} and not G@osrelease:2.0'
+    - tgt_type: compound
+    - expect_minions: false
     - sls:
       - kubelet.stop
     - require:
-      - early-services-setup
+      - {{ master_id }}-early-clean-shutdown-2.0
 
 {{ master_id }}-clean-shutdown:
   salt.state:


### PR DESCRIPTION
Before rebooting a 2 machine we drain it; make sure that when we send
the drain command in this case it's sent to the local apiserver running
in this machine, and only do this in the specific case in which the machine
is in the 2.0 version. Otherwise, perform the general case.

Fixes: bsc#1112744