### PR TITLE
User cert support

### DIFF
--- a/config/master.d/50-master.conf
+++ b/config/master.d/50-master.conf
@@ -44,7 +44,8 @@ module_dirs:
 ext_pillar:
   - velum:
       url: https://localhost:444/internal-api/v1/pillar.json
-      ca_bundle: /etc/pki/ca.crt
+      # use default system CA bundle file
+      # ca_bundle: /var/lib/ca-certificates/ca-bundle.pem
 
 # External Authentication Mechanisms
 external_auth:

--- a/pillar/certificates.sls
+++ b/pillar/certificates.sls
@@ -21,6 +21,8 @@ ssl:
   crt_file: '/etc/pki/minion.crt'
   key_file: '/etc/pki/minion.key'
 
+  sys_ca_bundle: '/var/lib/ca-certificates/ca-bundle.pem'
+
   crt_dir: '/etc/pki'
   key_dir: '/etc/pki'
 
@@ -49,6 +51,11 @@ ssl:
   kube_apiserver_proxy_key: '/etc/pki/private/kube-apiserver-proxy.key'
   kube_apiserver_proxy_crt: '/etc/pki/kube-apiserver-proxy.crt'
   kube_apiserver_proxy_bundle: '/etc/pki/private/kube-apiserver-proxy-bundle.pem'
+
+  # haproxy client auth to API server
+  kube_apiserver_haproxy_key: '/etc/pki/private/kube-apiserver-haproxy.key'
+  kube_apiserver_haproxy_crt: '/etc/pki/kube-apiserver-haproxy.crt'
+  kube_apiserver_haproxy_bundle: '/etc/pki/private/kube-apiserver-haproxy-bundle.pem'
 
   kube_scheduler_key: '/etc/pki/kube-scheduler.key'
   kube_scheduler_crt: '/etc/pki/kube-scheduler.crt'

--- a/salt/_macros/certs.jinja
+++ b/salt/_macros/certs.jinja
@@ -41,7 +41,7 @@
 
 #####################################################################
 
-{% macro certs(name, crt, key, cn='', o='', extra_alt_names=None) -%}
+{% macro certs(name, crt, key, cn='', o='', extra_alt_names=None, bundle=False) -%}
 
 {%- if extra_alt_names == None -%}
   {#- calculate automatically the altNames depending on the role -#}
@@ -77,7 +77,7 @@
     - Email: {{ pillar['certificate_information']['subject_properties']['Email']|yaml_dquote }}
     - GN: {{ pillar['certificate_information']['subject_properties']['GN']|yaml_dquote }}
     - L: {{ pillar['certificate_information']['subject_properties']['L']|yaml_dquote }}
-    {# "system:{{ name }}" is a kubernetes specific role identifying a {{ name }} in th system #}
+    {# "system:{{ name }}" is a kubernetes specific role identifying a {{ name }} in the system #}
   {%- if o %}
     - O: {{ o|yaml_dquote }}
   {%- else -%}
@@ -103,9 +103,13 @@
       - sls: crypto
       - x509: {{ key }}
 
-{{ crt }}-bundle:
+{{ bundle or crt + '-bundle' }}:
   file.managed:
+{% if bundle %}
+    - name: {{ bundle }}
+{% else %}
     - name: /etc/pki/private/{{ name }}-bundle.pem
+{% endif %}
     - source: salt://cert/cert-bundle.jinja
     - template: jinja
     - user: root
@@ -120,3 +124,38 @@
         - x509: {{ key }}
 
 {%- endmacro %}
+
+# externally-sourced certs; content in a pillar
+{% macro external_pillar_certs(crt, crt_pillar, key, key_pillar, bundle=False) -%}
+{{ crt }}:
+  file.managed:
+    - user:  root
+    - group: root
+    - mode: 0644
+    - contents_pillar: {{ crt_pillar }}
+
+{{ key }}:
+  file.managed:
+    - user:  root
+    - group: root
+    - mode: 0444
+    - contents_pillar: {{ key_pillar }}
+
+{% if bundle %}
+# TODO: move this out to a macro so it's not repeated in here?
+{{ bundle }}:
+  file.managed:
+    - source: salt://cert/cert-bundle.jinja
+    - template: jinja
+    - user: root
+    - group: root
+    - mode: 600
+    - makedirs: True
+    - context:
+        certificate: {{ crt }}
+        key:         {{ key }}
+    - require: # always verify -- in case this file was deleted/altered
+        - file: {{ crt }}
+        - file: {{ key }}
+{% endif %}
+{% endmacro %}

--- a/salt/addons/dex/init.sls
+++ b/salt/addons/dex/init.sls
@@ -3,8 +3,23 @@ include:
   - kubectl-config
   - kube-apiserver
 
+{% if salt.caasp_pillar.get('external_cert:dex:cert', False)
+  and salt.caasp_pillar.get('external_cert:dex:key',  False)
+%}
+
+{% from '_macros/certs.jinja' import external_pillar_certs with context %}
+
+{{ external_pillar_certs(
+      pillar['ssl']['dex_crt'],
+      'external_cert:dex:cert',
+      pillar['ssl']['dex_key'],
+      'external_cert:dex:key',
+      False
+) }}
+
+{% else %}
+
 {% from '_macros/certs.jinja' import alt_master_names, certs with context %}
-{% from '_macros/kubectl.jinja' import kubectl, kubectl_apply_dir_template with context %}
 
 {% set dex_alt_names = ["dex",
                         "dex.kube-system",
@@ -15,6 +30,10 @@ include:
          pillar['ssl']['dex_key'],
          cn = 'Dex',
          extra_alt_names = alt_master_names(dex_alt_names)) }}
+
+{% endif %}
+
+{% from '_macros/kubectl.jinja' import kubectl, kubectl_apply_dir_template with context %}
 
 # The following files need to be explicitly copied over *before*
 # kubectl_apply_dir_templates runs. Otherwise one of the templates attempts to

--- a/salt/addons/dex/wait.sls
+++ b/salt/addons/dex/wait.sls
@@ -6,7 +6,7 @@ ensure-dex-running:
     {% set dex_api_port = pillar['dex']['node_port'] -%}
     - name:       {{ 'https://' + dex_api_server + ':' + dex_api_port }}/.well-known/openid-configuration
     - wait_for:   300
-    - ca_bundle:  {{ pillar['ssl']['ca_file'] }}
+    - ca_bundle:  {{ pillar['ssl']['sys_ca_bundle'] }}
     - status:     200
     - opts:
         http_request_timeout: 30

--- a/salt/haproxy/haproxy.cfg.jinja
+++ b/salt/haproxy/haproxy.cfg.jinja
@@ -50,7 +50,7 @@ backend default-backend
         option forwardfor
         option httpchk GET /healthz
 {% for id, nodename in masters.items() %}
-        server master-{{ nodename }} {{ nodename }}.{{ pillar['internal_infra_domain'] }}:{{ pillar['api']['int_ssl_port'] }} ssl crt {{ pillar['ssl']['kube_apiserver_proxy_bundle'] }} ca-file /etc/pki/ca.crt check check-ssl port {{ pillar['api']['int_ssl_port'] }} verify required
+        server master-{{ nodename }} {{ nodename }}.{{ pillar['internal_infra_domain'] }}:{{ pillar['api']['int_ssl_port'] }} ssl crt {{ pillar['ssl']['kube_apiserver_haproxy_bundle'] }} ca-file {{ pillar['ssl']['sys_ca_bundle'] }} check check-ssl port {{ pillar['api']['int_ssl_port'] }} verify required
 {%- endfor %}
 
 backend no-timeout-backend
@@ -61,7 +61,7 @@ backend no-timeout-backend
         timeout server 0
         timeout tunnel 0
 {% for id, nodename in masters.items() %}
-        server master-{{ nodename }} {{ nodename }}.{{ pillar['internal_infra_domain'] }}:{{ pillar['api']['int_ssl_port'] }} ssl crt {{ pillar['ssl']['kube_apiserver_proxy_bundle'] }} ca-file /etc/pki/ca.crt check check-ssl port {{ pillar['api']['int_ssl_port'] }} verify required
+        server master-{{ nodename }} {{ nodename }}.{{ pillar['internal_infra_domain'] }}:{{ pillar['api']['int_ssl_port'] }} ssl crt {{ pillar['ssl']['kube_apiserver_haproxy_bundle'] }} ca-file {{ pillar['ssl']['sys_ca_bundle'] }} check check-ssl port {{ pillar['api']['int_ssl_port'] }} verify required
 {%- endfor %}
 
 

--- a/salt/haproxy/haproxy.yaml.jinja
+++ b/salt/haproxy/haproxy.yaml.jinja
@@ -31,8 +31,14 @@ spec:
         - name: ca-certificate
           mountPath: /etc/pki/ca.crt
           readOnly: True
+        - mountPath: {{ salt['file.dirname']( pillar['ssl']['sys_ca_bundle'] ) }}
+          name: ca-bundle-dir
+          readOnly: True
         - name: kubernetes-proxy-bundle-certificate
           mountPath: {{ pillar['ssl']['kube_apiserver_proxy_bundle'] }}
+          readOnly: True
+        - name: kubernetes-apiserver-haproxy-client-bundle
+          mountPath: {{ pillar['ssl']['kube_apiserver_haproxy_bundle'] }}
           readOnly: True
 {% if "admin" in salt['grains.get']('roles', []) %}
         - name: etc-hosts
@@ -55,10 +61,17 @@ spec:
         path: {{ pillar['ssl']['ca_file'] }}
 {% endif %}
         type: FileOrCreate
+    - name: ca-bundle-dir
+      hostPath:
+        path: {{ salt['file.dirname']( pillar['ssl']['sys_ca_bundle'] ) }}
     - name: kubernetes-proxy-bundle-certificate
       hostPath:
         path: {{ pillar['ssl']['kube_apiserver_proxy_bundle'] }}
         type: FileOrCreate
+    - name: kubernetes-apiserver-haproxy-client-bundle
+      hostPath:
+        path: {{ pillar['ssl']['kube_apiserver_haproxy_bundle'] }}
+        type: File
 {% if "admin" in salt['grains.get']('roles', []) %}
     - name: etc-hosts
       hostPath:

--- a/salt/kube-apiserver/init.sls
+++ b/salt/kube-apiserver/init.sls
@@ -12,14 +12,12 @@ include:
          cn = grains['nodename'],
          o = pillar['certificate_information']['subject_properties']['O']) }}
 
-{% from '_macros/certs.jinja' import certs with context %}
 {{ certs("kube-apiserver-proxy-client",
          pillar['ssl']['kube_apiserver_proxy_client_crt'],
          pillar['ssl']['kube_apiserver_proxy_client_key'],
          cn = grains['nodename'],
          o = pillar['certificate_information']['subject_properties']['O']) }}
 
-{% from '_macros/certs.jinja' import certs with context %}
 {{ certs("kube-apiserver-kubelet-client",
          pillar['ssl']['kube_apiserver_kubelet_client_crt'],
          pillar['ssl']['kube_apiserver_kubelet_client_key'],
@@ -135,7 +133,7 @@ kube-apiserver-wait-port-{{ port }}:
     # retry just in case the API server returns a transient error
     - retry:
         attempts: 3
-    - ca_bundle:  {{ pillar['ssl']['ca_file'] }}
+    - ca_bundle:  {{ pillar['ssl']['sys_ca_bundle'] }}
     - status:     200
     - opts:
         http_request_timeout: 30

--- a/salt/kube-apiserver/remove-pre-orchestration.sls
+++ b/salt/kube-apiserver/remove-pre-orchestration.sls
@@ -19,7 +19,7 @@ check-kube-apiserver-wait-port-{{ port }}:
     # retry just in case the API server returns a transient error
     - retry:
         attempts: 3
-    - ca_bundle:  {{ pillar['ssl']['ca_file'] }}
+    - ca_bundle:  {{ pillar['ssl']['sys_ca_bundle'] }}
     - status:     200
     - opts:
         http_request_timeout: 30

--- a/salt/kubeconfig/kubeconfig.jinja
+++ b/salt/kubeconfig/kubeconfig.jinja
@@ -5,7 +5,7 @@
 apiVersion: v1
 clusters:
 - cluster:
-    certificate-authority: {{ pillar['ssl']['ca_file'] }}
+    certificate-authority: {{ pillar['ssl']['sys_ca_bundle'] }}
     server: {{ api_server_url }}
   name: default-cluster
 contexts:

--- a/salt/orch/refresh-certs.sls
+++ b/salt/orch/refresh-certs.sls
@@ -1,0 +1,74 @@
+{%- set updates_all_target = 'P@roles:(admin|etcd|kube-(master|minion)) and ' +
+                             'not G@update_in_progress:true and ' +
+                             'not G@removal_in_progress:true and ' +
+                             'not G@force_removal_in_progress:true' %}
+
+{%- if salt.saltutil.runner('mine.get', tgt=updates_all_target, fun='nodename', tgt_type='compound')|length > 0 %}
+################################################################################
+# refresh salt data
+update_pillar:
+  salt.function:
+    - tgt: {{ updates_all_target }}
+    - tgt_type: compound
+    - name: saltutil.refresh_pillar
+
+update_grains:
+  salt.function:
+    - tgt: {{ updates_all_target }}
+    - tgt_type: compound
+    - name: saltutil.refresh_grains
+
+update_mine:
+  salt.function:
+    - tgt: {{ updates_all_target }}
+    - tgt_type: compound
+    - name: mine.update
+    - require:
+      - salt: update_pillar
+      - salt: update_grains
+
+################################################################################
+# update the CA list
+update_ca_list:
+  salt.state:
+    # all impacted machines
+    - tgt: {{ updates_all_target }}
+    - tgt_type: compound
+    - kwarg:
+        queue: True
+    - sls:
+      - cert
+    - require:
+      - salt: update_mine
+
+################################################################################
+# run the states managing systems where external certs are used
+
+# Velum (and kubeAPI, since it's just haproxy)
+update_certs_velum:
+  salt.state:
+    # admin only
+    - tgt: {{ updates_all_target + ' and P@roles:(admin)' }}
+    - tgt_type: compound
+    - kwarg:
+        queue: True
+    - sls:
+      - velum    # check cert
+      - haproxy  # reload haproxy on change
+    - require:
+      - salt: update_ca_list
+
+# Dex is special 
+update_certs_dex:
+  salt.state:
+    # TODO: is there a target definition for where Dex should be? Yes, the "super master"
+    - tgt: {{ updates_all_target + ' and P@roles:(kube-(master|minion))' }}
+    - tgt_type: compound
+    - kwarg:
+        queue: True
+    - sls:
+      - addons.dex
+    - require:
+      - salt: update_ca_list
+
+{% endif %}

--- a/salt/velum/init.sls
+++ b/salt/velum/init.sls
@@ -1,5 +1,23 @@
 include:
   - etc-hosts
+  - crypto
+
+{% if salt.caasp_pillar.get('external_cert:velum:cert', False)
+  and salt.caasp_pillar.get('external_cert:velum:key',  False)
+%}
+
+{% from '_macros/certs.jinja' import external_pillar_certs with context %}
+
+{{ external_pillar_certs(
+      pillar['ssl']['velum_crt'],
+      'external_cert:velum:cert',
+      pillar['ssl']['velum_key'],
+      'external_cert:velum:key',
+      bundle=pillar['ssl']['velum_bundle']
+
+) }}
+
+{% else %}
 
 {% set names = [salt.caasp_pillar.get('dashboard_external_fqdn'),
                 salt.caasp_pillar.get('dashboard')] %}
@@ -9,4 +27,7 @@ include:
          pillar['ssl']['velum_crt'],
          pillar['ssl']['velum_key'],
          cn = grains['nodename'],
-         extra_alt_names = alt_names(names)) }}
+         extra_alt_names = alt_names(names),
+         bundle=pillar['ssl']['velum_bundle']) }}
+
+{% endif %}


### PR DESCRIPTION
All the salt backend changes to make Velum, Dex, and kube-API (the external-facing services) support user-provided Certs (and their corresponding CA).

There is a related PR in kubic-project/caasp-container-manifests#213 which is necessary for this to work properly.

Marked work-in-progress since it's still not completely verified as working.