### PR TITLE
Adjust timeouts for the salt command and api (bsc1130242)

### DIFF
--- a/config/master.d/50-master.conf
+++ b/config/master.d/50-master.conf
@@ -7,7 +7,8 @@ auto_accept: False
 interface: 0.0.0.0
 event_return: mysql
 presence_events: True
-timeout: 20
+gather_job_timeout: 120
+timeout: 120
 
 event_return_whitelist:
   - salt/auth


### PR DESCRIPTION
By default, SUSE Manager globally sets timeout and gather_job_timeout to 120 seconds.
So, in the worst case, a Salt call targeting unreachable minions will end up with
240 seconds of waiting until getting a response.