### PR TITLE
Minor cleanup for flake8

### DIFF
--- a/salt/_modules/caasp_etcd.py
+++ b/salt/_modules/caasp_etcd.py
@@ -475,11 +475,11 @@ def member_list():
     result = {'active': [], 'unstarted': []}
     etcdctl_output = etcdctl(["member", "list"])
     if api_version() == 'etcd2':
-        etcdctl_output_active_matcher = re.compile('([^:]+):\s+name=([^\s]+)\s+peerURLs=([^\s]+)\s+clientURLs=([^\s]+)')
-        etcdctl_output_unstarted_matcher = re.compile('([^\[]+)\[unstarted\]:\s+peerURLs=([^\s]+)')
+        etcdctl_output_active_matcher = re.compile(r'([^:]+):\s+name=([^\s]+)\s+peerURLs=([^\s]+)\s+clientURLs=([^\s]+)')
+        etcdctl_output_unstarted_matcher = re.compile(r'([^\[]+)\[unstarted\]:\s+peerURLs=([^\s]+)')
     else:
-        etcdctl_output_active_matcher = re.compile('([^,]+), started,\s+([^,]+),\s+([^,]+),\s+([^,]+)')
-        etcdctl_output_unstarted_matcher = re.compile('([^,]+), unstarted,[^,]+,([^,]+)')
+        etcdctl_output_active_matcher = re.compile(r'([^,]+), started,\s+([^,]+),\s+([^,]+),\s+([^,]+)')
+        etcdctl_output_unstarted_matcher = re.compile(r'([^,]+), unstarted,[^,]+,([^,]+)')
     for member_line in etcdctl_output.splitlines():
         matches = etcdctl_output_active_matcher.match(member_line)
         if matches:

--- a/salt/_states/caasp_hosts.py
+++ b/salt/_states/caasp_hosts.py
@@ -47,7 +47,7 @@ def managed(name,
         else:
             ret['changes'] = {}
         ret['comment'] = '{name} successfully generated'.format(**locals())
-    except Exception as e:
+    except Exception as e:  # noqa: F841
         ret['result'] = False
         ret['changes'] = {}
         ret['comment'] = '{name} was not generated successfully: {e}'.format(

--- a/tox.ini
+++ b/tox.ini
@@ -55,7 +55,7 @@ commands =
 
 [testenv:flake8]
 deps =
-    flake8==3.5.0
+    flake8==3.6.0
     flake8_formatter_junit_xml==0.0.6
 
 commands =
@@ -70,4 +70,4 @@ builtins =
     __utils__
 
 # E501: line too long (NN > 79 characters)
-ignore = E501
+extend-ignore = E501


### PR DESCRIPTION
Minor changes to fix flake8 warnings
- use raw strings in regex methods
- inline-suppress an incorrect unused variable warning
- update to flake8 version 3.6.0 (release notes: http://flake8.pycqa.org/en/latest/release-notes/3.6.0.html)
- switch flake8 config to use new extend-ignore option ("ignore" is an exclusive list, so overrides the default ignored list)