### PR TITLE
[bsc#1125095] deployment timeout not correctly configured

### DIFF
--- a/salt/_macros/kubectl.jinja
+++ b/salt/_macros/kubectl.jinja
@@ -96,6 +96,7 @@ wait-for-{{ deployment }}-deployment:
         availableReplicas=$(kubectl --request-timeout=1m --kubeconfig={{ pillar['paths']['kubeconfig'] }} get deployment {{ deployment }} --namespace={{ namespace }} --template {{ '{{.status.availableReplicas}}' }})
         updatedReplicas=$(kubectl --request-timeout=1m --kubeconfig={{ pillar['paths']['kubeconfig'] }} get deployment {{ deployment }} --namespace={{ namespace }} --template {{ '{{.status.updatedReplicas}}' }})
         [ "$readyReplicas" == "$desiredReplicas" ] && [ "$availableReplicas" == "$desiredReplicas" ] && [ "$updatedReplicas" == "$desiredReplicas" ]
+    - timeout: {{ timeout }}
     - retry:
         attempts: {{ timeout }}
         interval: 1


### PR DESCRIPTION
instead of setting the timeout we were setting the retries which
causes the timeout to be prolonged too much

Signed-off-by: Maximilian Meister <mmeister@suse.de>