### PR TITLE
Disable insecure port in kube-apiserver (bsc#1121148)

### DIFF
--- a/salt/kube-apiserver/apiserver.jinja
+++ b/salt/kube-apiserver/apiserver.jinja
@@ -11,10 +11,10 @@
 {%- endif %}
 
 # The address on the local server to listen to.
-KUBE_API_ADDRESS="--insecure-bind-address=127.0.0.1 --bind-address=0.0.0.0"
+KUBE_API_ADDRESS="--bind-address=0.0.0.0"
 
 # The port on the local server to listen on.
-KUBE_API_PORT="--insecure-port=8080 --secure-port={{ pillar['api']['int_ssl_port'] }}"
+KUBE_API_PORT="--insecure-port=0 --secure-port={{ pillar['api']['int_ssl_port'] }}"
 
 # Comma separated list of nodes in the etcd cluster
 KUBE_ETCD_SERVERS="--etcd-cafile={{ pillar['ssl']['ca_file'] }} \


### PR DESCRIPTION
* Fixes bnc#1121148 - Critical Security issue for KubeAPI
  Insecure API port exposed to all Master Node guest containers

  In older versions of Kubernetes, you could run kube-apiserver
  with an API port that does not have any protections around it.

  This PR disables insecure port by passing the --insecure-port=0

  In recent versions, this has been disabled by default with the
  intention of completely deprecating it

(cherry picked from commit 01d91482e9a84b05b3b6eaec6a94b7b19ee74ee4)