### PR TITLE
Cleanup unneeded reactor code

### DIFF
--- a/config/master.d/50-reactor.conf
+++ b/config/master.d/50-reactor.conf
@@ -1,10 +1,7 @@
 reactor:
   - 'salt/presence/change':
-    - /usr/share/salt/kubernetes/reactor/presence.sls
     - /usr/share/salt/kubernetes/reactor/etc-hosts.sls
   - 'salt/beacon/*/default_network_interface_settings/*':
     - /usr/share/salt/kubernetes/reactor/etc-hosts.sls
   - 'salt/minion/*/start':
     - /usr/share/salt/kubernetes/reactor/etc-hosts.sls
-    - /usr/share/salt/kubernetes/reactor/sync-grains.sls
-    - /usr/share/salt/kubernetes/reactor/update-mine.sls

--- a/reactor/presence.sls
+++ b/reactor/presence.sls
@@ -1,8 +1,0 @@
-# actions to run when a minion disappears or appears in the master
-
-# remove unused keys for minions that are not present anymore
-# TODO: we should evaluate what to do here:
-# - we don't want to remove the key for minions that are suffering
-#   some transient connectivity error
-# - but we should remove keys for old minions that will not
-#   connect anymore

--- a/reactor/sync-grains.sls
+++ b/reactor/sync-grains.sls
@@ -1,3 +1,0 @@
-sync_grains:
-  local.saltutil.sync_grains:
-    - tgt: {{ data['id'] }}

--- a/reactor/update-mine.sls
+++ b/reactor/update-mine.sls
@@ -1,3 +1,0 @@
-update_mine:
-  local.mine.update:
-    - tgt: {{ data['id'] }}


### PR DESCRIPTION
we shouldn't sync grains/update mine during start minions. ( a part of slowing down orchestration and minion we don't needed this)