### PR TITLE
Jenkinsfile: Use docker cmdline directly instead of k8s Jenkins plugin

### DIFF
--- a/Jenkinsfile.flake8
+++ b/Jenkinsfile.flake8
@@ -10,32 +10,17 @@ githubCollaboratorCheck(
     user: env.CHANGE_AUTHOR,
     credentialsId: 'github-token')
 
-def label = "salt-flake8-${UUID.randomUUID().toString()}"
+node("leap15.0&&caasp-pr-worker") {
+    stage('Retrieve Code') {
+        checkout scm
+    }
 
-podTemplate(label: label, containers: [
-        containerTemplate(
-            name: 'tox',
-            image: 'registry.suse.de/devel/casp/ci/opensuse_leap_42.3_containers/jenkins-tox-container:latest',
-            ttyEnabled: true,
-            command: 'cat',
-            envVars: [
-                envVar(key: 'http_proxy', value: env.http_proxy),
-                envVar(key: 'https_proxy', value: env.http_proxy),
-            ],
-        ),
-]) {
-    node(label) {
-        stage('Retrieve Code') {
-            checkout scm
-        }
-
+    docker.image('registry.suse.de/devel/casp/ci/opensuse_leap_42.3_containers/jenkins-tox-container:latest').inside('-v ${WORKSPACE}:/salt') {
         stage('Style Checks') {
-            container('tox') {
-                try {
-                    sh 'tox -e flake8 -- --format=junit-xml --output-file junit.xml'
-                } finally {
-                    junit "junit.xml"
-                }
+            try {
+                sh(script: 'tox -e flake8 -- --format=junit-xml --output-file junit.xml')
+            } finally {
+                junit "junit.xml"
             }
         }
     }

--- a/Jenkinsfile.tests
+++ b/Jenkinsfile.tests
@@ -1,43 +1,28 @@
-def label = "salt-tests-${UUID.randomUUID().toString()}"
+def targetBranch = env.getEnvironment().get('CHANGE_TARGET', env.BRANCH_NAME)
 
-podTemplate(label: label, containers: [
-        containerTemplate(
-            name: 'tox',
-            image: 'registry.suse.de/devel/casp/ci/opensuse_leap_42.3_containers/jenkins-tox-container:latest',
-            ttyEnabled: true,
-            command: 'cat',
-            envVars: [
-                envVar(key: 'http_proxy', value: env.http_proxy),
-                envVar(key: 'https_proxy', value: env.http_proxy),
-            ],
-        ),
-        containerTemplate(
-            name: 'tox3',
-            image: 'registry.suse.de/devel/casp/ci/opensuse_leap_42.3_containers/jenkins-tox3-container:latest',
-            ttyEnabled: true,
-            command: 'cat',
-            envVars: [
-                envVar(key: 'http_proxy', value: env.http_proxy),
-                envVar(key: 'https_proxy', value: env.http_proxy),
-            ],
-        ),
-]) {
-    node(label) {
-        stage('Retrieve Code') {
-            checkout scm
-        }
+library "kubic-jenkins-library@${targetBranch}"
 
+// TODO: Don't hardcode salt repo name, find the right place
+// to lookup this information dynamically.
+githubCollaboratorCheck(
+    org: 'kubic-project',
+    repo: 'salt',
+    user: env.CHANGE_AUTHOR,
+    credentialsId: 'github-token')
+
+node("leap15.0&&caasp-pr-worker") {
+    stage('Retrieve Code') {
+        checkout scm
+    }
+
+    docker.image('registry.suse.de/devel/casp/ci/opensuse_leap_42.3_containers/jenkins-tox-container:latest').inside('-v ${WORKSPACE}:/salt') {
         stage('Create Test Virtualenv') {
             parallel(
                 'Python 2.7': {
-                    container('tox') {
-                        sh 'tox --notest -e tests-salt-2016.11.4-py27'
-                    }
+                    sh(script: 'tox --notest -e tests-salt-2018.3.0-py27')
                 },
                 'Python 3.4': {
-                    container('tox3') {
-                        sh 'tox --notest -e tests-salt-2016.11.4-py34'
-                    }
+                    sh(script: 'tox --notest -e tests-salt-2018.3.0-py34')
                 }
             )
         }
@@ -45,21 +30,17 @@ podTemplate(label: label, containers: [
         stage('Run Tests') {
             parallel(
                 'Python 2.7': {
-                    container('tox') {
-                        try {
-                            sh 'tox -e tests-salt-2016.11.4-py27 -- --with-xunit --xunit-testsuite-name=salt-2016.11.4-py27 --xunit-file=tests-salt-2016.11.4-py27.xml'
-                        } finally {
-                            junit "tests-salt-2016.11.4-py27.xml"
-                        }
+                    try {
+                        sh(script: 'tox -e tests-salt-2018.3.0-py27 -- --with-xunit --xunit-testsuite-name=salt-2018.3.0-py27 --xunit-file=tests-salt-2018.3.0-py27.xml')
+                    } finally {
+                        junit "tests-salt-2018.3.0-py27.xml"
                     }
                 },
                 'Python 3.4': {
-                    container('tox3') {
-                        try {
-                            sh 'tox -e tests-salt-2016.11.4-py34 -- --with-xunit --xunit-testsuite-name=salt-2016.11.4-py34 --xunit-file=tests-salt-2016.11.4-py34.xml'
-                        } finally {
-                            junit "tests-salt-2016.11.4-py34.xml"
-                        }
+                    try {
+                        sh(script: 'tox -e tests-salt-2018.3.0-py34 -- --with-xunit --xunit-testsuite-name=salt-2018.3.0-py34 --xunit-file=tests-salt-2018.3.0-py34.xml')
+                    } finally {
+                        junit "tests-salt-2018.3.0-py34.xml"
                     }
                 }
             )


### PR DESCRIPTION
The tox and flake8 pipelines are the only ones which depend on the k8s
Jenkins plugin. As such, we can use docker directly in order to be able
to drop the plugin from the server. The nodelabel is hardcoded because it
does not make much sense to make this configurable given everything happens
on a container.

(cherry picked from commit 8443e0d863790cb98ba09fd5e79e1df28dd9d1e5)

Backport of https://github.com/kubic-project/salt/pull/722