### PR TITLE
[WIP] [3.0] Fix 2 to 3 upgrades when draining nodes before rebooting

### DIFF
--- a/pillar/params.sls
+++ b/pillar/params.sls
@@ -78,8 +78,9 @@ addons:
 paths:
   service_account_key: '/etc/pki/sa.key'
 
-  var_kubelet:    '/var/lib/kubelet'
-  kubeconfig:     '/var/lib/kubelet/kubeconfig'
+  var_kubelet:      '/var/lib/kubelet'
+  kubeconfig:       '/var/lib/kubelet/kubeconfig'
+  kubeconfig_local: '/var/lib/kubelet/kubeconfig-local'
 
   kube_scheduler_config: '/var/lib/kubelet/kube-scheduler-config'
 

--- a/salt/_modules/caasp_etcd.py
+++ b/salt/_modules/caasp_etcd.py
@@ -30,7 +30,7 @@ class NoEtcdServersException(Exception):
 
 
 def api_version():
-    return __salt__['pillar.get']('etcd_version', 'etcd2')
+    return __salt__['pillar.get']('api:etcd_version', 'etcd3')
 
 
 def _optimal_etcd_number(num_nodes):

--- a/salt/_modules/caasp_etcd.py
+++ b/salt/_modules/caasp_etcd.py
@@ -503,6 +503,10 @@ def member_add(name=None, nodename=None, port=ETCD_PEER_PORT):
     '''
     this_id = name or __salt__['grains.get']('id')
     nodename_ = nodename or __salt__['caasp_net.get_nodename']()
+    aliases = __salt__['caasp_net.get_aliases'](nodename_)
+    if any([get_member_id(alias) for alias in aliases]):
+        # If this node is already registered in the cluster we pretend it was successfully added.
+        return True
     this_peer_url = 'https://{}:{}'.format(nodename_, port)
 
     debug('CaaS: adding etcd member %s', this_id)

--- a/salt/_modules/caasp_net.py
+++ b/salt/_modules/caasp_net.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import
 
 
 # note: do not import caasp modules other than caasp_log
-from caasp_log import error
+from caasp_log import error, debug
 
 
 DEFAULT_INTERFACE = 'eth0'
@@ -17,6 +17,34 @@ NODENAME_GRAIN = 'nodename'
 
 def __virtual__():
     return "caasp_net"
+
+
+def get_hosts():
+    """Wrapper around hosts.list_hosts that strips useless lines.
+
+    hosts.list_hosts includes comments as hosts - this function strips those out.
+
+    :return: Dict(ip_address -> [aliases])
+    """
+    hosts = __salt__['hosts.list_hosts']()  # type: dict
+    for key in hosts.keys():
+        if key.startswith("comment-"):
+            hosts.pop(key)
+    return hosts
+
+
+def get_aliases(hostname):
+    """Return the aliases for the given hostname
+
+    :param nodename:
+    :return: [string]
+    """
+    hosts = get_hosts()
+    for host, aliases in hosts.iteritems():
+        if hostname in aliases:
+            debug('CaaS: retrieved aliases %s for %s', aliases, hostname)
+            return aliases
+    return [hostname]
 
 
 def get_iface_ip(iface, host=None, ifaces=None):

--- a/salt/kubeconfig/kubeconfig_local.jinja
+++ b/salt/kubeconfig/kubeconfig_local.jinja
@@ -1,0 +1,23 @@
+{% set api_server = "api." + pillar['internal_infra_domain']  -%}
+{% set api_ssl_port = salt['pillar.get']('api:int_ssl_port', '6444') -%}
+{% set api_server_url = 'https://' + api_server + ':' + api_ssl_port -%}
+
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority: {{ pillar['ssl']['ca_file'] }}
+    server: {{ api_server_url }}
+  name: default-cluster
+contexts:
+- context:
+    cluster: default-cluster
+    user: {{ user }}
+  name: default-system
+current-context: default-system
+kind: Config
+preferences: {}
+users:
+- name: {{ user }}
+  user:
+    client-certificate: {{ client_certificate }}
+    client-key: {{ client_key }}

--- a/salt/kubectl-config/init.sls
+++ b/salt/kubectl-config/init.sls
@@ -22,6 +22,18 @@ include:
         client_certificate: {{ pillar['ssl']['kubectl_crt'] }}
         client_key: {{ pillar['ssl']['kubectl_key'] }}
 
+{{ pillar['paths']['kubeconfig_local'] }}:
+# this kubeconfig file is used by kubectl for administrative functions
+  file.managed:
+    - source: salt://kubeconfig/kubeconfig_local.jinja
+    - template: jinja
+    - require:
+      - /etc/pki/kubectl-client-cert.crt
+    - defaults:
+        user: 'cluster-admin'
+        client_certificate: {{ pillar['ssl']['kubectl_crt'] }}
+        client_key: {{ pillar['ssl']['kubectl_key'] }}
+
 /root/.kube/config:
   # this creates a symlink that sets the default kubeconfig location
   file.symlink:

--- a/salt/migrations/2-3/kubelet/stop.sls
+++ b/salt/migrations/2-3/kubelet/stop.sls
@@ -1,0 +1,41 @@
+# Stop and disable the Kubernetes minion daemons, ensuring pods have been drained
+# and the node is marked as unschedulable.
+
+include:
+  - kubectl-config
+
+{% set should_uncordon = salt['cmd.run']("kubectl --request-timeout=1m --kubeconfig=" + pillar['paths']['kubeconfig_local'] + " get nodes " + grains['nodename'] + " -o=jsonpath='{.spec.unschedulable}' 2>/dev/null") != "true" %}
+{% set node_removal_in_progress = salt['grains.get']('node_removal_in_progress', False) %}
+
+drain-kubelet:
+  cmd.run:
+    - name: |
+        kubectl --request-timeout=1m --kubeconfig={{ pillar['paths']['kubeconfig_local'] }} drain {{ grains['nodename'] }} --force --delete-local-data=true --ignore-daemonsets --timeout={{ pillar['kubelet']['drain-timeout'] }}s
+    - require:
+      - file: {{ pillar['paths']['kubeconfig_local'] }}
+  {%- if not node_removal_in_progress %}
+  grains.present:
+    - name: kubelet:should_uncordon
+    - value: {{ should_uncordon }}
+    - force: True
+  {%- endif %}
+
+kubelet:
+  service.dead:
+    - enable: False
+    - require:
+      - cmd: drain-kubelet
+  caasp_retriable.retry:
+    - name: iptables-kubelet
+    - target: iptables.append
+    - retry:
+        attempts: 2
+    - table:     filter
+    - family:    ipv4
+    - chain:     INPUT
+    - jump:      ACCEPT
+    - match:     state
+    - connstate: NEW
+    - dports:
+      - {{ pillar['kubelet']['port'] }}
+    - proto:     tcp


### PR DESCRIPTION
Before rebooting a 2 machine we drain it; make sure that when we send
the drain command in this case it's sent to the local apiserver running
in this machine, and only do this in the specific case in which the machine
is in the 2.0 version. Otherwise, perform the general case.

Fixes: bsc#1112744

Backport of https://github.com/kubic-project/salt/pull/696