### PR TITLE
bsc#1117942: fixes for volume plugins

### DIFF
--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -10,6 +10,7 @@ base:
     - docker
     - registries
     - schedule
+    - volume
   'roles:ca':
     - match: grain
     - ca

--- a/pillar/volume.sls
+++ b/pillar/volume.sls
@@ -1,0 +1,5 @@
+
+volume:
+  dirs:
+    bin: '/var/lib/kubelet/plugins'
+

--- a/salt/kube-controller-manager/controller-manager.jinja
+++ b/salt/kube-controller-manager/controller-manager.jinja
@@ -18,10 +18,13 @@ KUBE_CONTROLLER_MANAGER_ARGS="\
     --allocate-node-cidrs=true \
     --node-cidr-mask-size={{ pillar['cluster_cidr_len'] }} \
     --root-ca-file={{ pillar['ssl']['ca_file'] }} \
+{% if pillar['volume']['dirs']['bin'] -%}
+    --flex-volume-plugin-dir={{ pillar['volume']['dirs']['bin'] }} \
+{% endif -%}
 {% if cloud_provider -%}
-               --cloud-provider={{ cloud_provider }} \
+    --cloud-provider={{ cloud_provider }} \
   {% if cloud_provider == 'openstack' -%}
-               --cloud-config=/etc/kubernetes/openstack-config \
+    --cloud-config=/etc/kubernetes/openstack-config \
   {% endif -%}
 {% endif -%}
     {{ managr_args }}"

--- a/salt/kubelet/init.sls
+++ b/salt/kubelet/init.sls
@@ -52,6 +52,13 @@ kubeconfig:
     - dir_mode: 755
     - makedirs: True
 
+{{ pillar['volume']['dirs']['bin'] }}:
+  file.directory:
+    - user:     root
+    - group:    root
+    - dir_mode: 755
+    - makedirs: True
+
 kubelet-config:
   file.managed:
     - name:     /etc/kubernetes/kubelet-config.yaml
@@ -79,6 +86,7 @@ kubelet:
 {% endif %}
       - file:   {{ pillar['cni']['dirs']['bin'] }}
       - file:   {{ pillar['cni']['dirs']['conf'] }}
+      - file:   {{ pillar['volume']['dirs']['bin'] }}
     - require:
       - file:   /etc/kubernetes/manifests
       - file:   /etc/kubernetes/kubelet-initial

--- a/salt/kubelet/kubelet.jinja
+++ b/salt/kubelet/kubelet.jinja
@@ -52,4 +52,7 @@ KUBELET_ARGS="\
     --cni-bin-dir={{ pillar['cni']['dirs']['bin'] }} \
     --cni-conf-dir={{ pillar['cni']['dirs']['conf'] }} \
     --kubeconfig={{ pillar['paths']['kubelet_config'] }} \
-    --volume-plugin-dir=/usr/lib/kubernetes/kubelet-plugins"
+{%- if pillar['volume']['dirs']['bin'] %}
+    --volume-plugin-dir={{ pillar['volume']['dirs']['bin'] }} \
+{%- endif %}
+    "


### PR DESCRIPTION
* Use a writable directory for volume plugins
* Use the same volumes plugins directory for the `controller-manager` and the `kubelet`

bsc#1117942