### PR TITLE
[3.0][bsc#1116049] don't fail timing out on a drain

### DIFF
--- a/salt/kubelet/stop.sls
+++ b/salt/kubelet/stop.sls
@@ -10,7 +10,12 @@ include:
 drain-kubelet:
   cmd.run:
     - name: |
+        # give some time to drain the node, if it times out continue to ensure the update will continue
+        # this can cause downtime of applications, so ideally an application is drainable within the drain-timeout
+        # bsc#1116049
         kubectl --request-timeout=1m --kubeconfig={{ pillar['paths']['kubeconfig'] }} drain {{ grains['nodename'] }} --force --delete-local-data=true --ignore-daemonsets --timeout={{ pillar['kubelet']['drain-timeout'] }}s
+    - check_cmd:
+      - /bin/true
     - require:
       - file: {{ pillar['paths']['kubeconfig'] }}
   {%- if not node_removal_in_progress %}


### PR DESCRIPTION
we want to ensure that the platform 'survives' even if an application
is not 'drainable'

it already happened that some applications are getting stuck in a
termination process and won't recover anymore. This can happen for
various reasons (volume not detachable, podDisruptionBudget ...)

as we are using the drain during every update, we are likely to run
into this issue multiple times per cluster

Signed-off-by: Maximilian Meister <mmeister@suse.de>
(cherry picked from commit 73b87c4f7bac62678a009aff73257aa4399b8d5c)

Backport of https://github.com/kubic-project/salt/pull/709