### PR TITLE
Sort nodenames first when generating /etc/hosts entries

### DIFF
--- a/salt/_modules/caasp_hosts.py
+++ b/salt/_modules/caasp_hosts.py
@@ -68,10 +68,22 @@ def __virtual__():
     return "caasp_hosts"
 
 
-def _concat(lst1, lst2):
+# returns a list resulting of appending `lst2` to `lst1`, removing duplicates on
+# both lists (not preserving order on any of them) and removing empty elements on
+# the result. The result will be sorted as well
+def _sorted_append(lst1, lst2):
     res = list(set(lst1) | set(lst2))  # join both lists (without dups)
     res = [x for x in res if x]  # remove empty strings
     res.sort()  # sort the result (for determinism)
+    return res
+
+
+# returns a list resulting of prepending `lst2` to `lst1`, not removing
+# duplicates on any of both lists (preserving order on both of them) and
+# removing empty elements on the result
+def _unsorted_prepend(lst1, lst2):
+    res = lst2 + lst1  # unsorted prepend of lst2 in lst1
+    res = [x for x in res if x]  # remove empty strings
     return res
 
 
@@ -141,7 +153,7 @@ def _load_hosts_file(hosts, filename, marker_start=None, marker_end=None):
 
 # add a (list of) name(s) to a (maybe existing) IP
 # it will remove duplicates, sort names, etc...
-def _add_names(hosts, ips, names):
+def _add_names(hosts, ips, names, insert_fun=_sorted_append):
     if not isinstance(names, list):
         names = [names]
     if not isinstance(ips, list):
@@ -150,20 +162,25 @@ def _add_names(hosts, ips, names):
     for ip in ips:
         __utils__['caasp_log.debug']('hosts: adding %s -> %s', ip, names)
         if ip not in hosts:
-            hosts[ip] = _concat([], names)
+            hosts[ip] = insert_fun([], names)
         else:
-            hosts[ip] = _concat(hosts[ip], names)
+            hosts[ip] = insert_fun(hosts[ip], names)
 
 
-def _add_names_for(hosts, nodes_dict, infra_domain):
+def _add_names_for(hosts, nodes_dict, infra_domain, insert_fun=_sorted_append):
     for id, ifaces in nodes_dict.items():
         ip = __salt__['caasp_net.get_primary_ip'](host=id, ifaces=ifaces)
         if ip:
-            _add_names(hosts, ip, [id, id + '.' + infra_domain])
+            _add_names(hosts, ip, [id, id + '.' + infra_domain], insert_fun)
 
+
+def _add_nodenames_for(hosts, nodes_dict, infra_domain):
+    for id, ifaces in nodes_dict.items():
+        ip = __salt__['caasp_net.get_primary_ip'](host=id, ifaces=ifaces)
+        if ip:
             nodename = __salt__['caasp_net.get_nodename'](host=id)
             if nodename:
-                _add_names(hosts, ip, [nodename, nodename + '.' + infra_domain])
+                _add_names(hosts, ip, [nodename, nodename + '.' + infra_domain], _unsorted_prepend)
 
 
 # note regarding node removals:
@@ -271,12 +288,15 @@ def managed(name=HOSTS_FILE,
     def get_with_expr(expr):
         return __salt__['caasp_nodes.get_with_expr'](expr, grain='network.interfaces')
 
+    admin_nodes = admin_nodes or get_with_expr(ADMIN_EXPR)
+    master_nodes = master_nodes or get_with_expr(MASTER_EXPR)
+    worker_nodes = worker_nodes or get_with_expr(WORKER_EXPR)
+    other_nodes = other_nodes or get_with_expr(OTHER_EXPR)
+
     # add all the entries
     try:
-        _add_names_for(hosts, admin_nodes or get_with_expr(ADMIN_EXPR), infra_domain)
-        _add_names_for(hosts, master_nodes or get_with_expr(MASTER_EXPR), infra_domain)
-        _add_names_for(hosts, worker_nodes or get_with_expr(WORKER_EXPR), infra_domain)
-        _add_names_for(hosts, other_nodes or get_with_expr(OTHER_EXPR), infra_domain)
+        for nodes in [admin_nodes, master_nodes, worker_nodes, other_nodes]:
+            _add_names_for(hosts, nodes, infra_domain)
     except Exception as e:
         raise EtcHostsRuntimeException(
             'Could not add entries for roles in /etc/hosts: {}'.format(e))
@@ -308,19 +328,30 @@ def managed(name=HOSTS_FILE,
         raise EtcHostsRuntimeException(
             'Could not add special entries in /etc/hosts: {}'.format(e))
 
+    # sort the names for determinism
+    for ip, names in hosts.items():
+        names.sort()
+
+    # prepend the nodenames at the beginning of each entry
+    try:
+        for nodes in [admin_nodes, master_nodes, worker_nodes, other_nodes]:
+            _add_nodenames_for(hosts, nodes, infra_domain)
+    except Exception as e:
+        raise EtcHostsRuntimeException(
+            'Could not add nodenames entries in /etc/hosts: {}'.format(e))
+
     # (over)write the /etc/hosts
     try:
         preface = PREFACE.format(file=caasp_hosts_file).splitlines()
         new_etc_hosts_contents = []
         for ip, names in hosts.items():
-            names.sort()
             line = '{0}        {1}'.format(ip, ' '.join(names))
             new_etc_hosts_contents.append(line.strip().replace('\n', ''))
 
         new_etc_hosts_contents.sort()
         new_etc_hosts_contents = preface + new_etc_hosts_contents
 
-        __utils__['caasp_log.info']('hosts: writting new content to %s', orig_etc_hosts)
+        __utils__['caasp_log.info']('hosts: writing new content to %s', orig_etc_hosts)
         _write_lines(orig_etc_hosts, new_etc_hosts_contents)
 
     except Exception as e:

--- a/salt/_modules/tests/test_caasp_hosts.py
+++ b/salt/_modules/tests/test_caasp_hosts.py
@@ -56,22 +56,22 @@ class TestEtcHosts(unittest.TestCase):
         caasp_hosts.__utils__ = Utils()
 
         ips = {
-            'admin': '10.10.10.1',
-            'master0': '10.10.10.2',
-            'minion1': '10.10.10.3',
-            'other0': '10.10.10.4'
+            'admin-minion-id': '10.10.10.1',
+            'master0-minion-id': '10.10.10.2',
+            'minion1-minion-id': '10.10.10.3',
+            'other0-minion-id': '10.10.10.4'
         }
 
-        admin_nodes = {'admin': 'eth0'}
-        master_nodes = {'master0': 'eth0'}
-        worker_nodes = {'minion1': 'eth0'}
-        other_nodes = {'other0': 'eth0'}
+        admin_nodes = {'admin-minion-id': 'eth0'}
+        master_nodes = {'master0-minion-id': 'eth0'}
+        worker_nodes = {'minion1-minion-id': 'eth0'}
+        other_nodes = {'other0-minion-id': 'eth0'}
 
         def mock_get_primary_ip(host, ifaces):
             return ips[host]
 
         def mock_get_nodename(host):
-            return host
+            return "nodename-{}".format(host)
 
         def mock_get_pillar(s, default=None):
             return {
@@ -185,13 +185,17 @@ ff02::3         ipv6-allhosts
                 caasp_hosts._load_hosts_file(new_etc_hosts_contents,
                                              etc_hosts.name)
 
+                def check_entry_strict(ip, names):
+                    self.assertIn(ip, new_etc_hosts_contents)
+                    self.assertEqual(names, new_etc_hosts_contents[ip])
+
                 def check_entry(ip, names):
                     self.assertIn(ip, new_etc_hosts_contents)
                     for name in names:
                         self.assertIn(name, new_etc_hosts_contents[ip])
 
                 # check the Admin node has the right entries
-                check_entry('10.10.10.1', ['admin',
+                check_entry('10.10.10.1', ['admin-minion-id',
                                            'some-other-name-for-admin'])
 
                 # check we are setting the right things in 127.0.0.1
@@ -206,6 +210,15 @@ ff02::3         ipv6-allhosts
                 # check the old entries atre not present
                 for ip in ['10.10.9.1', '10.10.9.2', '10.10.9.3', '10.10.9.4']:
                     self.assertNotIn(ip, new_etc_hosts_contents)
+
+                #
+                # story: nodenames are appended at the beginning of the line
+                #
+
+                check_entry_strict('10.10.10.2', ['nodename-master0-minion-id',
+                                                  'nodename-master0-minion-id.infra.caasp.local',
+                                                  'master0-minion-id',
+                                                  'master0-minion-id.infra.caasp.local'])
 
                 #
                 # story: this host is highstated again
@@ -256,7 +269,7 @@ ff02::3         ipv6-allhosts
                 check_entry('10.10.23.8', ['bar.server.com'])
 
                 # repeat previous checks
-                check_entry('10.10.10.1', ['admin',
+                check_entry('10.10.10.1', ['admin-minion-id',
                                            'some-other-name-for-admin'])
                 check_entry('127.0.0.1', ['api', 'api.infra.caasp.local',
                                           EXTERNAL_MASTER_NAME,


### PR DESCRIPTION
Salt will pick the first name on the current default interface to determine
the hostname of the machine. Since we are sorting with all entries for each
machine there's a high change that a salt minion id will win the first position,
affecting certain grains that we use to determine the hostname of the node.

With this change we are not only sorting alphabetically by the name of each column
in each entry, but also adding weight to each column on each entry. This means that
the nodename will always win, as its primary weight will be lower than the rest,
while the second sorting strategy is purely alphabetical.

Fixes: bsc#1117339