### PR TITLE
caasp_filters: properly parse IP addresses

### DIFF
--- a/salt/_modules/caasp_filters.py
+++ b/salt/_modules/caasp_filters.py
@@ -1,6 +1,12 @@
 from __future__ import absolute_import
 
-from salt._compat import ipaddress
+import socket
+
+# TODO: in Python 3 there is an ipaddress module which works out of the box. In
+# fact, Salt is using this module when running in Python 3. For Python 2 Salt
+# is using a custom implementation, which is buggy on some checks. Thus,
+# whenever we jump into Python3, we should consider using either
+# salt._compat.ipaddress, or the module from Python 3.
 
 
 def __virtual__():
@@ -11,8 +17,6 @@ def is_ip(ip):
     '''
     Returns a bool telling if the passed IP is a valid IPv4 or IPv6 address.
     '''
-    # TODO: use the builtin filter (https://docs.saltstack.com/en/latest/topics/jinja/index.html#is-ip)
-    #       once we Salt>2017.7.0
     return is_ipv4(ip) or is_ipv6(ip)
 
 
@@ -20,11 +24,10 @@ def is_ipv4(ip):
     '''
     Returns a bool telling if the value passed to it was a valid IPv4 address
     '''
-    # TODO: use the builtin filter (https://docs.saltstack.com/en/latest/topics/jinja/index.html#is-ipv4)
-    #       once we Salt>2017.7.0
     try:
-        return ipaddress.ip_address(ip).version == 4
-    except ValueError:
+        socket.inet_pton(socket.AF_INET, ip)
+        return True
+    except socket.error:
         return False
 
 
@@ -32,15 +35,15 @@ def is_ipv6(ip):
     '''
     Returns a bool telling if the value passed to it was a valid IPv6 address
     '''
-    # TODO: use the builtin filter (https://docs.saltstack.com/en/latest/topics/jinja/index.html#is-ipv6)
-    #       once we Salt>2017.7.0
     try:
-        return ipaddress.ip_address(ip).version == 6
-    except ValueError:
+        socket.inet_pton(socket.AF_INET6, ip)
+        return True
+    except socket.error:
         return False
 
 
 def get_max(seq):
-    # TODO: use the builtin filter (https://docs.saltstack.com/en/latest/topics/jinja/index.html#max)
+    # TODO: use the builtin filter
+    # (https://docs.saltstack.com/en/latest/topics/jinja/index.html#max)
     #       once we Salt>2017.7.0
     return max(seq)

--- a/salt/_modules/tests/test_caasp_filters.py
+++ b/salt/_modules/tests/test_caasp_filters.py
@@ -1,0 +1,45 @@
+from __future__ import absolute_import
+
+import unittest
+
+import caasp_filters
+
+
+class TestIsIP(unittest.TestCase):
+    def test_is_ipv4(self):
+        # Valid IPv4 addresses.
+        self.assertTrue(caasp_filters.is_ipv4("127.0.0.1"))
+        self.assertTrue(caasp_filters.is_ipv4("192.168.23.1"))
+        self.assertTrue(caasp_filters.is_ipv4("192.168.23.255"))
+        self.assertTrue(caasp_filters.is_ipv4("255.255.255.255"))
+        self.assertTrue(caasp_filters.is_ipv4("0.0.0.0"))
+
+        # Invalid IPv4 addresses.
+        self.assertFalse(caasp_filters.is_ipv4("30.168.1.255.1"))
+        self.assertFalse(caasp_filters.is_ipv4("127.1"))
+        self.assertFalse(caasp_filters.is_ipv4("-1.0.2.3"))
+        self.assertFalse(caasp_filters.is_ipv4("3...3"))
+        self.assertFalse(caasp_filters.is_ipv4("whatever"))
+
+        # see bsc#1123291
+        self.assertFalse(caasp_filters.is_ipv4("master85.test.net"))
+
+    def test_is_ipv6(self):
+        self.assertTrue(
+            caasp_filters.is_ipv6("1111:2222:3333:4444:5555:6666:7777:8888")
+        )
+        self.assertTrue(
+            caasp_filters.is_ipv6("1111:2222:3333:4444:5555:6666:7777::")
+        )
+        self.assertTrue(caasp_filters.is_ipv6("::"))
+        self.assertTrue(caasp_filters.is_ipv6("::8888"))
+
+        self.assertFalse(
+            caasp_filters.is_ipv6("11112222:3333:4444:5555:6666:7777:8888")
+        )
+        self.assertFalse(caasp_filters.is_ipv6("1111:"))
+        self.assertFalse(caasp_filters.is_ipv6("::."))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
As it appears, for Python 2 Salt is using a custom module for providing the
ipaddress from Python 3. This implementation turned out to have
bugs (e.g. accepting something70.domain.net as a valid IPv4 record). I've
re-implemented the is_ip* functions so they are using socket.inet_pton instead,
which should suffice in our use case.

bsc#1123291