### PR TITLE
Limit access to KUBE-APISERVER port 6444 on master nodes, bsc#1121144

### DIFF
--- a/salt/_modules/caasp_net.py
+++ b/salt/_modules/caasp_net.py
@@ -102,6 +102,15 @@ def get_primary_ips_for(compound, **kwargs):
         return []
 
 
+def get_primary_net(host=None):
+    '''
+    (given some optional 'host')
+    return the primary network
+    '''
+    primary_net = __salt__['network.subnets'](get_primary_iface(host=host))
+    return primary_net[0]
+
+
 def get_nodename(host=None, **kwargs):
     '''
     (given some optional 'host')

--- a/salt/kube-apiserver/stop.sls
+++ b/salt/kube-apiserver/stop.sls
@@ -1,17 +1,38 @@
 kube-apiserver:
   service.dead:
     - enable: False
+
+iptables-kube-apiserver-accept:
   caasp_retriable.retry:
-    - name: iptables-kube-apiserver
-    - target: iptables.delete
+    - name:       iptables-accept-kube-apiserver
+    - target:     iptables.delete
     - retry:
         attempts: 2
-    - table: filter
-    - family: ipv4
-    - chain: INPUT
-    - jump: ACCEPT
-    - match: state
-    - connstate: NEW
-    - dports:
-        - {{ pillar['api']['int_ssl_port'] }}
-    - proto: tcp
+    - table:      filter
+    - family:     ipv4
+    - chain:      INPUT
+    - jump:       ACCEPT
+    - match:      state
+    - connstate:  NEW
+    - proto:      tcp
+    - source:     '127.0.0.1,{{ salt.caasp_net.get_primary_net() }},{{ salt.caasp_pillar.get('cluster_cidr') }}'
+    - dport:      {{ pillar['api']['int_ssl_port'] }}
+    - require:
+      - service:  kube-apiserver
+
+iptables-kube-apiserver-drop:
+  caasp_retriable.retry:
+    - name:       iptables-drop-kube-apiserver
+    - target:     iptables.delete
+    - retry:
+        attempts: 2
+    - table:      filter
+    - family:     ipv4
+    - chain:      INPUT
+    - jump:       DROP
+    - match:      state
+    - connstate:  NEW
+    - proto:      tcp
+    - dport:      {{ pillar['api']['int_ssl_port'] }}
+    - require:
+      - caasp_retriable: iptables-accept-kube-apiserver


### PR DESCRIPTION
For limiting access to KUBE-APISERVER on port 6444 only connection
from localhost and CaaSP cluster nodes should be allowed,
rest of the traffic should be forbidden.