### PR TITLE
[bsc#1127326] Enable Kubelet token authentication

### DIFF
--- a/salt/kubelet/kubelet-config.jinja
+++ b/salt/kubelet/kubelet-config.jinja
@@ -12,7 +12,7 @@ authentication:
   x509:
     clientCAFile: "{{ pillar['ssl']['ca_file'] }}"
   webhook:
-    enabled: false
+    enabled: true
     cacheTTL: 2m0s
   anonymous:
     enabled: false


### PR DESCRIPTION
Enabling Token authentication allows external
components like monitoring tools to fetch information
against kubelet on port 10250 over HTTPS and authenticate
with a Bearer token.

Fixes bsc#1127326

Signed-off-by: Ludovic Cavajani <lcavajani@suse.com>
(cherry picked from commit c4005e5288496ade4f5e50392538356ea5b40061)