### PR TITLE
Increase timeout for salt-minion-ca modules, bsc#1108470

### DIFF
--- a/salt/orch/kubernetes.sls
+++ b/salt/orch/kubernetes.sls
@@ -100,6 +100,7 @@ ca-setup:
     - tgt: 'roles:ca'
     - tgt_type: grain
     - highstate: True
+    - timeout: 120
     - require:
       - etc-hosts-setup
 
@@ -109,6 +110,7 @@ generate-sa-key:
     - tgt_type: grain
     - sls:
       - kubernetes-common.generate-serviceaccount-key
+    - timeout: 120
     - require:
       - ca-setup
 


### PR DESCRIPTION
On realy slow deployments salt-minion-ca can exceed timeouts
for "ca-setup" and "generate-sa-key" modules. We can avoid this
and add timeout option to "generate-sa-key".

Option "timeout" is the maximum time in seconds to wait before failing.