### PR TITLE
Add a dummy state to not have an empty state in an orchestration

### DIFF
--- a/salt/migrations/cri/pre-update.sls
+++ b/salt/migrations/cri/pre-update.sls
@@ -14,4 +14,11 @@ Cleanup crio pods:
   cmd.script:
     - source: salt://migrations/cri/clean-up-crio-pods.sh
 
+{% else %}
+
+{# See https://github.com/saltstack/salt/issues/14553 #}
+cni-cleanup-dummy:
+  cmd.run:
+    - name: "echo saltstack bug 14553"
+
 {% endif %}


### PR DESCRIPTION
This is a workaround for https://github.com/saltstack/salt/issues/14553 when
upgrading crio 1.9 to 1.10.