### PR TITLE
Don't always reenable the transaction-update timer on update

### DIFF
--- a/salt/_modules/caasp_nodes.py
+++ b/salt/_modules/caasp_nodes.py
@@ -187,6 +187,17 @@ def get_with_expr(expr, **kwargs):
     return res
 
 
+def get_with_expected_ret_value(expr, val, **kwargs):
+    '''
+    Utility function for getting a list of nodes which match a given return
+    value from Salt.
+    '''
+    res = __salt__[expr](**kwargs)
+    ret = {k: v for k, v in res.iteritems() if v['ret'] == val}
+    __utils__['caasp_log.debug']('%s', ret)
+    return ret
+
+
 def get_from_args_or_with_expr(arg_name, args_dict, *args, **kwargs):
     '''
     Utility function for getting a list of nodes from either the kwargs

--- a/salt/transactional-update/init.sls
+++ b/salt/transactional-update/init.sls
@@ -1,10 +1,12 @@
 {% if 'ca' not in salt['grains.get']('roles', []) %}
+{% if not salt['grains.get']('update_in_progress')  %}
 transactional-update.timer:
   service.running:
     - name: transactional-update.timer
     - enable: True
     - watch:
       - file: /etc/transactional-update.conf
+{% endif %}
 
 /etc/transactional-update.conf:
   file.managed:


### PR DESCRIPTION
When executing the update orchestration, it's not always desired to reenable the
transactional-update. Moreover, sometimes the timer was on a weird state if the
update failed. This commit refines the update orchestration following this
logic:

1. Check first which nodes have explicitely disabled the timer, so they are not
   reenabled in the end.
2. Disable the timer at the very beginning.
3. If this is a migration, reenable it always.
4. Otherwise, reenable the timer only for these nodes which did not explicitely
   disable it before the update.

Last but not least, I've also tweaked the `transactional-update/init.sls` file
so the timer is not touched by this file when updating.

bsc#1113518

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>