### PR TITLE
Fix python3 iteration over dictionary.

### DIFF
--- a/salt/_modules/caasp_net.py
+++ b/salt/_modules/caasp_net.py
@@ -23,10 +23,9 @@ def get_hosts():
     :return: Dict(ip_address -> [aliases])
     """
     hosts = __salt__['hosts.list_hosts']()  # type: dict
-    for key in hosts.keys():
-        if key.startswith("comment-"):
-            hosts.pop(key)
-    return hosts
+    # Python3 (correctly) prevents modifying a dictionary we are iterating
+    # over, so we have to copy it first, so we can remove comment entries.
+    return {k:v for k,v in hosts.items() if not k.startswith("comment-")}
 
 
 def get_aliases(hostname):

--- a/salt/_modules/caasp_net.py
+++ b/salt/_modules/caasp_net.py
@@ -4,6 +4,7 @@
 #
 
 from __future__ import absolute_import
+from salt.ext.six import iteritems
 
 
 DEFAULT_INTERFACE = 'eth0'
@@ -25,7 +26,7 @@ def get_hosts():
     hosts = __salt__['hosts.list_hosts']()  # type: dict
     # Python3 (correctly) prevents modifying a dictionary we are iterating
     # over, so we have to copy it first, so we can remove comment entries.
-    return {k:v for k,v in hosts.items() if not k.startswith("comment-")}
+    return {k: v for k, v in hosts.items() if not k.startswith("comment-")}
 
 
 def get_aliases(hostname):
@@ -35,7 +36,7 @@ def get_aliases(hostname):
     :return: [string]
     """
     hosts = get_hosts()
-    for host, aliases in hosts.iteritems():
+    for host, aliases in iteritems(hosts):
         if hostname in aliases:
             __utils__['caasp_log.debug']('CaaS: retrieved aliases %s for %s', aliases, hostname)
             return aliases


### PR DESCRIPTION
In python3 python prevents modifying the dictionary that is iterated over.

Instead of modifying the initial dictionary it will be copied first.

Also `iteritems` is no longer available in `python3`, so the code should use the `six` function instead to be cross-version compatible.