### PR TITLE
Synchronize everything before starting an orchestration.

### DIFF
--- a/salt/_modules/caasp_orch.py
+++ b/salt/_modules/caasp_orch.py
@@ -1,0 +1,16 @@
+from __future__ import absolute_import
+
+
+def __virtual__():
+    return "caasp_orch"
+
+
+def sync_all():
+    '''
+    Syncronize everything before starting a new orchestration
+    '''
+    __utils__['caasp_log.debug']('orch: refreshing all')
+    __salt__['saltutil.sync_all'](refresh=True)
+
+    __utils__['caasp_log.debug']('orch: synchronizing the mine')
+    __salt__['saltutil.runner']('mine.update', tgt='*', clear=True)

--- a/salt/orch/etcd-migrate.sls
+++ b/salt/orch/etcd-migrate.sls
@@ -1,3 +1,6 @@
+{#- Make sure we start with an updated mine #}
+{%- set _ = salt.caasp_orch.sync_all() %}
+
 # Generic Updates
 update_pillar:
   salt.function:

--- a/salt/orch/force-removal.sls
+++ b/salt/orch/force-removal.sls
@@ -1,4 +1,7 @@
-# must provide the node (id) to be removed in the 'target' pillar
+{#- Make sure we start with an updated mine #}
+{%- set _ = salt.caasp_orch.sync_all() %}
+
+{#- must provide the node (id) to be removed in the 'target' pillar #}
 {%- set target = salt['pillar.get']('target') %}
 
 {%- set super_master = salt.saltutil.runner('manage.up', tgt='G@roles:kube-master and not ' + target, expr_form='compound')|first %}

--- a/salt/orch/kubernetes.sls
+++ b/salt/orch/kubernetes.sls
@@ -1,8 +1,11 @@
+{#- Make sure we start with an updated mine #}
+{%- set _ = salt.caasp_orch.sync_all() %}
+
 {%- set default_batch = salt['pillar.get']('default_batch', 5) %}
 
-{%- set etcd_members = salt.saltutil.runner('mine.get', tgt='G@roles:etcd',        fun='network.interfaces', tgt_type='compound').keys() %}
-{%- set masters      = salt.saltutil.runner('mine.get', tgt='G@roles:kube-master', fun='network.interfaces', tgt_type='compound').keys() %}
-{%- set minions      = salt.saltutil.runner('mine.get', tgt='G@roles:kube-minion', fun='network.interfaces', tgt_type='compound').keys() %}
+{%- set etcd_members = salt.caasp_nodes.get_with_expr('G@roles:etcd') %}
+{%- set masters      = salt.caasp_nodes.get_with_expr('G@roles:kube-master') %}
+{%- set minions      = salt.caasp_nodes.get_with_expr('G@roles:kube-minion') %}
 
 {%- set super_master = masters|first %}
 

--- a/salt/orch/prepare-product-migration.sls
+++ b/salt/orch/prepare-product-migration.sls
@@ -1,3 +1,6 @@
+{#- Make sure we start with an updated mine #}
+{%- set _ = salt.caasp_orch.sync_all() %}
+
 {#- Get a list of nodes seem to be down or unresponsive #}
 {#- This sends a "are you still there?" message to all #}
 {#- the nodes and wait for a response, so it takes some time. #}

--- a/salt/orch/removal.sls
+++ b/salt/orch/removal.sls
@@ -1,3 +1,6 @@
+{#- Make sure we start with an updated mine #}
+{%- set _ = salt.caasp_orch.sync_all() %}
+
 {#- must provide the node (id) to be removed in the 'target' pillar #}
 {%- set target = salt['pillar.get']('target') %}
 
@@ -22,9 +25,9 @@
   {%- endif %}
 {%- endif %}
 
-{%- set etcd_members = salt.saltutil.runner('mine.get', tgt='G@roles:etcd',        fun='network.interfaces', tgt_type='compound').keys() %}
-{%- set masters      = salt.saltutil.runner('mine.get', tgt='G@roles:kube-master', fun='network.interfaces', tgt_type='compound').keys() %}
-{%- set minions      = salt.saltutil.runner('mine.get', tgt='G@roles:kube-minion', fun='network.interfaces', tgt_type='compound').keys() %}
+{%- set etcd_members = salt.caasp_nodes.get_with_expr('G@roles:etcd') %}
+{%- set masters      = salt.caasp_nodes.get_with_expr('G@roles:kube-master') %}
+{%- set minions      = salt.caasp_nodes.get_with_expr('G@roles:kube-minion') %}
 
 {%- set super_master_tgt = salt.caasp_nodes.get_super_master(masters=masters,
                                                              excluded=[target] + nodes_down) %}

--- a/salt/orch/update-etc-hosts.sls
+++ b/salt/orch/update-etc-hosts.sls
@@ -1,3 +1,6 @@
+{#- Make sure we start with an updated mine #}
+{%- set _ = salt.caasp_orch.sync_all() %}
+
 {%- set updates_all_target = 'P@roles:(admin|etcd|kube-(master|minion)) and ' +
                              'G@bootstrap_complete:true and ' +
                              'not G@bootstrap_in_progress:true and ' +
@@ -5,7 +8,8 @@
                              'not G@removal_in_progress:true and ' +
                              'not G@force_removal_in_progress:true' %}
 
-{%- if salt.saltutil.runner('mine.get', tgt=updates_all_target, fun='nodename', tgt_type='compound')|length > 0 %}
+{%- if salt.caasp_nodes.get_with_expr(updates_all_target)|length > 0 %}
+
 update_pillar:
   salt.function:
     - tgt: {{ updates_all_target }}
@@ -37,4 +41,5 @@ etc_hosts_setup:
       - etc-hosts
     - require:
       - salt: update_mine
+
 {% endif %}


### PR DESCRIPTION
* Synchronize everything before starting an orchestration.
* Replace all the `mine.get` calls by the more compact `get_with_expr` function.

bsc#1124784