### PR TITLE
update.sls: using wrong module to start timer

### DIFF
--- a/salt/orch/update.sls
+++ b/salt/orch/update.sls
@@ -524,12 +524,21 @@ reenable-transactional-update-timer:
     - tgt: '{{ enabled_timer_nodes_list|join(",") }}'
     - tgt_type: list
     - batch: 3
-    - name: service.running
+    - name: service.enable
     - arg:
         - transactional-update.timer
-        - enable: true
     - require:
       - remove-caasp-fqdn-grain
+start-transactional-update-timer:
+  salt.function:
+    - tgt: '{{ enabled_timer_nodes_list|join(",") }}'
+    - tgt_type: list
+    - batch: 3
+    - name: service.start
+    - arg:
+        - transactional-update.timer
+    - require:
+      - reenable-transactional-update-timer
 {%- endif %}
 
 remove-update-grain:


### PR DESCRIPTION
A previous commit trying to start the transactional-update timer is
wrong. The right module is `service.start`. The current orchestration
step fails to start the timer, but does not fail the whole orchestration.
To fix that, a new step has been added to start the timer after re
enabling it. Unfortunately, the start/enable state functions do not
allow do both steps at once.

Signed-off-by: José Guilherme Vanz <jguilhermevanz@suse.com>