### PR TITLE
[bsc#1121162] haproxy: block requests to /internal-api endpoint

### DIFF
--- a/salt/haproxy/haproxy.cfg.jinja
+++ b/salt/haproxy/haproxy.cfg.jinja
@@ -82,7 +82,9 @@ listen velum
         bind 0.0.0.0:80
         bind 0.0.0.0:443 ssl crt {{ pillar['ssl']['velum_bundle'] }} ca-file /etc/pki/ca.crt
         acl path_autoyast path_reg ^/autoyast$
+        acl path_internal_api path_beg /internal-api
         option forwardfor
+        http-request deny if path_internal_api
         http-request set-header X-Forwarded-Proto https
         redirect scheme https code 302 if !{ ssl_fc } !path_autoyast
         server velum unix@/var/run/puma/dashboard.sock


### PR DESCRIPTION
Internal api endpoints exposes sensitive data and this cannot be
accessed via internet.

This internal api was developed inside velum project and haproxy was
allowing the request to that endpoint. Velum listens on 0.0.0.0 and
needs to block for that specific path.

With this patch we are blocking any request to anything that starts
with /internal-api.

Signed-off-by: Vítor Avelino <vavelino@suse.com>

bsc#1121162