### PR TITLE
Use pillar location of the pause image for CRI-O

### DIFF
--- a/salt/crio/crio.conf.jinja
+++ b/salt/crio/crio.conf.jinja
@@ -121,7 +121,7 @@ log_size_max = -1
 default_transport = "docker://"
 
 # pause_image is the image which we use to instantiate infra containers.
-pause_image = "docker.io/sles12/pause"
+pause_image = "docker.io/{{ pillar['pod_infra_container_image'] }}"
 
 # pause_command is the command to run in a pause_image to have a container just
 # sit there.  If the image contains the necessary information, this value need


### PR DESCRIPTION
The pause image was hardcoded in the CRI-O configuration. We now use
the same pillar that defines the location of the pause image and set
it in the cri-o configuration.

Fixes: bsc#1123469