### PR TITLE
Run flannel in unprivileged mode (bsc#1121153 bsc#1121154)

### DIFF
--- a/salt/cni/kube-flannel-rbac.yaml.jinja
+++ b/salt/cni/kube-flannel-rbac.yaml.jinja
@@ -1,9 +1,63 @@
 ---
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: suse.caasp.psp.flannel.unprivileged
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: docker/default
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: docker/default
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+spec:
+  # Privileged
+  privileged: false
+  # Volumes and File Systems
+  volumes:
+    # Kubernetes Pseudo Volume Types
+    - configMap
+    - secret
+    - emptyDir
+    - hostPath
+  allowedHostPaths:
+    - pathPrefix: "/run/flannel"
+    - pathPrefix: "/etc/cni/net.d"
+    - pathPrefix: "/var/lib/kubelet/cni/bin"
+  readOnlyRootFilesystem: false
+  # Users and groups
+  runAsUser:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  # Privilege Escalation
+  allowPrivilegeEscalation: false
+  defaultAllowPrivilegeEscalation: false
+  # Capabilities
+  allowedCapabilities: ['NET_ADMIN']
+  defaultAddCapabilities: []
+  requiredDropCapabilities: []
+  # Host namespaces
+  hostPID: false
+  hostIPC: false
+  hostNetwork: true
+  hostPorts:
+  - min: 0
+    max: 65535
+  # SELinux
+  seLinux:
+    # SELinux is unsed in CaaSP
+    rule: 'RunAsAny'
+---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: suse:caasp:flannel
 rules:
+  - apiGroups: ['extensions']
+    resources: ['podsecuritypolicies']
+    verbs: ['use']
+    resourceNames: ['suse.caasp.psp.flannel.unprivileged']
   - apiGroups:
       - ""
     resources:
@@ -23,7 +77,6 @@ rules:
       - nodes/status
     verbs:
       - patch
-
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -33,22 +86,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: suse:caasp:flannel
-subjects:
-- kind: ServiceAccount
-  name: flannel
-  namespace: kube-system
-
----
-# Allow Flannel to use the suse:caasp:psp:privileged
-# PodSecurityPolicy.
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: suse:caasp:psp:flannel
-roleRef:
-  kind: ClusterRole
-  name: suse:caasp:psp:privileged
-  apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
   name: flannel

--- a/salt/cni/kube-flannel.yaml.jinja
+++ b/salt/cni/kube-flannel.yaml.jinja
@@ -108,7 +108,9 @@ spec:
           - "--healthz-ip=$(POD_IP)"
           - "--healthz-port={{ pillar['flannel']['healthz_port'] }}"
         securityContext:
-          privileged: true
+          privileged: false
+          capabilities:
+            add: ["NET_ADMIN"]
         ports:
         - name: healthz
           containerPort: {{ pillar['flannel']['healthz_port'] }}
@@ -141,7 +143,7 @@ spec:
               fieldPath: spec.nodeName
         volumeMounts:
         - name: run
-          mountPath: /run
+          mountPath: /run/flannel
         - name: host-cni-conf
           mountPath: /etc/cni/net.d
         - name: flannel-plugin-config
@@ -160,7 +162,7 @@ spec:
       volumes:
         - name: run
           hostPath:
-            path: /run
+            path: /run/flannel
         - name: host-cni-conf
           hostPath:
             path: {{ pillar['cni']['dirs']['conf'] }}


### PR DESCRIPTION
Fixes bsc#1121153 - High Security issue for Kubernetes:
Flannel container runs in privileged mode

This fix makes sure that flannel runs in unprivileged mode.

This is done by changing the flannel manifests and also adding
a new PSP policy that disables both privilege mode and privilege
escallation.

The new PSP activates 'NET_ADMIN' capability, hostNetwork
and allowedHostPaths.

* Fixes bsc#1121154 - High Security issue for Kubernetes:
Flannel container has read/write access to /run, including docker.sock

Change the path from '/run' into '/run/flannel'

Co-authored-by: chentex <vzepedamas@suse.com>
(cherry picked from commit 8216c9ce691c8174eb2fcd66a1a2fecc446ee106)