### PR TITLE
Automatically update the kubernetes-service endpoint.

### DIFF
--- a/salt/kube-apiserver/apiserver.jinja
+++ b/salt/kube-apiserver/apiserver.jinja
@@ -30,8 +30,14 @@ KUBE_SERVICE_ADDRESSES="--service-cluster-ip-range={{ pillar['services_cidr'] }}
 KUBE_ADMISSION_CONTROL="--admission-control={{ admission_control|join(',') }}"
 
 # Add your own!
+# We add the reconciler to update the endpoint should one of the additional apiserver go down.
+# In newer version of kubernetes (1.11) the `lease` option has become the default and this can be removed.
+{%- set num_apiservers = salt['mine.get']('roles:kube-master', 'nodename', expr_form='grain').values()|length %}
 KUBE_API_ARGS="--advertise-address={{ salt.caasp_net.get_primary_ip() }} \
-               --apiserver-count={{ salt['mine.get']('roles:kube-master', 'nodename', expr_form='grain').values()|length }} \
+               --apiserver-count={{ num_apiservers }} \
+{%- if num_apiservers > 1 %}
+               --endpoint-reconciler-type='lease' \
+{%- endif -%}
 {%- if cloud_provider %}
                --cloud-provider={{ pillar['cloud']['provider'] }} \
   {%- if cloud_provider == 'openstack' %}


### PR DESCRIPTION
When a cluster is bootstrapped with multiple kube-apiservers, the `kubernetes`
service contains a list of all of these endpoints.

By default, this list of endpoints will *not* be updated if one of the
apiservers goes down. This can lead to the api becoming unresponsive and
breaking it. To have the endpoints automatically keep track of the apiservers
that are available the `--endpoint-reconciler-type` option `lease` needs to be
added.

(The default option for 1.10 `master-count` only changes the endpoint when the
count changes: https://github.com/apprenda/kismatic/issues/987)

See:

https://github.com/kubernetes/kubernetes/issues/22609
https://github.com/kubernetes/kubernetes/issues/56584
https://github.com/kubernetes/kubernetes/pull/51698

Fixes bsc#1098664