### PR TITLE
Remove the proxy config files when `proxy:systemwide` is not set

### DIFF
--- a/salt/proxy/init.sls
+++ b/salt/proxy/init.sls
@@ -1,17 +1,18 @@
-{% if salt.caasp_pillar.get('proxy:systemwide') %}
-  {% set proxy_http  = salt.caasp_pillar.get('proxy:http') %}
-  {% set proxy_https = salt.caasp_pillar.get('proxy:https') %}
+{%- if salt.caasp_pillar.get('proxy:systemwide') %}
+  {%- set proxy_http  = salt.caasp_pillar.get('proxy:http') %}
+  {%- set proxy_https = salt.caasp_pillar.get('proxy:https') %}
 
-  {% set no_proxy = [salt.caasp_pillar.get('dashboard'), '.infra.caasp.local', '.cluster.local'] %}
-  {% set extra_no_proxy = salt.caasp_pillar.get('proxy:no_proxy') %}
-  {% if extra_no_proxy %}
-    {% do no_proxy.append(extra_no_proxy) %}
-  {% endif %}
+  {%- set no_proxy = [salt.caasp_pillar.get('dashboard'), '.infra.caasp.local', '.cluster.local'] %}
+  {%- set extra_no_proxy = salt.caasp_pillar.get('proxy:no_proxy') %}
+  {%- if extra_no_proxy %}
+    {%- do no_proxy.append(extra_no_proxy) %}
+  {%- endif %}
 
 /etc/sysconfig/proxy:
   file.managed:
     - makedirs: True
     - contents: |
+        # NOTE: do not modify. Managed by CaaSP Salt code.
         PROXY_ENABLED="yes"
         HTTP_PROXY="{{ proxy_http }}"
         HTTPS_PROXY="{{ proxy_https }}"
@@ -22,8 +23,21 @@
 /root/.curlrc:
   file.managed:
     - contents: |
+        # NOTE: do not modify. Managed by CaaSP Salt code.
         --proxy "{{ proxy_http }}"
         --noproxy "{{ no_proxy|join(',') }}"
   {% endif %}
 
-{% endif %}
+{%- else %}
+
+# note: we assume thse files are managed and modified
+#       only by us. so once the proxy is disabled, it is
+#       ok to remove them.
+
+/etc/sysconfig/proxy:
+  file.absent
+
+/root/.curlrc:
+  file.absent
+
+{%- endif %}


### PR DESCRIPTION
Remove the proxy config files when `proxy:systemwide` is not set (or set to False).

[bsc#1116572](https://bugzilla.suse.com/show_bug.cgi?id=1116572)
