### PR TITLE
Fix deprecationWarning: tgt_type in logs

### DIFF
--- a/salt/_macros/certs.jinja
+++ b/salt/_macros/certs.jinja
@@ -65,7 +65,7 @@
 {{ crt }}:
   caasp_retriable.retry:
     - target: x509.certificate_managed
-    - ca_server: {{ salt['mine.get']('roles:ca', 'ca.crt', expr_form='grain').keys()|first }}
+    - ca_server: {{ salt['mine.get']('roles:ca', 'ca.crt', tgt_type='grain').keys()|first }}
     - signing_policy: minion
     - public_key: {{ key }}
   {%- if cn %}

--- a/salt/_modules/caasp_grains.py
+++ b/salt/_modules/caasp_grains.py
@@ -17,4 +17,4 @@ def get(expr, grain=DEFAULT_GRAIN, type='compound'):
                                            tgt=expr,
                                            fun=grain, tgt_type=type)
     else:
-        return __salt__['mine.get'](expr, grain, expr_form=type)
+        return __salt__['mine.get'](expr, grain, tgt_type=type)

--- a/salt/ca-cert/init.sls
+++ b/salt/ca-cert/init.sls
@@ -1,7 +1,7 @@
 include:
   - crypto
 
-{%- set ca_crt = salt['mine.get']('roles:ca', 'ca.crt', expr_form='grain').values()|first %}
+{%- set ca_crt = salt['mine.get']('roles:ca', 'ca.crt', tgt_type='grain').values()|first %}
 
 {{ pillar['ssl']['ca_dir'] }}:
   file.directory:

--- a/salt/kube-apiserver/apiserver.jinja
+++ b/salt/kube-apiserver/apiserver.jinja
@@ -32,7 +32,7 @@ KUBE_ADMISSION_CONTROL="--admission-control={{ admission_control|join(',') }}"
 # Add your own!
 # We add the reconciler to update the endpoint should one of the additional apiserver go down.
 # In newer version of kubernetes (1.11) the `lease` option has become the default and this can be removed.
-{%- set num_apiservers = salt['mine.get']('roles:kube-master', 'nodename', expr_form='grain').values()|length %}
+{%- set num_apiservers = salt['mine.get']('roles:kube-master', 'nodename', tgt_type='grain').values()|length %}
 KUBE_API_ARGS="--advertise-address={{ salt.caasp_net.get_primary_ip() }} \
                --apiserver-count={{ num_apiservers }} \
 {%- if num_apiservers > 1 %}

--- a/salt/kubernetes-common/serviceaccount-key.sls
+++ b/salt/kubernetes-common/serviceaccount-key.sls
@@ -1,4 +1,4 @@
-{%- set ca_crt = salt['mine.get']('roles:ca', 'sa.key', expr_form='grain').values()|first %}
+{%- set ca_crt = salt['mine.get']('roles:ca', 'sa.key', tgt_type='grain').values()|first %}
 
 {{ pillar['paths']['service_account_key'] }}:
   x509.pem_managed:

--- a/salt/orch/force-removal.sls
+++ b/salt/orch/force-removal.sls
@@ -4,7 +4,7 @@
 {#- must provide the node (id) to be removed in the 'target' pillar #}
 {%- set target = salt['pillar.get']('target') %}
 
-{%- set super_master = salt.saltutil.runner('manage.up', tgt='G@roles:kube-master and not ' + target, expr_form='compound')|first %}
+{%- set super_master = salt.saltutil.runner('manage.up', tgt='G@roles:kube-master and not ' + target, tgt_type='compound')|first %}
 
 set-cluster-wide-removal-grain:
   salt.function:

--- a/salt/reboot/init.sls
+++ b/salt/reboot/init.sls
@@ -2,7 +2,7 @@
 # Configuration for the reboot manager
 ##################################################
 
-{%- set etcd_members = salt['mine.get']('G@roles:etcd', 'nodename', expr_form='compound').values() %}
+{%- set etcd_members = salt['mine.get']('G@roles:etcd', 'nodename', tgt_type='compound').values() %}
 {%- set etcd_server = etcd_members|first %}
 
 {% set reboot_uri = "https://" + etcd_server + ":2379/v2/keys/" + pillar['reboot']['directory'] + "/" +


### PR DESCRIPTION
DeprecationWarning: the target type should be passed using the 'tgt_type' argument instead of 'expr_form'.
Support for using 'expr_form' will be removed in Salt Fluorine.