### PR TITLE
Use `jenkins-tox-container` image instead of `jenkins-tox3-container` image

### DIFF
--- a/Jenkinsfile.tests
+++ b/Jenkinsfile.tests
@@ -26,7 +26,7 @@ podTemplate(label: label, containers: [
         ),
         containerTemplate(
             name: 'tox3',
-            image: 'registry.suse.de/devel/casp/ci/opensuse_leap_42.3_containers/jenkins-tox3-container:latest',
+            image: 'registry.suse.de/devel/casp/ci/opensuse_leap_42.3_containers/jenkins-tox-container:latest',
             alwaysPullImage: true,
             ttyEnabled: true,
             command: 'cat',


### PR DESCRIPTION
Maintenance update 9039 on opensuse increased `pluggy` version to 0.6.0. This
rendered `python3-tox` unusable with that pluggy version, as the current version
in OBS requires `pluggy` (pluggy>=0.3.0,<0.4.0).

Since this is making salt pipelines fail we are including the `python3` environment
on the regular `jenkins-tox-container`.

[1] https://build.suse.de/request/show/182868