### PR TITLE
update.sls: start transactional-update timer

### DIFF
--- a/salt/orch/update.sls
+++ b/salt/orch/update.sls
@@ -524,9 +524,10 @@ reenable-transactional-update-timer:
     - tgt: '{{ enabled_timer_nodes_list|join(",") }}'
     - tgt_type: list
     - batch: 3
-    - name: service.enable
+    - name: service.running
     - arg:
         - transactional-update.timer
+        - enable: true
     - require:
       - remove-caasp-fqdn-grain
 {%- endif %}


### PR DESCRIPTION
In the update process we disable the transactional update timer and re
enabled it after update the machine. However, just re enable it is not
enough. We need to start the timer. Otherwise, the update service will
not run and consequently no updates is installed. This commit adds in
the update.sls a step to start the timer after re enabling it.

bsc#1141675

Signed-off-by: José Guilherme Vanz <jguilhermevanz@suse.com>