### PR TITLE
Jenkinsfile: Switch to dynamic library fetching and drop branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
-def targetBranch = env.getEnvironment().get('CHANGE_TARGET', env.BRANCH_NAME)
-
-library "kubic-jenkins-library@${targetBranch}"
+library identifier: "kubic-jenkins-library@master", retriever: modernSCM(
+    [$class: 'GitSCMSource',
+    remote: 'https://gitlab.suse.de/caasp/jenkins-library.git'])
 
 coreKubicProjectCi()

--- a/Jenkinsfile.flake8
+++ b/Jenkinsfile.flake8
@@ -1,6 +1,6 @@
-def targetBranch = env.getEnvironment().get('CHANGE_TARGET', env.BRANCH_NAME)
-
-library "kubic-jenkins-library@${targetBranch}"
+library identifier: "kubic-jenkins-library@master", retriever: modernSCM(
+    [$class: 'GitSCMSource',
+    remote: 'https://gitlab.suse.de/caasp/jenkins-library.git'])
 
 // TODO: Don't hardcode salt repo name, find the right place
 // to lookup this information dynamically.

--- a/Jenkinsfile.housekeeping
+++ b/Jenkinsfile.housekeeping
@@ -1,5 +1,5 @@
-def targetBranch = env.getEnvironment().get('CHANGE_TARGET', env.BRANCH_NAME)
-
-library "kubic-jenkins-library@${targetBranch}"
+library identifier: "kubic-jenkins-library@master", retriever: modernSCM(
+    [$class: 'GitSCMSource',
+    remote: 'https://gitlab.suse.de/caasp/jenkins-library.git'])
 
 coreKubicProjectHousekeeping()

--- a/Jenkinsfile.tests
+++ b/Jenkinsfile.tests
@@ -1,6 +1,6 @@
-def targetBranch = env.getEnvironment().get('CHANGE_TARGET', env.BRANCH_NAME)
-
-library "kubic-jenkins-library@${targetBranch}"
+library identifier: "kubic-jenkins-library@master", retriever: modernSCM(
+    [$class: 'GitSCMSource',
+    remote: 'https://gitlab.suse.de/caasp/jenkins-library.git'])
 
 // TODO: Don't hardcode salt repo name, find the right place
 // to lookup this information dynamically.


### PR DESCRIPTION
Instead of having the library hardcoded to Jenkins master, we can fetch
it dynamically. We also drop the usage of library branches since it does
not make sense to maintain such a thing in the CI. The master branch
should be able to handle both development and release branches.