### PR TITLE
Remove sync-modules from reactor

### DIFF
--- a/config/master.d/50-reactor.conf
+++ b/config/master.d/50-reactor.conf
@@ -6,6 +6,5 @@ reactor:
     - /usr/share/salt/kubernetes/reactor/etc-hosts.sls
   - 'salt/minion/*/start':
     - /usr/share/salt/kubernetes/reactor/etc-hosts.sls
-    - /usr/share/salt/kubernetes/reactor/sync-modules.sls
     - /usr/share/salt/kubernetes/reactor/sync-grains.sls
     - /usr/share/salt/kubernetes/reactor/update-mine.sls

--- a/reactor/sync-modules.sls
+++ b/reactor/sync-modules.sls
@@ -1,3 +1,0 @@
-sync_modules:
-  local.saltutil.sync_modules:
-    - tgt: {{ data['id'] }}


### PR DESCRIPTION
we sync modules already in different places during orcherstration
so it is not needed to sync modules

( sync-modules in saltstack actually can create race-conditions so better to remove it if not needed)